### PR TITLE
Add CODEOWNERS and SECURITY.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @docker/coding-agent-sandboxes

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+The maintainers of this repository take security seriously.
+If you discover a security issue, please bring it to their attention right away!
+
+## Reporting a Vulnerability
+
+Please **DO NOT** file a public issue, instead send your report privately
+to [security@docker.com](mailto:security@docker.com).
+
+Reporter(s) can expect a response within 72 hours, acknowledging the issue was
+received.
+
+## Review Process
+
+After receiving the report, an initial triage and technical analysis is
+performed to confirm the report and determine its scope. We may request
+additional information in this stage of the process.
+
+Once a reviewer has confirmed the relevance of the report, a draft security
+advisory will be created on GitHub. The draft advisory will be used to discuss
+the issue with maintainers, the reporter(s), and where applicable, other
+affected parties under embargo.
+
+If the vulnerability is accepted, a timeline for developing a patch, public
+disclosure, and patch release will be determined. If there is an embargo period
+on public disclosure before the patch release, the reporter(s) are expected to
+participate in the discussion of the timeline and abide by agreed upon dates
+for public disclosure.
+
+## Accreditation
+
+Security reports are greatly appreciated and we will publicly thank you,
+although we will keep your name confidential if you request it. We also like to
+send gifts - if you're into swag, make sure to let us know. We do not currently
+offer a paid security bounty program at this time.
+
+## Further Information
+
+Should anything in this document be unclear or if you are looking for additional
+information about how Docker reviews and responds to security vulnerabilities,
+please take a look at Docker's
+[Vulnerability Disclosure Policy](https://www.docker.com/trust/vulnerability-disclosure-policy/).


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` assigning `@docker/coding-agent-sandboxes` as code owner for all paths
- Add `SECURITY.md` pointing to [security@docker.com](mailto:security@docker.com) and Docker's [Vulnerability Disclosure Policy](https://www.docker.com/trust/vulnerability-disclosure-policy/) (adapted from [docker/vscode-extension](https://github.com/docker/vscode-extension/blob/main/SECURITY.md))

## Test plan
- [ ] Verify CODEOWNERS team handle resolves once the team has access to the repo
- [ ] Confirm `SECURITY.md` renders correctly on GitHub and the "Report a vulnerability" tab surfaces the policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)