### PR TITLE
fix(nanoclaw): land into the nanoclaw dir

### DIFF
--- a/nanoclaw/README.md
+++ b/nanoclaw/README.md
@@ -1,40 +1,61 @@
 # nanoclaw
 
-A mixin that ships a self-installing launcher for
+A mixin that pre-clones and builds
 [nanoclaw](https://github.com/qwibitai/nanoclaw) — a lightweight
-AI assistant runtime — into a `shell` sandbox.
+AI assistant runtime driven by Claude Code — into a `claude` sandbox.
 
 > [!NOTE]
 > Upstream nanoclaw trunk only ships the **CLI channel**. Chat-platform
 > adapters (WhatsApp, Telegram, Discord, Slack, …) live on the upstream
-> `channels` branch and are installed via `/add-<channel>` skills that
-> copy the relevant modules into the user's fork. This kit installs
-> trunk; channel-specific kits (`nanoclaw-whatsapp`, `nanoclaw-telegram`,
-> …) can layer on top later.
+> `channels` branch and are installed via `/add-<channel>` skills run
+> from inside Claude Code. This kit installs trunk and lets you drive
+> the rest from the shipped `claude` CLI.
 
 ## Usage
 
 ```console
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=nanoclaw" shell
+$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=nanoclaw" claude
 ```
 
 Or with a local clone of this repo:
 
 ```console
-$ sbx run --kit ./nanoclaw/ shell
+$ sbx run --kit ./nanoclaw/ claude
 ```
 
-Once inside the sandbox shell:
+The first `sbx create` clones the upstream repo to `/home/agent/nanoclaw`,
+runs `npm install`, rebuilds native modules, and runs the TypeScript
+build (~2 minutes). Subsequent attaches are immediate.
+
+`sbx run` drops you straight into a Claude Code session whose working
+directory is the nanoclaw checkout, with its `CLAUDE.md` loaded —
+exactly as upstream's [install guide](https://nanoclaws.io/install)
+recommends. From there, `/setup`, `/add-whatsapp`, `/customize`, etc.
+work as documented.
+
+If you want the daemon directly instead of the Claude-Code-driven
+setup flow, exec a shell into the sandbox from another terminal and
+run:
 
 ```console
 $ nanoclaw
 ```
 
-The first invocation clones the upstream repo into
-`/home/agent/nanoclaw`, runs `npm install`, rebuilds native modules,
-and runs the TypeScript build (~2 minutes). Subsequent invocations
-start the daemon directly, listening on the local CLI channel
-(`/home/agent/nanoclaw/data/cli.sock`).
+### How the cwd thing works
+
+The `claude` template's entrypoint runs `claude --dangerously-skip-permissions`
+without an absolute path, so `PATH` resolution applies. This kit
+installs a wrapper at `/home/agent/.local/bin/claude` that `cd`s into
+`/home/agent/nanoclaw` and execs the real Claude binary (preserved as
+`/home/agent/.local/bin/claude_real`). Net effect: `sbx run` lands
+inside Claude Code already pointed at the nanoclaw checkout.
+
+If you need vanilla Claude Code in a different directory in this
+sandbox, invoke the original directly:
+
+```console
+$ /home/agent/.local/bin/claude_real
+```
 
 ## How auth works
 
@@ -43,10 +64,11 @@ automatically: `NODE_USE_ENV_PROXY=1` (set globally by sbx) makes
 Node.js honor `HTTP_PROXY`/`HTTPS_PROXY`, and the proxy substitutes
 the real Anthropic credentials in place of the `proxy-managed`
 sentinel that's already in the default sandbox environment. The agent
-never sees the real key.
+never sees the real key. The `claude` CLI inherits the same wiring
+from the `claude` template this kit extends.
 
 The kit's `allowedDomains` covers `registry.npmjs.org` (for the
 install), the WhatsApp hosts the bridge connects to (when the
 WhatsApp adapter is later added), and `nanoclaw.dev`.
-`api.anthropic.com` is reached via default sandbox policy, not a kit
-allowlist entry.
+`api.anthropic.com` is reached via default sandbox policy and the
+parent template's network rules, not a kit allowlist entry.

--- a/nanoclaw/spec.yaml
+++ b/nanoclaw/spec.yaml
@@ -1,8 +1,9 @@
 schemaVersion: "1"
 kind: mixin
 name: nanoclaw
+extends: claude
 displayName: NanoClaw
-description: "Lightweight AI assistant runtime — ships the CLI channel; chat platforms (WhatsApp, Telegram, Discord, …) add via upstream skills"
+description: "Lightweight AI assistant runtime driven by Claude Code; ships the CLI channel — chat platforms (WhatsApp, Telegram, Discord, …) add via upstream skills"
 
 network:
   allowedDomains:
@@ -17,6 +18,12 @@ commands:
     - command: "npm config set proxy $HTTP_PROXY && npm config set https-proxy $HTTP_PROXY"
       user: "1000"
       description: Configure npm to use the sandbox proxy
-    - command: "cat > /usr/local/bin/nanoclaw << 'SCRIPT'\n#!/bin/sh\nif [ ! -f /home/agent/nanoclaw/dist/index.js ]; then\n  echo \"First run: installing nanoclaw (this takes ~2 minutes)...\"\n  cd /home/agent\n  git clone --depth 1 https://github.com/qwibitai/nanoclaw.git\n  cd nanoclaw\n  npm install --maxsockets=1 --fetch-timeout=600000\n  npm rebuild better-sqlite3\n  npm run build\n  echo \"Done! Starting nanoclaw...\"\nfi\ncd /home/agent/nanoclaw\nexec node dist/index.js \"$@\"\nSCRIPT\nchmod +x /usr/local/bin/nanoclaw"
+    - command: "git clone --depth 1 https://github.com/qwibitai/nanoclaw.git /home/agent/nanoclaw && cd /home/agent/nanoclaw && npm install --maxsockets=1 --fetch-timeout=600000 && npm rebuild better-sqlite3 && npm run build"
+      user: "1000"
+      description: Clone and build nanoclaw (~2 minutes; runs once at sandbox creation)
+    - command: "cat > /usr/local/bin/nanoclaw << 'SCRIPT'\n#!/bin/sh\ncd /home/agent/nanoclaw\nexec node dist/index.js \"$@\"\nSCRIPT\nchmod +x /usr/local/bin/nanoclaw"
       user: "0"
-      description: Create self-installing nanoclaw launcher (root-owned path)
+      description: Create nanoclaw launcher (root-owned path)
+    - command: "if [ ! -f /home/agent/.local/bin/claude_real ]; then mv /home/agent/.local/bin/claude /home/agent/.local/bin/claude_real; fi && cat > /home/agent/.local/bin/claude << 'SCRIPT'\n#!/bin/sh\ncd /home/agent/nanoclaw 2>/dev/null\nexec /home/agent/.local/bin/claude_real \"$@\"\nSCRIPT\nchmod +x /home/agent/.local/bin/claude"
+      user: "1000"
+      description: Wrap claude so it always launches from /home/agent/nanoclaw (original at claude_real)


### PR DESCRIPTION
## What's changed

`nanoclaw` now extends the `claude` template, pre-clones and builds
the upstream repo at `sbx create` time, and ships a tiny wrapper at
`/home/agent/.local/bin/claude` that `cd`s into `/home/agent/nanoclaw`
before exec'ing the real Claude Code binary (preserved as
`claude_real`).

Net effect: `sbx run --kit … claude` drops the user straight into a
Claude Code session whose working directory is the nanoclaw checkout
— exactly the entry point upstream's [install guide](https://nanoclaws.io/install)
assumes when it tells you to `git clone … && cd NanoClaw && claude`.

## Why is this important?

Upstream nanoclaw is Claude-Code-driven by design: `/setup`,
`/add-whatsapp`, `/customize`, etc. are slash commands that only work
when Claude Code is launched from inside the nanoclaw checkout so it
picks up the project's `CLAUDE.md` and `.claude/skills/`. Before this
change the kit landed users in the workspace mount instead, so the
upstream flow silently degraded — slash commands didn't see the
expected context.

The previous lazy-install launcher also meant the ~2-minute
`npm install` + `npm run build` ran at the user's first `nanoclaw`
invocation rather than at create time, hiding the cost from the
"create succeeded" signal and stretching the first interactive
attach. Moving it into `commands.install` makes the cost honest and
lets the TCK assert that the upstream repo can actually build
inside a sandbox.

## Changes

### `nanoclaw/spec.yaml`

- Add `extends: claude` so the kit composes onto the claude template
  (which ships the `claude` CLI). Description updated to reflect
  that the runtime is Claude-Code-driven rather than just "shell
  with a launcher".
- Replace the old self-installing launcher with three install steps:
  1. `npm config set proxy …` (unchanged)
  2. Eager `git clone … && npm install && npm rebuild better-sqlite3
     && npm run build` into `/home/agent/nanoclaw`
  3. Plain `/usr/local/bin/nanoclaw` launcher (now just `cd …; exec
     node dist/index.js "$@"` — no install logic inside)
- Add a fourth install step that swaps Claude Code for a wrapper:
  `mv claude → claude_real`, then write a 3-line wrapper at
  `/home/agent/.local/bin/claude` that `cd`s into the checkout and
  exec's `claude_real`. Idempotent — safe across re-applies.

### `nanoclaw/README.md`

- Switch the `sbx run` example from `shell` to `claude` (matches the
  new template).
- Replace the "two paths" UX section with a single sentence about
  what `sbx run` does (lands in Claude Code at the nanoclaw
  checkout) plus a footnote on how to launch the daemon from a
  separate exec.
- Add a "How the cwd thing works" subsection explaining the
  PATH-shadow trick and how to reach vanilla Claude Code via
  `claude_real` if the user wants it in a different directory.
- Update "How auth works" to note the kit inherits the claude
  template's Anthropic wiring.

## Test plan

- [x] `go test -count=1 -timeout 5m ./nanoclaw/...` passes — the
      `install_execution` sub-test executes all four install
      commands inside a `claude-code-docker` container (clone +
      build runs ~50s, exits 0; wrapper write exits 0).
- [x] Manual: `sbx run --kit ./nanoclaw/ claude` drops directly into
      a Claude Code session whose cwd is `/home/agent/nanoclaw`,
      with the upstream `CLAUDE.md` already in context. No manual
      `cd` step.
- [x] `claude_real` exists alongside the wrapper and runs vanilla
      Claude Code without the cwd hijack.
- [x] `nanoclaw` (the daemon launcher) still starts the upstream
      runtime when invoked from a separate shell into the sandbox.
