### PR TITLE
Add claude-ollama kit

### DIFF
--- a/claude-ollama/README.md
+++ b/claude-ollama/README.md
@@ -1,0 +1,45 @@
+# claude-ollama
+
+> `ollama launch claude --model gemma4:e4b-it-q4_K_M` — but in `sbx`.
+
+A fork of the built-in `claude` agent that routes all API calls to a local
+**[Ollama](https://ollama.com)** instance instead of Anthropic's API. Useful for
+offline development, cost-free experimentation, or testing with custom local models.
+
+> **Prerequisite:** Ollama must be running on your host machine at its default port
+> (`localhost:11434`) before starting this sandbox.
+
+## Usage
+
+```console
+$ sbx run claude-ollama --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=claude-ollama" ~/my-project
+```
+
+The agent name passed to `sbx run` (`claude-ollama`) matches the `name:` field in
+the kit's `spec.yaml`.
+
+The default model is `gemma4:e4b-it-q4_K_M`. To use a different model, fork this
+kit and change the `CLAUDE_OLLAMA_MODEL` default in `spec.yaml`.
+
+## What changed vs the built-in `claude`
+
+Instead of calling `api.anthropic.com`, a wrapper script replaces the entrypoint:
+
+```diff
+-  entrypoint:
+-    run: [claude, "--dangerously-skip-permissions"]
++  entrypoint:
++    run: [/home/agent/.local/bin/claude-ollama]
+```
+
+The wrapper script:
+
+1. Sets `ANTHROPIC_BASE_URL` to `http://host.docker.internal:11434` (Ollama via Docker's host bridge)
+2. Uses a dummy `ANTHROPIC_AUTH_TOKEN` — Ollama doesn't require real credentials
+3. Maps every Claude model alias (Opus, Sonnet, Haiku, sub-agent) to `$CLAUDE_OLLAMA_MODEL`
+4. Calls `exec claude "$@"` — the real Claude Code CLI takes over from there
+
+**Reference:** [`ollama/ollama` — cmd/launch/claude.go](https://github.com/ollama/ollama/blob/8f39fff70bac0bef2370a6af7020efa29a6a7cad/cmd/launch/claude.go)
+
+Network access is restricted to `localhost:11434` only; no Anthropic API domains are reachable.
+

--- a/claude-ollama/README.md
+++ b/claude-ollama/README.md
@@ -9,10 +9,15 @@ offline development, cost-free experimentation, or testing with custom local mod
 > **Prerequisite:** Ollama must be running on your host machine at its default port
 > (`localhost:11434`) before starting this sandbox.
 
+> **Linux hosts:** `host.docker.internal` requires Docker to be started with
+> `--add-host=host.docker.internal:host-gateway`. If Ollama is unreachable, verify
+> this flag is set or use your host's LAN/bridge IP in place of `host.docker.internal`.
+
 ## Usage
 
 ```console
-$ sbx run claude-ollama --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=claude-ollama" ~/my-project
+$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=claude-ollama" claude-ollama ~/my-project
+$ sbx run --kit ./claude-ollama/ claude-ollama ~/my-project
 ```
 
 The agent name passed to `sbx run` (`claude-ollama`) matches the `name:` field in

--- a/claude-ollama/claude_ollama_tck_test.go
+++ b/claude-ollama/claude_ollama_tck_test.go
@@ -1,0 +1,14 @@
+package claude_ollama_test
+
+import (
+	"testing"
+
+	"github.com/docker/sbx-kits-contrib/tck"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClaudeOllamaTCK(t *testing.T) {
+	suite, err := tck.NewSuiteFromDir(".")
+	require.NoError(t, err)
+	suite.RunAll(t)
+}

--- a/claude-ollama/spec.yaml
+++ b/claude-ollama/spec.yaml
@@ -15,6 +15,10 @@ environment:
   variables:
     CLAUDE_OLLAMA_MODEL: "gemma4:e4b-it-q4_K_M"
 
+settings:
+  containerSettings:
+    claude: true
+
 network:
   allowedDomains:
     - "localhost:11434"
@@ -23,12 +27,13 @@ commands:
   initFiles:
     - path: /home/agent/.local/bin/claude-ollama
       mode: "0755"
+      description: Wrapper script that routes Claude Code to the local Ollama instance
       content: |
         #!/usr/bin/env bash
         set -euo pipefail
 
         export ANTHROPIC_AUTH_TOKEN="ollama"
-        export ANTHROPIC_API_KEY=""
+        unset ANTHROPIC_API_KEY
         export ANTHROPIC_BASE_URL="http://host.docker.internal:11434"
 
         export ANTHROPIC_DEFAULT_OPUS_MODEL="$CLAUDE_OLLAMA_MODEL"
@@ -37,3 +42,11 @@ commands:
         export CLAUDE_CODE_SUBAGENT_MODEL="$CLAUDE_OLLAMA_MODEL"
 
         exec claude "$@"
+
+memory: |
+  ## Sandbox environment
+
+  You are running inside a Docker sandbox. All API calls are routed to a local
+  Ollama instance on the host (http://host.docker.internal:11434) — Anthropic's
+  API is not reachable. The workspace is mounted at its absolute host path.
+  `sudo` is passwordless; use it for package installs.

--- a/claude-ollama/spec.yaml
+++ b/claude-ollama/spec.yaml
@@ -1,0 +1,39 @@
+schemaVersion: "1"
+kind: agent
+name: claude-ollama
+displayName: Claude Code (Ollama)
+description: Claude Code wired to Ollama Anthropic-compatible API, with configurable model.
+
+agent:
+  image: "docker/sandbox-templates:claude-code-docker"
+  aiFilename: CLAUDE.md
+  persistence: persistent
+  entrypoint:
+    run: [/home/agent/.local/bin/claude-ollama]
+
+environment:
+  variables:
+    CLAUDE_OLLAMA_MODEL: "gemma4:e4b-it-q4_K_M"
+
+network:
+  allowedDomains:
+    - "localhost:11434"
+
+commands:
+  initFiles:
+    - path: /home/agent/.local/bin/claude-ollama
+      mode: "0755"
+      content: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        export ANTHROPIC_AUTH_TOKEN="ollama"
+        export ANTHROPIC_API_KEY=""
+        export ANTHROPIC_BASE_URL="http://host.docker.internal:11434"
+
+        export ANTHROPIC_DEFAULT_OPUS_MODEL="$CLAUDE_OLLAMA_MODEL"
+        export ANTHROPIC_DEFAULT_SONNET_MODEL="$CLAUDE_OLLAMA_MODEL"
+        export ANTHROPIC_DEFAULT_HAIKU_MODEL="$CLAUDE_OLLAMA_MODEL"
+        export CLAUDE_CODE_SUBAGENT_MODEL="$CLAUDE_OLLAMA_MODEL"
+
+        exec claude "$@"


### PR DESCRIPTION
# Summary

Adds a `claude-ollama` kit that routes all Claude Code API calls to a local [Ollama](https://ollama.com) instance instead of Anthropic's API. Useful for offline development, cost-free experimentation, and testing with custom local models.

# Spec choices worth flagging for review

- Uses `initFiles` to inject the wrapper script inline
- `ANTHROPIC_` variables are set similar to approach used in [Ollama's own Claude launcher](https://github.com/ollama/ollama/blob/8f39fff70bac0bef2370a6af7020efa29a6a7cad/cmd/launch/claude.go); skips the Claude Code sign-in screen.
- `allowedDomains` is narrow (`localhost:11434` only) — no Anthropic API domains are reachable, which is the whole point.

# Test plan

- `sbx kit validate ./claude-ollama/` ✅
- `go test -v -count=1 -timeout 10m ./claude-ollama/...` ✅
- `sbx run --kit ./claude-ollama/ claude` end-to-end with Ollama running locally ✅

# Origin

Adapted from [`alakae/sbx-kits`](https://github.com/alakae/sbx-kits) (MIT), which was itself adapted from [`dvdksn/kits-cookbook`](https://github.com/dvdksn/kits-cookbook) (claude-safe kit) (also MIT).