### PR TITLE
fix(openclaw): fix startup race and Node.js version requirement

### DIFF
--- a/openclaw/spec.yaml
+++ b/openclaw/spec.yaml
@@ -9,7 +9,7 @@ agent:
   aiFilename: AGENTS.md
   persistence: persistent
   entrypoint:
-    run: [openclaw, chat]
+    run: ["/usr/local/bin/openclaw-start"]
 
 network:
   serviceDomains:
@@ -21,8 +21,9 @@ network:
       headerName: x-api-key
       valueFormat: "%s"
   allowedDomains:
-    - deb.nodesource.com
     - registry.npmjs.org
+    - "*.npmjs.org"
+    - "nodejs.org:443"
     - "*.telegram.org"
     - "*.discord.com"
     - gateway.discord.gg
@@ -46,17 +47,17 @@ environment:
 
 commands:
   install:
-    - command: "curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && apt-get install -y nodejs"
+    - command: "npm config set proxy $HTTP_PROXY && npm config set https-proxy $HTTP_PROXY"
       user: "0"
-      description: "Install Node.js 22 (OpenClaw requires >= 22.12.0)"
-    - command: "sudo apt update && sudo apt install -y ssh"
-      user: "1000"
-      description: Install SSH
-    - command: "npm config set proxy $HTTP_PROXY && npm config set https-proxy $HTTP_PROXY && npm install -g --maxsockets=1 --fetch-timeout=600000 openclaw@latest"
+      description: Configure npm proxy
+    - command: "printf '#!/bin/sh\\nif ! [ -f /home/agent/.openclaw-installed ]; then\\n  echo \"Waiting for OpenClaw installation to complete...\" >&2\\n  until [ -f /home/agent/.openclaw-installed ]; do sleep 2; done\\nfi\\nexec /usr/local/share/npm-global/bin/openclaw chat\\n' > /usr/local/bin/openclaw-start && chmod +x /usr/local/bin/openclaw-start"
       user: "0"
-      description: Configure npm proxy and install OpenClaw globally
+      description: Create agent entrypoint early; polls for install flag before starting openclaw
+    - command: "printf '#!/bin/sh\\nnpm install -g n && n install 22 && npm install -g --maxsockets=1 --fetch-timeout=600000 openclaw@latest && touch /home/agent/.openclaw-installed\\n' > /home/agent/openclaw-install.sh && chmod +x /home/agent/openclaw-install.sh && setsid /home/agent/openclaw-install.sh > /home/agent/openclaw-install.log 2>&1 &"
+      user: "0"
+      description: Upgrade to Node.js 22 and install OpenClaw in detached background session (~3 minutes; .openclaw-installed flag written on completion)
   startup:
-    - command: ["node", "/usr/local/share/npm-global/bin/openclaw", "gateway", "run", "--allow-unconfigured"]
+    - command: [sh, -c, "until [ -f /home/agent/.openclaw-installed ]; do sleep 5; done; /usr/local/share/npm-global/bin/openclaw gateway run --allow-unconfigured"]
       user: "1000"
       background: true
-      description: Start OpenClaw gateway
+      description: Wait for install then start OpenClaw gateway


### PR DESCRIPTION
## Problem

The openclaw kit fails to start a working sandbox due to three compounding issues:

1. **`curl | bash -` (nodesource setup script) kills the container.** The nodesource `setup_22.x` script triggers a service restart inside the privileged DinD container, which kills the tini init process and terminates the whole sandbox.
2. **`apt install ssh` is blocked.** The apt repository domains are not in `allowedDomains`, so the command hangs/fails.
3. **Synchronous `npm install -g openclaw` in a PostStart hook stalls.** Long-running installs in PostStart hooks block the hook chain; Docker eventually stops the container due to a health-check timeout.

Additionally, the `shell-docker` image ships Node.js v20, but openclaw enforces a hard runtime check requiring v22.12+, so even if the install completed it would fail to start.

## Fix

Adopt the same **setsid background install** pattern introduced for the nanoclaw kit:

- **Entrypoint changed** to `/usr/local/bin/openclaw-start` — a tiny wrapper that polls for a `.openclaw-installed` flag before exec'ing `openclaw chat`.
- **Wrapper created early** (before the background install) so Binary health-check logic sees a valid executable immediately.
- **Background install** (`setsid script.sh &`) runs: `npm install -g n` → `n install 22` (upgrades Node to v22) → `npm install -g openclaw@latest` → writes `.openclaw-installed`.
- **Startup gateway command** also waits for the flag to avoid racing the install.
- **`deb.nodesource.com` removed** from `allowedDomains`; **`nodejs.org:443`** added (needed by the `n` version manager to fetch Node 22 binaries).
- The broken `apt install ssh` step is removed entirely.

## Test plan

- [x] `sbx run --kit ./openclaw/ openclaw` creates sandbox without "container is not running" error
- [x] `/home/agent/openclaw-install.log` shows Node 22 install + openclaw package install completing successfully
- [x] `/home/agent/.openclaw-installed` flag file written after install
- [x] `openclaw --version` returns `OpenClaw 2026.5.3-1` on Node v22
- [x] `ps aux` shows both `openclaw` (gateway) and `openclaw-tui` (chat) processes running

🤖 Generated with [Claude Code](https://claude.com/claude-code)