### PR TITLE
feat(spec): add deniedDomains

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ description: "Short description of what this kit does"
 network:
   allowedDomains:
     - example.com
+  deniedDomains:
+    - tracker.example.com
 
 environment:
   variables:

--- a/spec/testdata/sample-agent/spec.yaml
+++ b/spec/testdata/sample-agent/spec.yaml
@@ -15,6 +15,8 @@ agent:
 network:
   allowedDomains:
     - sample-agent.example.com
+  deniedDomains:
+    - telemetry.sample-agent.example.com
 
 environment:
   variables:

--- a/spec/testdata/sample-mixin/spec.yaml
+++ b/spec/testdata/sample-mixin/spec.yaml
@@ -8,6 +8,8 @@ network:
   allowedDomains:
     - example.com
     - "*.example.org"
+  deniedDomains:
+    - tracker.example.com
   serviceDomains:
     api.example.com: example
   serviceAuth:

--- a/spec/types.go
+++ b/spec/types.go
@@ -103,6 +103,12 @@ type NetworkPolicy struct {
 
 	// AllowedDomains is an explicit allowlist of domains the agent may access.
 	AllowedDomains []string `json:"allowedDomains,omitempty" yaml:"allowedDomains,omitempty"`
+
+	// DeniedDomains is an explicit denylist of domains the agent must not access.
+	// Deny rules take precedence over allow rules at policy evaluation time, so a
+	// kit can lock its sandbox out of specific domains regardless of presets or
+	// other allow lists contributed by composed kits.
+	DeniedDomains []string `json:"deniedDomains,omitempty" yaml:"deniedDomains,omitempty"`
 }
 
 // ServiceAuth defines how to format authentication headers for a service.

--- a/spec/validate.go
+++ b/spec/validate.go
@@ -77,6 +77,18 @@ func ValidateNetworkPolicy(n *NetworkPolicy) error {
 		}
 	}
 
+	if len(n.AllowedDomains) > 0 && len(n.DeniedDomains) > 0 {
+		allowed := make(map[string]bool, len(n.AllowedDomains))
+		for _, d := range n.AllowedDomains {
+			allowed[d] = true
+		}
+		for _, d := range n.DeniedDomains {
+			if allowed[d] {
+				return fmt.Errorf("network: domain %q is in both allowedDomains and deniedDomains", d)
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/spec/validate_test.go
+++ b/spec/validate_test.go
@@ -95,6 +95,29 @@ func TestValidateNetworkPolicy(t *testing.T) {
 		}
 		require.ErrorContains(t, ValidateNetworkPolicy(n), "%s placeholder")
 	})
+
+	t.Run("allowed_and_denied_disjoint", func(t *testing.T) {
+		n := &NetworkPolicy{
+			AllowedDomains: []string{"api.example.com:443", "good.example.com:443"},
+			DeniedDomains:  []string{"evil.example.com:443"},
+		}
+		require.NoError(t, ValidateNetworkPolicy(n))
+	})
+
+	t.Run("denied_only_is_valid", func(t *testing.T) {
+		n := &NetworkPolicy{
+			DeniedDomains: []string{"evil.example.com:443"},
+		}
+		require.NoError(t, ValidateNetworkPolicy(n))
+	})
+
+	t.Run("domain_in_both_allow_and_deny", func(t *testing.T) {
+		n := &NetworkPolicy{
+			AllowedDomains: []string{"api.example.com:443"},
+			DeniedDomains:  []string{"api.example.com:443"},
+		}
+		require.ErrorContains(t, ValidateNetworkPolicy(n), "in both allowedDomains and deniedDomains")
+	})
 }
 
 func TestValidateCredentialPolicy(t *testing.T) {

--- a/tck/derive.go
+++ b/tck/derive.go
@@ -47,6 +47,7 @@ func NewSuiteFromDir(dir string, opts ...Option) (*Suite, error) {
 	// Derive network expectations
 	if artifact.Network != nil {
 		suite.ExpectedAllowedDomains = artifact.Network.AllowedDomains
+		suite.ExpectedDeniedDomains = artifact.Network.DeniedDomains
 		suite.ExpectedServiceDomains = artifact.Network.ServiceDomains
 		suite.ExpectedServiceAuth = artifact.Network.ServiceAuth
 	}

--- a/tck/suite.go
+++ b/tck/suite.go
@@ -41,6 +41,7 @@ type Suite struct {
 	ExpectedEnvVars        []string
 	ExpectedContainerFiles []string
 	ExpectedAllowedDomains []string
+	ExpectedDeniedDomains  []string
 	ExpectedServiceDomains map[string]string
 	ExpectedServiceAuth    map[string]spec.ServiceAuth
 	ExpectedTmpfs          map[string]string // path -> options (manifest tmpfs + /run/secrets)
@@ -331,7 +332,7 @@ func (s *Suite) RunValidationTests(t *testing.T) {
 
 // RunNetworkPolicyTests verifies the artifact's network policy is consistent.
 func (s *Suite) RunNetworkPolicyTests(t *testing.T) {
-	if s.Artifact.Network == nil && len(s.ExpectedAllowedDomains) == 0 && len(s.ExpectedServiceDomains) == 0 {
+	if s.Artifact.Network == nil && len(s.ExpectedAllowedDomains) == 0 && len(s.ExpectedDeniedDomains) == 0 && len(s.ExpectedServiceDomains) == 0 {
 		return
 	}
 
@@ -339,6 +340,7 @@ func (s *Suite) RunNetworkPolicyTests(t *testing.T) {
 		net := s.Artifact.Network
 		if net == nil {
 			require.Empty(t, s.ExpectedAllowedDomains, "expected allowed domains but network policy is nil")
+			require.Empty(t, s.ExpectedDeniedDomains, "expected denied domains but network policy is nil")
 			require.Empty(t, s.ExpectedServiceDomains, "expected service domains but network policy is nil")
 			return
 		}
@@ -346,6 +348,11 @@ func (s *Suite) RunNetworkPolicyTests(t *testing.T) {
 		if len(s.ExpectedAllowedDomains) > 0 {
 			require.ElementsMatch(t, s.ExpectedAllowedDomains, net.AllowedDomains,
 				"allowed domains should match")
+		}
+
+		if len(s.ExpectedDeniedDomains) > 0 {
+			require.ElementsMatch(t, s.ExpectedDeniedDomains, net.DeniedDomains,
+				"denied domains should match")
 		}
 
 		if len(s.ExpectedServiceDomains) > 0 {


### PR DESCRIPTION
## What's changed

Adds an explicit `deniedDomains` field to `NetworkPolicy`, the counterpart
to the existing `allowedDomains`. A kit can now declare domains its
sandbox must not reach, and consumers (e.g. Docker Sandboxes' policy
engine) are expected to evaluate deny rules with precedence over allow
rules.

The TCK is extended with `ExpectedDeniedDomains` so kit authors can
assert their deny lists round-trip through spec parsing.

## Why is this important?

Until now `allowedDomains` only widens what a kit can reach — there is
no way for a kit to lock its sandbox out of specific domains regardless
of presets or domains contributed by composed kits. Several real-world
kit scenarios (telemetry blocking, lockdowns, defense-in-depth) need
deny capability, not just additive allow.

This is the spec-side change required by the upstream feature work in
docker/sandboxes#2535. Once tagged, the sandboxes daemon will wire
`DeniedDomains` into a sandbox-scoped deny policy via the existing
per-sandbox policy plumbing.

## Changes

### Spec
- `spec/types.go` — new `DeniedDomains []string` field on `NetworkPolicy`
  with `omitempty` JSON/YAML tags, mirroring `AllowedDomains`.
- `spec/validate.go` — `ValidateNetworkPolicy` now rejects a domain
  listed in both `allowedDomains` and `deniedDomains` (clear authoring
  error rather than relying on consumer-side precedence).
- `spec/validate_test.go` — three subtests: disjoint lists pass,
  deny-only is valid, overlap fails with a descriptive error.
- `spec/testdata/sample-mixin/spec.yaml`,
  `spec/testdata/sample-agent/spec.yaml` — exercise the new field in
  the canonical fixtures (the mixin fixture's purpose is to cover
  every TCK-validated spec field).

### TCK
- `tck/suite.go` — `ExpectedDeniedDomains` field on `Suite`, asserted
  in `RunNetworkPolicyTests` (both the early-return guard and the
  matched-elements check).
- `tck/derive.go` — populate `ExpectedDeniedDomains` from
  `artifact.Network.DeniedDomains` in `NewSuiteFromDir`.

### Docs
- `README.md` — extend the `network:` example with a `deniedDomains`
  entry alongside `allowedDomains`.

## Test plan

- [x] `go test ./spec/... ./tck/...` — green, including the three new
      validation subtests and the TCK fixture round-trip.
- [x] `go build ./...` — clean.
- [ ] Downstream: docker/sandboxes pulls a tagged release and wires
      `DeniedDomains` into the scoped policy path (tracked separately).
