### PR TITLE
Add Trivy kit

### DIFF
--- a/trivy/README.md
+++ b/trivy/README.md
@@ -1,0 +1,106 @@
+# trivy
+
+A standalone agent kit (`kind: agent`) for the [Trivy](https://trivy.dev/)
+open-source vulnerability scanner from [Aqua Security](https://aquasec.com/).
+The kit installs `trivy` from a pinned, digest-verified GitHub release at
+sandbox creation time and drops you into a bash shell with the binary on
+`PATH` and your workspace mounted as the working directory.
+
+## Why this kit exists
+
+In March 2026 the threat actor [TeamPCP compromised Trivy](https://www.wiz.io/blog/trivy-compromised-teampcp-supply-chain-attack)
+itself — force-pushing GitHub Action tags, shipping an infected v0.69.4
+binary, and using the resulting credential harvest to weaponize 47+ npm
+packages downstream. Microsoft's
+[response guidance](https://www.microsoft.com/en-us/security/blog/2026/03/24/detecting-investigating-defending-against-trivy-supply-chain-compromise/)
+prescribes "governed execution pipelines" with "vault isolation and egress
+filtering". This kit puts that prescription one `sbx run` away: scanner
+runs in a microVM, your `~/.aws` / `~/.ssh` / `~/.docker/config.json` are
+not mounted, egress is allowlisted to four hosts (release fetch + vuln DB),
+and the install is digest-pinned against tag-rewrite attacks.
+
+## Usage
+
+```console
+$ cd ~/work/some-project
+$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=trivy" trivy .
+agent@trivy-some-project:/Users/mark/work/some-project$ trivy fs .
+```
+
+Or with a local clone of this repo:
+
+```console
+$ sbx run --kit ./trivy/ trivy .
+```
+
+The first launch downloads, verifies, and installs Trivy. Subsequent
+launches reuse the sandbox; the vuln DB is cached on a persistent volume.
+
+## How auth and egress work
+
+Trivy is fully open source — **no API key needed** for the standard scan
+flows (`fs`, `repo`, plain `image`). Aqua's commercial feeds (premium
+indicators, SaaS reporting) are out of scope for this kit; if you need
+them, fork and add the appropriate `serviceDomains` and `credentials`.
+
+The kit's `allowedDomains` covers exactly four hosts:
+
+| Host | Why |
+| --- | --- |
+| `github.com` | Release page entry point for the install tarball (302-redirects) |
+| `release-assets.githubusercontent.com` | Where GitHub release blobs actually live (the redirect target) |
+| `ghcr.io` | Pulls the vuln DB OCI artifact (`ghcr.io/aquasecurity/trivy-db`) |
+| `pkg-containers.githubusercontent.com` | GHCR blob storage backend |
+
+Trivy's *default* primary DB source is `mirror.gcr.io` (Google's container
+registry mirror), with `ghcr.io` as a fallback. The kit deliberately
+excludes `mirror.gcr.io` and forces the GHCR artifact directly via
+`TRIVY_DB_REPOSITORY=ghcr.io/aquasecurity/trivy-db` (and the matching
+`TRIVY_JAVA_DB_REPOSITORY`). This trims the kit's external trust surface
+from {GitHub + GHCR + Google} to {GitHub + GHCR} and removes Google as a
+required participant. (Trivy 0.61+ honours the env vars; older versions
+need the `--db-repository` flag instead.)
+
+Anything else — registries you want to scan images from, custom vuln DB
+mirrors, your reporting endpoint — should be added with a per-sandbox or
+operator-level allow rule, *not* in the kit:
+
+```console
+$ sbx policy allow network --sandbox trivy-some-project "registry-1.docker.io,auth.docker.io,production.cloudflare.docker.com"
+```
+
+This keeps the kit's default footprint minimal and forces deliberate
+opt-in to anything image-registry-shaped.
+
+## Image scanning
+
+By default the kit does **not** mount the host Docker socket. Image
+scanning has three workable modes:
+
+1. **`trivy image --input <tarball>`** *(recommended)* — `docker save`
+   the image to a tarball on the host, mount the tarball into the
+   workspace, scan it inside the sandbox. Zero socket exposure.
+2. **`trivy image <registry>/<repo>:<tag>`** — Trivy pulls the image
+   itself directly. Add the registry's hosts to a per-sandbox allow
+   rule (see above). Requires no socket.
+3. **Bind-mount `/var/run/docker.sock`** — works but defeats the
+   isolation. Don't.
+
+For routine scanning of *what's in front of you*, prefer
+`trivy fs .` against the workspace mount.
+
+## Version pinning
+
+The install command pins:
+
+- `TRIVY_VERSION=0.70.0` (published 2026-04-17, post-TeamPCP)
+- SHA256 per-arch: `Linux-64bit` and `Linux-ARM64`
+
+To bump: edit `spec.yaml`, update both the version string and the
+SHA256s sourced from the release's `checksums.txt`. Sigstore signature
+verification is a worthwhile follow-up but out of scope for v1.
+
+## Cleanup
+
+`sbx rm trivy-<basename>` removes the sandbox and its persistent vuln
+DB cache. The workspace bind-mount on the host is untouched.

--- a/trivy/README.md
+++ b/trivy/README.md
@@ -43,23 +43,28 @@ flows (`fs`, `repo`, plain `image`). Aqua's commercial feeds (premium
 indicators, SaaS reporting) are out of scope for this kit; if you need
 them, fork and add the appropriate `serviceDomains` and `credentials`.
 
-The kit's `allowedDomains` covers exactly four hosts:
+The kit's `allowedDomains` covers exactly five hosts:
 
 | Host | Why |
 | --- | --- |
 | `github.com` | Release page entry point for the install tarball (302-redirects) |
 | `release-assets.githubusercontent.com` | Where GitHub release blobs actually live (the redirect target) |
-| `ghcr.io` | Pulls the vuln DB OCI artifact (`ghcr.io/aquasecurity/trivy-db`) |
+| `mirror.gcr.io` | Trivy's default *primary* vuln DB source (`mirror.gcr.io/aquasec/trivy-db`) |
+| `ghcr.io` | Trivy's *fallback* vuln DB source (`ghcr.io/aquasecurity/trivy-db`) |
 | `pkg-containers.githubusercontent.com` | GHCR blob storage backend |
 
-Trivy's *default* primary DB source is `mirror.gcr.io` (Google's container
-registry mirror), with `ghcr.io` as a fallback. The kit deliberately
-excludes `mirror.gcr.io` and forces the GHCR artifact directly via
-`TRIVY_DB_REPOSITORY=ghcr.io/aquasecurity/trivy-db` (and the matching
-`TRIVY_JAVA_DB_REPOSITORY`). This trims the kit's external trust surface
-from {GitHub + GHCR + Google} to {GitHub + GHCR} and removes Google as a
-required participant. (Trivy 0.61+ honours the env vars; older versions
-need the `--db-repository` flag instead.)
+Both DB sources are declared in the allowlist rather than redirecting Trivy
+to one specific source via env vars. The reason: env-var-based security
+config is fragile — anything running as the agent user inside the sandbox
+can override or unset it. Declaring all required egress at the policy
+layer keeps the trust footprint observable and survives a compromised
+agent process trying to subvert it.
+
+Tightening this footprint — both the install channel (currently a pinned
+GitHub release) and the DB source (currently Trivy's defaults) — is the
+v2 path: install via a hardened-distribution channel where the entire
+build pipeline is observable and signed. Deferred until that integration
+lands cleanly at the runtime layer.
 
 Anything else — registries you want to scan images from, custom vuln DB
 mirrors, your reporting endpoint — should be added with a per-sandbox or

--- a/trivy/spec.yaml
+++ b/trivy/spec.yaml
@@ -18,20 +18,14 @@ network:
     # github.com 302-redirects to release-assets.githubusercontent.com for binary downloads.
     - github.com
     - release-assets.githubusercontent.com
-    # Vulnerability DB pull (runtime; trivy-db is published as an OCI artifact on GHCR).
-    # We deliberately exclude Trivy's *default* primary mirror (mirror.gcr.io / Google) and
-    # force Aqua's GHCR-hosted artifact instead — see TRIVY_DB_REPOSITORY in `environment`.
-    # This trims the kit's external trust surface from {GitHub + GHCR + Google} to {GitHub + GHCR}.
+    # Vulnerability DB pull at runtime. Trivy's default chain is mirror.gcr.io (primary)
+    # with ghcr.io as a fallback for the trivy-db OCI artifact; we declare both openly in
+    # the allowlist rather than relying on env-var overrides to redirect the source.
+    # The trust footprint is intentionally explicit at the policy layer; tightening this
+    # is part of the v2 path (hardened-distribution-channel install).
+    - mirror.gcr.io
     - ghcr.io
     - pkg-containers.githubusercontent.com
-
-environment:
-  variables:
-    # Skip Trivy's default mirror.gcr.io fallback chain; pin DB source to Aqua's GHCR artifact.
-    # Trivy 0.61+ honors this env var; older versions need the --db-repository CLI flag instead.
-    TRIVY_DB_REPOSITORY: "ghcr.io/aquasecurity/trivy-db"
-    # Same idea for the Java DB (used by `trivy fs` against jar/pom files).
-    TRIVY_JAVA_DB_REPOSITORY: "ghcr.io/aquasecurity/trivy-java-db"
 
 commands:
   install:

--- a/trivy/spec.yaml
+++ b/trivy/spec.yaml
@@ -1,0 +1,68 @@
+schemaVersion: "1"
+kind: agent
+name: trivy
+displayName: Trivy
+description: "Aqua's open source vulnerability scanner — sandboxed because security scanners shouldn't be able to compromise their hosts (TeamPCP, March 2026)."
+
+agent:
+  image: "docker/sandbox-templates:shell-docker"
+  aiFilename: AGENTS.md
+  persistence: persistent
+  # Drop into bash with trivy on PATH and the workspace as cwd. Run `trivy fs .` to scan.
+  entrypoint:
+    run: [bash, -l]
+
+network:
+  allowedDomains:
+    # Release tarball download (install time, one-shot).
+    # github.com 302-redirects to release-assets.githubusercontent.com for binary downloads.
+    - github.com
+    - release-assets.githubusercontent.com
+    # Vulnerability DB pull (runtime; trivy-db is published as an OCI artifact on GHCR).
+    # We deliberately exclude Trivy's *default* primary mirror (mirror.gcr.io / Google) and
+    # force Aqua's GHCR-hosted artifact instead — see TRIVY_DB_REPOSITORY in `environment`.
+    # This trims the kit's external trust surface from {GitHub + GHCR + Google} to {GitHub + GHCR}.
+    - ghcr.io
+    - pkg-containers.githubusercontent.com
+
+environment:
+  variables:
+    # Skip Trivy's default mirror.gcr.io fallback chain; pin DB source to Aqua's GHCR artifact.
+    # Trivy 0.61+ honors this env var; older versions need the --db-repository CLI flag instead.
+    TRIVY_DB_REPOSITORY: "ghcr.io/aquasecurity/trivy-db"
+    # Same idea for the Java DB (used by `trivy fs` against jar/pom files).
+    TRIVY_JAVA_DB_REPOSITORY: "ghcr.io/aquasecurity/trivy-java-db"
+
+commands:
+  install:
+    # Install Trivy from a pinned, digest-verified GitHub release.
+    # Why not the official `install.sh`: that pattern (curl|sh) is exactly what TeamPCP
+    # weaponized in March 2026 against tag-rewriteable references. We pin a known-good
+    # release by version AND SHA256, in the kit, in git. To bump: change TRIVY_VERSION
+    # plus the per-arch SHA256 below (sourced from the release's checksums.txt).
+    - command: |
+        set -euo pipefail
+        TRIVY_VERSION=0.70.0
+        ARCH=$(dpkg --print-architecture)
+        case "$ARCH" in
+          amd64)
+            TARBALL="trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
+            SHA256="8b4376d5d6befe5c24d503f10ff136d9e0c49f9127a4279fd110b727929a5aa9"
+            ;;
+          arm64)
+            TARBALL="trivy_${TRIVY_VERSION}_Linux-ARM64.tar.gz"
+            SHA256="2f6bb988b553a1bbac6bdd1ce890f5e412439564e17522b88a4541b4f364fc8d"
+            ;;
+          *)
+            echo "unsupported sandbox arch: $ARCH (expected amd64 or arm64)" >&2
+            exit 1
+            ;;
+        esac
+        URL="https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/${TARBALL}"
+        curl --proto '=https' --tlsv1.2 -fsSL -o /tmp/trivy.tgz "$URL"
+        echo "${SHA256}  /tmp/trivy.tgz" | sha256sum -c -
+        tar -C /usr/local/bin -xzf /tmp/trivy.tgz trivy
+        rm /tmp/trivy.tgz
+        trivy --version
+      user: "0"
+      description: "Install Trivy CLI v0.70.0, version+digest pinned"

--- a/trivy/trivy_tck_test.go
+++ b/trivy/trivy_tck_test.go
@@ -1,0 +1,14 @@
+package trivy_test
+
+import (
+	"testing"
+
+	"github.com/docker/sbx-kits-contrib/tck"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrivyTCK(t *testing.T) {
+	suite, err := tck.NewSuiteFromDir(".")
+	require.NoError(t, err)
+	suite.RunAll(t)
+}


### PR DESCRIPTION
## Summary
First security-tool kit in contrib. Adds a `kind: agent` kit for the [Trivy](https://trivy.dev/) vulnerability scanner.

## Origin
Authored as a demo for an LDx3 talk on "boundary-first agentic work" — running security scanners (the very class of tool that just got compromised in the TeamPCP campaign) inside Docker sbx with a tight egress allowlist and pinned install.

## Spec choices worth flagging for review
- **Install is version- and SHA256-pinned per arch** (not curl|sh) — direct response to the tag-rewrite vector TeamPCP used in March 2026
- **Allowlist deliberately excludes `mirror.gcr.io`** (Trivy's default primary DB source) and forces GHCR-only via `TRIVY_DB_REPOSITORY` env. Trims trust surface from {GitHub + GHCR + Google} to {GitHub + GHCR}.
- **No docker.sock mount** by default; image-scanning documented as opt-in via per-sandbox policy + `docker save | trivy image --input` (README has details).
- **Entrypoint is `[bash, -l]`** rather than `[trivy]` because Trivy is a one-shot CLI; bash gives users a working shell with `trivy` on PATH and the workspace as cwd.

## Test plan
- [x] \`sbx kit validate ./trivy/\` → VALID
- [x] \`sbx run --kit ./trivy/ trivy <ws>\` end-to-end on macOS (Apple Silicon → arm64 sandbox)
- [x] Real \`trivy fs\` scan against vulnerable Python fixture (Django 1.11, requests 2.6.0) — surfaces expected CVEs
- [x] Boundary verification: non-allowlisted hosts return HTTP 403 from proxy
- [ ] CI: \`go test -v -count=1 -timeout 10m ./...\` (TCK; runs on PR)