### PR TITLE
Add code-server kit

### DIFF
--- a/code-server/README.md
+++ b/code-server/README.md
@@ -1,0 +1,108 @@
+# code-server
+
+A mixin that installs [code-server](https://github.com/coder/code-server)
+and runs it as a background service on port 8080, with the
+[Claude Code VS Code extension](https://code.claude.com/docs/en/vscode)
+pre-installed. Combined with `sbx ports --publish`, you get a web-based
+VS Code pointed at the sandbox workspace with a native Claude panel that
+shares credentials and conversation history with the `claude` CLI agent.
+
+## Usage
+
+Pair it with the built-in `claude` agent:
+
+```console
+$ sbx run claude --kit "git+https://github.com/dvdksn/kits-cookbook.git#dir=code-server" ~/my-project
+```
+
+Publish the port from your host:
+
+```console
+$ sbx ports <sandbox-name> --publish 8080:8080/tcp
+```
+
+Open `http://localhost:8080/` in a browser. code-server opens the
+sandbox workspace on launch — no **File → Open Folder…** needed.
+Click the **Spark** icon in the editor toolbar (top-right) to open the
+Claude Code panel; it picks up the same auth the CLI uses.
+
+If the page doesn't load, check the startup log inside the sandbox:
+
+```console
+$ sbx exec -it <sandbox-name> -- cat /tmp/code-server.log
+```
+
+## How the workspace path gets set
+
+The kit uses `commands.initFiles` to write a tiny wrapper script at
+`/home/agent/.local/bin/start-code-server.sh` each time the sandbox
+starts. `${WORKDIR}` expands to the actual workspace path at that
+point, so the script has the correct folder baked in before
+`code-server` runs. `commands.startup` invokes it via `sh <script>`
+(the `mode` field on initFiles didn't reliably apply the execute
+bit, so we sidestep needing it), backgrounded with `nohup … &`,
+stdout/stderr redirected to `/tmp/code-server.log`.
+
+This is the cleanest place to see why `initFiles` exists — the
+workspace path isn't known until the sandbox starts, so it can't be
+hardcoded in a static file or a shell-string command.
+
+## About authentication
+
+The startup command passes `--auth none`. code-server is only reachable
+through `sbx ports`, which publishes to `localhost` on your host by
+default, so you're already behind the sandbox boundary. If you want a
+password anyway, override the startup command in a forked kit.
+
+### Claude Code extension auth
+
+The extension and the `claude` CLI share state in `~/.claude/` and both
+read `ANTHROPIC_API_KEY` from the environment. The built-in `claude`
+agent already routes Anthropic auth through the sandbox credential
+proxy, so the extension inherits that: no separate sign-in required.
+
+If the extension shows a sign-in prompt when you open the Spark panel,
+check that the underlying CLI is authenticated first (run `claude` in
+the integrated terminal inside VS Code, or `sbx attach` to the agent).
+
+## Shipped VS Code settings
+
+The kit drops a minimal `User/settings.json` into code-server's user
+data directory to reduce first-launch noise:
+
+```json
+{
+  "workbench.startupEditor": "none",
+  "chat.commandCenter.enabled": false,
+  "workbench.tips.enabled": false,
+  "telemetry.telemetryLevel": "off",
+  "claudeCode.preferredLocation": "sidebar"
+}
+```
+
+- `startupEditor: "none"` — no welcome page on launch
+- `chat.commandCenter.enabled: false` — hides the built-in chat widget
+  that newer VS Code ships in the top bar
+- `claudeCode.preferredLocation: "sidebar"` — Claude opens in the
+  right-hand sidebar rather than a full editor tab
+
+VS Code doesn't have a clean "auto-open this view on startup" setting,
+so Claude still needs one click on the Spark icon the first time.
+After that, state persists across browser reloads (the sandbox's
+`persistence: persistent` volume preserves `~/.local/share/code-server/`).
+
+Edit `files/home/.local/share/code-server/User/settings.json` in a fork
+to customize further.
+
+## Can I run a native editor (Cursor, Zed, …) like this?
+
+Not through this kit, but it's plausible as a follow-up recipe.
+code-server works because VS Code has a first-party web server mode —
+Cursor, Zed, and most other editors don't. To run one of those in a
+sandbox and use it from the host browser, the cleanest path is
+probably [xpra](https://xpra.org/) with its HTML5 client: xpra starts
+the editor under a virtual display and serves its window to a browser
+over HTTPS, without the latency and clipboard limitations of VNC.
+A kit would install xpra + the editor, then run
+`xpra start --start-child=<editor> --bind-tcp=0.0.0.0:14500 --html=on`
+as a startup command.

--- a/code-server/code_server_tck_test.go
+++ b/code-server/code_server_tck_test.go
@@ -1,0 +1,14 @@
+package code_server_test
+
+import (
+	"testing"
+
+	"github.com/docker/sbx-kits-contrib/tck"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCodeServerTCK(t *testing.T) {
+	suite, err := tck.NewSuiteFromDir(".")
+	require.NoError(t, err)
+	suite.RunAll(t)
+}

--- a/code-server/files/home/.local/share/code-server/User/settings.json
+++ b/code-server/files/home/.local/share/code-server/User/settings.json
@@ -1,0 +1,7 @@
+{
+  "workbench.startupEditor": "none",
+  "chat.commandCenter.enabled": false,
+  "workbench.tips.enabled": false,
+  "telemetry.telemetryLevel": "off",
+  "claudeCode.preferredLocation": "sidebar"
+}

--- a/code-server/spec.yaml
+++ b/code-server/spec.yaml
@@ -1,0 +1,30 @@
+schemaVersion: "1"
+kind: mixin
+name: code-server
+extends: claude
+displayName: code-server (web VS Code) with Claude Code
+description: Runs code-server on port 8080, opened on the sandbox workspace, with the Claude Code VS Code extension preinstalled. Pair with the built-in claude agent so the extension inherits the sandbox's Anthropic credentials.
+
+network:
+  allowedDomains:
+    - code-server.dev
+    - github.com
+    - objects.githubusercontent.com
+    - open-vsx.org
+
+commands:
+  install:
+    - command: "curl -fsSL https://code-server.dev/install.sh | sh"
+      description: Install code-server via the upstream install script
+    - command: "code-server --install-extension anthropic.claude-code"
+      user: "1000"
+      description: Pre-install the Claude Code extension from open-vsx so you have a native chat panel that talks to the claude agent's credentials
+  initFiles:
+    - path: /home/agent/.local/bin/start-code-server.sh
+      content: |
+        exec code-server --bind-addr 0.0.0.0:8080 --auth none "${WORKDIR}"
+      description: Startup wrapper with the workspace path baked in at sandbox start
+  startup:
+    - command: ["sh", "-c", "nohup sh /home/agent/.local/bin/start-code-server.sh > /tmp/code-server.log 2>&1 &"]
+      user: "1000"
+      description: Start code-server in the background, opened on the primary workspace


### PR DESCRIPTION
## Summary

Adds a **code-server** mixin kit that runs web VS Code on port 8080 paired with the built-in `claude` agent. The Claude Code VS Code extension is preinstalled, so users get a graphical editor in a browser tab while the CLI agent works in parallel — both authenticated through the same sandbox credential proxy.

## Spec choices worth flagging for review

- **`extends: claude`** — the kit is designed to pair with the claude agent so the Claude Code extension inherits Anthropic credentials. TCK runs it against the claude template.
- **Extension installed from open-vsx** (`anthropic.claude-code`) rather than the MS marketplace — open-vsx is code-server's default gallery, no `EXTENSIONS_GALLERY` override needed.
- **`initFiles` writes a startup wrapper** with `\${WORKDIR}` baked in, then startup invokes it via `nohup sh <script> … &`. The `sh <script>` form avoids relying on the `mode` field being applied to initFiles (I observed it landing as `0644` despite `"0755"` — may be a sandboxd bug worth a separate issue). The `nohup + &` pattern keeps the service alive past the startup phase; `background: true` alone didn't in my testing.
- **Ships a minimal `User/settings.json`** (`chat.commandCenter.enabled: false`, `workbench.startupEditor: "none"`, `claudeCode.preferredLocation: "sidebar"`) to quiet the default VS Code welcome/chat UI at first launch.

## Origin

Ported from my working-draft cookbook at <https://github.com/dvdksn/kits-cookbook/tree/main/code-server>, which is where I iterated on the pattern. Submitting the code-server kit as the one from that set most worth upstreaming.

## Test plan

- [ ] CI runs TCK: `go test -v -count=1 -timeout 10m ./code-server/...`
- [ ] Manual: `sbx run claude --kit <this-branch-as-git-url>#dir=code-server ~/my-project`, then `sbx ports … --publish 8080:8080/tcp`, open `http://localhost:8080/`, click Spark icon → Claude Code panel should authenticate without prompting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)