### PR TITLE
Add Open Interpreter agent kit

### DIFF
--- a/open-interpreter/README.md
+++ b/open-interpreter/README.md
@@ -91,12 +91,21 @@ mixin kit with the extra domains.
 
 | Component | How |
 | --- | --- |
-| `open-interpreter` | `pip install open-interpreter` at creation time |
+| `uv` | `curl -LsSf https://astral.sh/uv/install.sh \| sh` at creation time |
+| `open-interpreter` | `uv tool install --python 3.12 open-interpreter` at creation time |
 | Default profile | Dropped via `files/` at `/home/agent/.config/open-interpreter/profiles/default.yaml` |
 
+`uv` is used instead of `pip` for two reasons: the base image runs Ubuntu 24.04
+which enforces PEP 668 (bare `pip install` is blocked), and `open-interpreter`'s
+`numpy` dependency has no Python 3.13 wheel — `uv --python 3.12` fetches a
+standalone Python 3.12 runtime automatically without needing a system compiler.
+
+On every sandbox start, `uv tool upgrade open-interpreter` runs in the background
+so you stay on the latest release without recreating the sandbox.
+
 The install is substantial (LiteLLM, Anthropic SDK, Selenium, FastAPI, and more
-are bundled). First sandbox creation takes 2–3 minutes; subsequent starts reuse
-the persistent volume.
+are bundled). First sandbox creation takes 3–5 minutes; subsequent starts reuse
+the persistent volume and upgrade in the background.
 
 ## Cleanup
 

--- a/open-interpreter/README.md
+++ b/open-interpreter/README.md
@@ -1,0 +1,104 @@
+# open-interpreter
+
+An agent kit (`kind: agent`) for [Open Interpreter](https://www.openinterpreter.com/) —
+a natural language interface for your computer. Describe what you want in plain English;
+Open Interpreter writes and runs the code (Python, JS, Shell, and more) to complete it.
+
+Running OI inside a Docker Sandbox is a natural fit: the sandbox provides OS-level
+isolation so `auto_run` (code executes without confirmation prompts) is safe to enable
+by default.
+
+## Prerequisites
+
+At least one LLM API key exported on your host. Open Interpreter defaults to GPT-4o:
+
+```console
+export OPENAI_API_KEY=<your-openai-key>
+```
+
+To use Claude instead (recommended — Anthropic key only):
+
+```console
+export ANTHROPIC_API_KEY=<your-anthropic-key>
+```
+
+Both are declared in `credentials.sources`. The kit proxy-manages whichever ones
+are present on the host — the real values never enter the sandbox.
+
+## Usage
+
+```console
+# From this repo (tracks default branch)
+$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=open-interpreter" open-interpreter
+
+# Pinned to a tag
+$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#ref=v1.0.0&dir=open-interpreter" open-interpreter
+
+# Local development
+$ sbx run --kit ./open-interpreter/ open-interpreter
+```
+
+You attach directly to the Open Interpreter REPL. Type a natural language request
+and OI will write and execute code to complete it:
+
+```
+> Download the last 7 days of Apache logs from /var/log/apache2/ and plot
+  request counts by hour as a PNG.
+```
+
+## Switching models
+
+The default profile sets `model: gpt-4o`. Override at launch:
+
+```console
+# Use Claude (requires ANTHROPIC_API_KEY)
+$ sbx run --kit ./open-interpreter/ open-interpreter --args="--model claude-3-5-sonnet-20241022"
+
+# Use a local Ollama model (no API key needed)
+$ sbx run --kit ./open-interpreter/ open-interpreter --args="--model ollama/llama3"
+
+# Or update ~/.config/open-interpreter/profiles/default.yaml inside the sandbox
+```
+
+## How auth works
+
+Both `api.openai.com` and `api.anthropic.com` are listed in `serviceDomains`.
+The proxy injects `Authorization: Bearer <key>` for OpenAI and `x-api-key: <key>`
+for Anthropic on matching outbound requests. Keys never enter the sandbox VM.
+
+`serviceDomains` is intentionally limited to the two LLM API hosts. A wildcard
+there would put the proxy into TLS-intercept mode for all traffic, including the
+arbitrary HTTP requests that OI's executed code makes — breaking downloads,
+package installs, and web scraping tasks.
+
+## Network policy and code execution
+
+OI executes arbitrary code that can reach any domain. The kit's `allowedDomains`
+covers OI's own operational needs:
+
+| Domain | Purpose |
+| --- | --- |
+| `raw.githubusercontent.com` | Open Procedures — task best-practice snippets OI fetches at runtime |
+| `pypi.org` / `files.pythonhosted.org` | pip (install time + code execution) |
+| `registry.npmjs.org` | npm (OI can write and run JS) |
+| `deb.debian.org` / `archive.ubuntu.com` | apt (OI can install system packages) |
+| `api.github.com` / `objects.githubusercontent.com` | GitHub API and asset downloads |
+
+If your tasks reach other hosts, add them with `sbx kit add` or stack an additional
+mixin kit with the extra domains.
+
+## What gets installed
+
+| Component | How |
+| --- | --- |
+| `open-interpreter` | `pip install open-interpreter` at creation time |
+| Default profile | Dropped via `files/` at `/home/agent/.config/open-interpreter/profiles/default.yaml` |
+
+The install is substantial (LiteLLM, Anthropic SDK, Selenium, FastAPI, and more
+are bundled). First sandbox creation takes 2–3 minutes; subsequent starts reuse
+the persistent volume.
+
+## Cleanup
+
+Open Interpreter creates no host-side state. The sandbox volume persists files
+and conversation history across restarts; `sbx rm open-interpreter` removes it.

--- a/open-interpreter/files/home/.config/open-interpreter/profiles/default.yaml
+++ b/open-interpreter/files/home/.config/open-interpreter/profiles/default.yaml
@@ -1,0 +1,12 @@
+### Open Interpreter — Docker Sandbox profile
+# auto_run skips the "approve this code?" prompt — the sandbox provides
+# the isolation that makes this safe to enable.
+auto_run: true
+
+llm:
+  model: "gpt-4o"
+  temperature: 0
+
+computer:
+  # Gives OI a built-in Computer API for file, browser, and OS operations
+  import_computer_api: true

--- a/open-interpreter/open_interpreter_tck_test.go
+++ b/open-interpreter/open_interpreter_tck_test.go
@@ -1,0 +1,14 @@
+package open_interpreter_test
+
+import (
+	"testing"
+
+	"github.com/docker/sbx-kits-contrib/tck"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenInterpreterTCK(t *testing.T) {
+	suite, err := tck.NewSuiteFromDir(".")
+	require.NoError(t, err)
+	suite.RunAll(t)
+}

--- a/open-interpreter/spec.yaml
+++ b/open-interpreter/spec.yaml
@@ -1,0 +1,86 @@
+schemaVersion: "1"
+kind: agent
+name: open-interpreter
+displayName: Open Interpreter
+description: >
+  Natural language interface for your sandbox. Describe what you need;
+  Open Interpreter writes and runs the code (Python, JS, Shell, and more)
+  to complete the task.
+
+agent:
+  image: "docker/sandbox-templates:shell-docker"
+  aiFilename: AGENTS.md
+  persistence: persistent
+  entrypoint:
+    run: [interpreter]
+
+credentials:
+  sources:
+    openai:
+      env:
+        - OPENAI_API_KEY
+      file:
+        path: ~/.openai-api-key
+    anthropic:
+      env:
+        - ANTHROPIC_API_KEY
+
+network:
+  # Narrow serviceDomains: only the LLM API hosts that need auth injection.
+  # A wildcard here would TLS-intercept all traffic, including code that
+  # OI executes on your behalf, breaking arbitrary downloads.
+  serviceDomains:
+    api.openai.com: openai
+    api.anthropic.com: anthropic
+  serviceAuth:
+    openai:
+      headerName: Authorization
+      valueFormat: "Bearer %s"
+    anthropic:
+      headerName: x-api-key
+      valueFormat: "%s"
+  allowedDomains:
+    # Open Procedures: OI fetches task-specific best-practice snippets at runtime
+    - raw.githubusercontent.com
+    - objects.githubusercontent.com
+    - api.github.com
+    # PyPI: pip installs at creation time and during code execution
+    - pypi.org
+    - files.pythonhosted.org
+    # npm: OI can write and run JS
+    - registry.npmjs.org
+    - "*.npmjs.org"
+    # apt: OI can run shell commands that install system packages
+    - deb.debian.org
+    - archive.ubuntu.com
+    - security.ubuntu.com
+    # LiteLLM model info and routing
+    - "*.litellm.ai"
+
+environment:
+  proxyManaged:
+    - OPENAI_API_KEY
+    - ANTHROPIC_API_KEY
+
+commands:
+  install:
+    - command: "pip install open-interpreter"
+      user: "1000"
+      description: Install Open Interpreter and its dependencies
+
+memory: |
+  ## Open Interpreter
+
+  You are Open Interpreter. You take natural language requests and complete
+  them by writing and running code.
+
+  The sandbox is isolated — you can run code freely without worrying about
+  damaging the host system.
+
+  - **Auto-run is on**: code executes without confirmation prompts.
+  - **Supported languages**: Python, JavaScript, Shell, and anything else
+    installed in the environment.
+  - **Switch models**: run `interpreter --model claude-3-5-sonnet-20241022`
+    to use Claude, or `interpreter --model ollama/llama3` for a local model.
+  - **Workspace**: your working directory is `${WORKDIR}`. Files created
+    there persist across sandbox restarts.

--- a/open-interpreter/spec.yaml
+++ b/open-interpreter/spec.yaml
@@ -12,7 +12,7 @@ agent:
   aiFilename: AGENTS.md
   persistence: persistent
   entrypoint:
-    run: [interpreter]
+    run: ["/home/agent/.local/bin/interpreter"]
 
 credentials:
   sources:
@@ -44,7 +44,10 @@ network:
     - raw.githubusercontent.com
     - objects.githubusercontent.com
     - api.github.com
-    # PyPI: pip installs at creation time and during code execution
+    # uv installer and releases (including Python 3.12 standalone runtime)
+    - "astral.sh"
+    - "*.astral.sh"
+    # PyPI: uv installs at creation time and during code execution
     - pypi.org
     - files.pythonhosted.org
     # npm: OI can write and run JS
@@ -64,9 +67,28 @@ environment:
 
 commands:
   install:
-    - command: "pip install open-interpreter"
+    - command: "curl -LsSf https://astral.sh/uv/install.sh | sh"
       user: "1000"
-      description: Install Open Interpreter and its dependencies
+      description: Install uv
+
+    # --python 3.12: the base image ships Python 3.13, but open-interpreter's
+    # numpy dependency has no Python 3.13 wheel and the base image has no C
+    # compiler. uv downloads a Python 3.12 standalone (~28 MB) from
+    # releases.astral.sh (already in allowedDomains) automatically.
+    - command: "/home/agent/.local/bin/uv tool install --python 3.12 open-interpreter"
+      user: "1000"
+      description: Install Open Interpreter with Python 3.12
+
+  startup:
+    - command:
+        - "/home/agent/.local/bin/uv"
+        - "tool"
+        - "upgrade"
+        - "open-interpreter"
+        - "--quiet"
+      user: "1000"
+      background: true
+      description: Upgrade Open Interpreter to latest
 
 memory: |
   ## Open Interpreter


### PR DESCRIPTION
## Summary

- Adds an `open-interpreter/` agent kit for [Open Interpreter](https://www.openinterpreter.com/) — a natural language interface that writes and runs code (Python, JS, Shell) to complete tasks
- `auto_run: true` enabled in the default profile — safe here because the sandbox provides OS-level isolation
- Supports both OpenAI (GPT-4o default) and Anthropic (Claude) via proxy-managed credentials; both are declared in `credentials.sources`
- `serviceDomains` is intentionally narrow (only the two LLM API hosts) — a wildcard would TLS-intercept OI's own code execution traffic, breaking downloads and package installs
- Default profile dropped via `files/` at `/home/agent/.config/open-interpreter/profiles/default.yaml`
- Ships `computer.import_computer_api: true` so OI gets its built-in file/browser/OS tool surface

## Network policy rationale

OI executes arbitrary user-directed code. The `allowedDomains` list covers OI's own operational needs (PyPI, npm, apt, GitHub for Open Procedures) without a catch-all wildcard. Tasks that reach unlisted hosts can be unblocked by stacking a domain-specific mixin kit.

## Test plan

- [x] `sbx kit validate ./open-interpreter/` — VALID
- [ ] `cd open-interpreter && go test -v -count=1 -timeout 10m ./...`
- [ ] `sbx run --kit ./open-interpreter/ open-interpreter` with `OPENAI_API_KEY` set — OI REPL launches, `auto_run` active, profile loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)