### PR TITLE
fix(nanoclaw): fix startup race and missing github domain allowlist

### DIFF
--- a/nanoclaw/spec.yaml
+++ b/nanoclaw/spec.yaml
@@ -9,7 +9,7 @@ agent:
   aiFilename: CLAUDE.md
   persistence: persistent
   entrypoint:
-    run: ["sh", "-c", "cd /home/agent/nanoclaw && exec claude --dangerously-skip-permissions"]
+    run: ["/usr/local/bin/nanoclaw-start"]
 
 network:
   serviceDomains:
@@ -28,6 +28,8 @@ network:
     - registry.npmjs.org
     - "*.npmjs.org"
     - nanoclaw.dev
+    - "github.com:443"
+    - "objects.githubusercontent.com:443"
 
 credentials:
   sources:
@@ -48,9 +50,12 @@ commands:
     - command: "npm config set proxy $HTTP_PROXY && npm config set https-proxy $HTTP_PROXY"
       user: "1000"
       description: Configure npm to use the sandbox proxy
-    - command: "git clone --depth 1 https://github.com/qwibitai/nanoclaw.git /home/agent/nanoclaw && cd /home/agent/nanoclaw && npm install --maxsockets=1 --fetch-timeout=600000 && npm rebuild better-sqlite3 && npm run build"
+    - command: "printf '#!/bin/sh\\nif ! [ -f /home/agent/nanoclaw/.installed ] || ! [ -f /home/agent/.claude/settings.json ]; then\\n  echo \"Waiting for nanoclaw installation to complete...\" >&2\\n  until [ -f /home/agent/nanoclaw/.installed ] && [ -f /home/agent/.claude/settings.json ]; do sleep 2; done\\nfi\\nexec claude --dangerously-skip-permissions\\n' > /usr/local/bin/nanoclaw-start && chmod +x /usr/local/bin/nanoclaw-start"
+      user: "0"
+      description: Create agent entrypoint early; waits for nanoclaw install and claude settings before starting
+    - command: "printf '#!/bin/sh\\ngit clone --depth 1 https://github.com/qwibitai/nanoclaw.git /home/agent/nanoclaw && cd /home/agent/nanoclaw && npm install --maxsockets=1 --fetch-timeout=600000 && npm rebuild better-sqlite3 && npm run build && touch /home/agent/nanoclaw/.installed\\n' > /home/agent/nanoclaw-install.sh && chmod +x /home/agent/nanoclaw-install.sh && setsid /home/agent/nanoclaw-install.sh > /home/agent/nanoclaw-install.log 2>&1 &"
       user: "1000"
-      description: Clone and build nanoclaw (~2 minutes; runs once at sandbox creation)
+      description: Clone and build nanoclaw in detached background session (~2 minutes; .installed flag written on completion)
     - command: "cat > /usr/local/bin/nanoclaw << 'SCRIPT'\n#!/bin/sh\ncd /home/agent/nanoclaw\nexec node dist/index.js \"$@\"\nSCRIPT\nchmod +x /usr/local/bin/nanoclaw"
       user: "0"
       description: Create nanoclaw launcher (root-owned path)


### PR DESCRIPTION
## Summary

  - **Entrypoint race**: `["sh", "-c", "..."]` sets `Binary=sh`, so the agent healthcheck (`command -v sh`) passes instantly — before nanoclaw is built. Changed
  entrypoint to `/usr/local/bin/nanoclaw-start`, a wrapper created early in install that polls for both the `.installed` flag and `.claude/settings.json` before exec'ing
   `claude`.
  - **Blocked git clone**: `github.com` was not in `allowedDomains`; added `github.com:443` and `objects.githubusercontent.com:443`.
  - **30s healthcheck timeout**: Synchronous git clone + npm install (~2 min) ran as PostStart hooks and exceeded the healthcheck timeout. Moved the build into a
  detached `setsid` background session so PostStart hooks exit immediately.

  ## Test plan

  - [ ] `sbx run --kit ./nanoclaw nanoclaw` completes without "container is not running" error
  - [ ] `claude --dangerously-skip-permissions` starts after nanoclaw build completes (~2 min)
  - [ ] `/usr/local/bin/nanoclaw` binary is available in the sandbox

  🤖 Generated with [Claude Code](https://claude.com/claude-code)