### PR TITLE
Add opencode-model-runner kit

### DIFF
--- a/opencode-model-runner/README.md
+++ b/opencode-model-runner/README.md
@@ -1,0 +1,71 @@
+# opencode-model-runner
+
+A fork of the built-in `opencode` agent that routes all model API calls to a
+local **[Docker Model Runner](https://docs.docker.com/ai/model-runner/)**
+instance via its OpenAI-compatible endpoint. Useful for offline development,
+cost-free experimentation, or testing custom local models with the OpenCode UI.
+
+> **Prerequisites:** Docker Model Runner must be enabled on the host with TCP
+> access on port 12434, and the model you want to use must be pulled:
+>
+> ```console
+> $ docker desktop enable model-runner --tcp
+> $ docker model pull qwen3
+> ```
+>
+> **Linux hosts:** `host.docker.internal` requires Docker to be started with
+> `--add-host=host.docker.internal:host-gateway`. If Model Runner is
+> unreachable, verify this flag is set or use your host's LAN/bridge IP in
+> place of `host.docker.internal`.
+
+## Usage
+
+```console
+$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=opencode-model-runner" opencode-model-runner ~/my-project
+$ sbx run --kit ./opencode-model-runner/ opencode-model-runner ~/my-project
+```
+
+The agent name passed to `sbx run` (`opencode-model-runner`) matches the
+`name:` field in the kit's `spec.yaml`.
+
+OpenCode opens already pointed at `model-runner/qwen3`. Switch any time with
+`/models`.
+
+## Switch models
+
+Three values in `spec.yaml` reference the model tag (the key under `models`,
+the display `name`, and the top-level default `model`). To use a different
+model, save `spec.yaml` to a local directory, replace the three occurrences
+of `qwen3` with the tag you want, and pass `--kit` at that path:
+
+```console
+$ mkdir opencode-model-runner
+$ curl -o opencode-model-runner/spec.yaml \
+    https://raw.githubusercontent.com/docker/sbx-kits-contrib/main/opencode-model-runner/spec.yaml
+$ # edit opencode-model-runner/spec.yaml
+$ sbx run --kit ./opencode-model-runner opencode-model-runner ~/my-project
+```
+
+The tag must match what `docker model ls` shows. For a larger context window
+than the default, package a variant first:
+
+```console
+$ docker model package --from qwen3 --context-size 64000 qwen3:64k
+```
+
+then point `spec.yaml` at `qwen3:64k`.
+
+## How it works
+
+OpenCode reads its provider configuration from
+`~/.config/opencode/opencode.json`. This kit uses `commands.initFiles` to drop
+that JSON into the sandbox at startup, declaring a single
+`@ai-sdk/openai-compatible` provider whose `baseURL` is
+`http://host.docker.internal:12434/v1` (Model Runner's OpenAI-compatible
+endpoint) and a top-level `model` of `model-runner/qwen3` so OpenCode boots
+directly into the local model.
+
+## Related
+
+- [Docker Model Runner](https://docs.docker.com/ai/model-runner/)
+- [OpenCode with Docker Model Runner for Private AI Coding](https://www.docker.com/blog/opencode-docker-model-runner-private-ai-coding/), the inspiration for this kit

--- a/opencode-model-runner/opencode_model_runner_tck_test.go
+++ b/opencode-model-runner/opencode_model_runner_tck_test.go
@@ -1,0 +1,14 @@
+package opencode_model_runner_test
+
+import (
+	"testing"
+
+	"github.com/docker/sbx-kits-contrib/tck"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpencodeModelRunnerTCK(t *testing.T) {
+	suite, err := tck.NewSuiteFromDir(".")
+	require.NoError(t, err)
+	suite.RunAll(t)
+}

--- a/opencode-model-runner/spec.yaml
+++ b/opencode-model-runner/spec.yaml
@@ -1,0 +1,37 @@
+schemaVersion: "1"
+kind: agent
+name: opencode-model-runner
+displayName: OpenCode (Docker Model Runner)
+description: OpenCode wired to a local Docker Model Runner instance via its OpenAI-compatible API, preconfigured for qwen3.
+
+agent:
+  image: "docker/sandbox-templates:opencode-docker"
+  aiFilename: AGENTS.md
+  persistence: persistent
+  entrypoint:
+    run: [opencode]
+
+commands:
+  initFiles:
+    - path: /home/agent/.config/opencode/opencode.json
+      mode: "0644"
+      description: Configure OpenCode to use the local Docker Model Runner
+      content: |
+        {
+          "$schema": "https://opencode.ai/config.json",
+          "provider": {
+            "model-runner": {
+              "npm": "@ai-sdk/openai-compatible",
+              "name": "Docker Model Runner",
+              "options": {
+                "baseURL": "http://host.docker.internal:12434/v1"
+              },
+              "models": {
+                "qwen3": {
+                  "name": "Qwen3 (Model Runner)"
+                }
+              }
+            }
+          },
+          "model": "model-runner/qwen3"
+        }


### PR DESCRIPTION
## Summary

Adds `opencode-model-runner`, a fork of the built-in `opencode` agent that points OpenCode at a local Docker Model Runner instance via its OpenAI-compatible endpoint. At sandbox startup it drops `~/.config/opencode/opencode.json` declaring a single `@ai-sdk/openai-compatible` provider with `baseURL=http://host.docker.internal:12434/v1` and a default `model` of `model-runner/qwen3`, so OpenCode boots directly into the local model.

## Spec choices worth flagging for review

- **Static JSON via `commands.initFiles`**: OpenCode reads provider config from `~/.config/opencode/opencode.json`, so a literal JSON file is the simplest way to wire the provider without a wrapper script. To switch models, save `spec.yaml` to a local directory, edit the three `qwen3` references, and pass `--kit ./local-path`.

## Origin

Started as a public gist (https://gist.github.com/doringeman/7d52d319914e86e797ce6bd5f14af04b) and brought into the contrib repo for upstream. Inspired by the [OpenCode with Docker Model Runner for Private AI Coding](https://www.docker.com/blog/opencode-docker-model-runner-private-ai-coding/) post.

```
sbx run --kit ./opencode-model-runner opencode-model-runner
```