### PR TITLE
chore(nanoclaw): add maintainers to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,5 @@
 # For more details, see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 * @docker/coding-agent-sandboxes
+
+/nanoclaw/ @gavrielc @gabi-simons


### PR DESCRIPTION
## What's changed

Adds `@gavrielc` and `@gabi-simons` as code owners for the `/nanoclaw/` path in `.github/CODEOWNERS`. The repository-wide ownership by `@docker/coding-agent-sandboxes` remains unchanged.

## Why is this important?

The `nanoclaw` kit has dedicated maintainers who should be automatically requested for review on changes to that subtree. Listing them in CODEOWNERS ensures PRs touching `nanoclaw/` route to the right reviewers without relying on manual assignment.

## Changes

- `.github/CODEOWNERS`: add `/nanoclaw/ @gavrielc @gabi-simons` rule

## Test plan

- [ ] GitHub recognizes the new rule (CODEOWNERS validation in the PR sidebar shows no syntax errors)
- [ ] A subsequent PR touching files under `nanoclaw/` automatically requests review from `@gavrielc` and `@gabi-simons`
