### PR TITLE
docs: explain GPG/SSH commit signing in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,19 +39,81 @@ $ sbx run --kit ./my-kit/ <agent>
 
 The first two are what CI runs. The third catches things the TCK doesn't — install scripts hitting unexpected hosts, startup wrappers crashing silently, agents not authenticating.
 
-## Developer Certificate of Origin (DCO)
+## Sign-off and signing
 
-By contributing to this repository, you certify that you have the right to submit the work under the repository license.
+Every commit needs **two** things, which are unrelated:
 
-Please sign off every commit:
+1. A **DCO sign-off** — a `Signed-off-by:` trailer in the commit message, certifying you have the right to submit the work under the repo license. Added with `git commit -s`.
+2. A **cryptographic signature** — a GPG or SSH signature on the commit itself, which is what produces the green **Verified** badge on GitHub. Added with `git commit -S` (or by configuring git to sign by default).
+
+Both are required. A signed commit without `-s` will fail DCO check; a signed-off commit without a signature won't show as Verified.
+
+The fastest path is to configure git once so every `git commit` does both automatically:
 
 ```bash
-git commit -s -m "Your commit message"
+git config --global commit.gpgsign true
 ```
 
-## Signing Commits
+Then commits only need `-s`:
 
-Please ensure that your commits are signed. You can learn more about signing commits [here](https://docs.github.com/en/free-pro-team@latest/authentication/managing-commit-signature-verification).
+```bash
+git commit -s -m "fix(amp): bump install timeout"
+```
+
+### Option A — GPG signing
+
+1. Generate a key (skip if you already have one — list with `gpg --list-secret-keys --keyid-format=long`):
+
+   ```bash
+   gpg --full-generate-key
+   # Choose: ECC (sign and encrypt) or RSA 4096, 0 = does not expire (or pick an expiry),
+   # use the same email as your GitHub account.
+   ```
+
+2. Tell git which key to use:
+
+   ```bash
+   KEY_ID=$(gpg --list-secret-keys --keyid-format=long | awk '/^sec/ {split($2,a,"/"); print a[2]; exit}')
+   git config --global user.signingkey "$KEY_ID"
+   git config --global commit.gpgsign true
+   ```
+
+3. Export the public key and add it to GitHub under **Settings → SSH and GPG keys → New GPG key**:
+
+   ```bash
+   gpg --armor --export "$KEY_ID"
+   ```
+
+4. On macOS, install `pinentry-mac` so the passphrase prompt works in non-interactive shells:
+
+   ```bash
+   brew install gnupg pinentry-mac
+   echo "pinentry-program $(brew --prefix)/bin/pinentry-mac" >> ~/.gnupg/gpg-agent.conf
+   gpgconf --kill gpg-agent
+   ```
+
+### Option B — SSH signing
+
+If you already use SSH for git, you can sign with the same key and skip GPG entirely. Requires git ≥ 2.34.
+
+```bash
+git config --global gpg.format ssh
+git config --global user.signingkey ~/.ssh/id_ed25519.pub
+git config --global commit.gpgsign true
+```
+
+Then add the **same** public key to GitHub a second time under **Settings → SSH and GPG keys → New SSH key**, with key type **Signing Key** (an Authentication key alone won't verify commits).
+
+### Verifying it works
+
+```bash
+git commit -s --allow-empty -m "test: verify signing"
+git log -1 --show-signature
+```
+
+You should see `Good signature` (GPG) or `Good "git" signature` (SSH), and a `Signed-off-by:` trailer at the bottom of the message. After pushing, GitHub will show the commit as **Verified**.
+
+For deeper background, see GitHub's docs on [managing commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification).
 
 ## Pull requests
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Community-contributed kits for [Docker Sandboxes](https://docs.docker.com/ai/san
 
 Each top-level directory is a **kit** — a declarative artifact containing a `spec.yaml` and optional `files/` directory that extends sandbox agents with additional capabilities.
 
+Contributing a kit or a fix? Read [`CONTRIBUTING.md`](./CONTRIBUTING.md) first — this repo enforces verified commit signatures, so you'll need GPG or SSH signing set up before your PR can be merged.
+
 > [!NOTE]
 > Kits are experimental. The kit file format, CLI commands, and experience
 > for creating, loading, and managing kits are subject to change as the

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sbx-kits-contrib
 
-Community-contributed kits for [Docker Sandboxes](https://github.com/docker/sandboxes).
+Community-contributed kits for [Docker Sandboxes](https://docs.docker.com/ai/sandboxes/).
 
 Each top-level directory is a **kit** — a declarative artifact containing a `spec.yaml` and optional `files/` directory that extends sandbox agents with additional capabilities.
 


### PR DESCRIPTION
## What's changed

Rewrites the signing guidance in `CONTRIBUTING.md` so contributors actually know how to produce verified commits, and makes the contributing guide discoverable from the repo's front door. Also fixes a broken link in the README.

## Why is this important?

`sbx-kits-contrib` enforces GitHub's "Commits must have verified signatures" branch protection rule, but the previous docs only said "please sign your commits" with a single external link, conflating DCO sign-off with cryptographic signing. Community contributors discovered the requirement at PR-merge time instead of during setup. The README also pointed the Docker Sandboxes link at a private repo, which 404'd for outside visitors.

## Changes

- **`CONTRIBUTING.md`** — replaces the separate "DCO" and "Signing Commits" sections with one "Sign-off and signing" section that:
  - Distinguishes DCO sign-off (`-s`, plain trailer) from cryptographic signing (`-S`, what produces the **Verified** badge).
  - Provides copy-pasteable GPG setup (key generation, `user.signingkey`, GitHub upload, macOS `pinentry-mac` workaround).
  - Documents SSH signing as a lighter alternative for contributors already using SSH for git, with the gotcha that the key must be uploaded to GitHub a second time as a **Signing Key**.
  - Recommends `commit.gpgsign true` globally so `git commit -s` covers both DCO and signing.
  - Ends with a `--allow-empty` verification step so contributors can confirm setup before opening a PR.
- **`README.md`** — fixes the Docker Sandboxes link (was pointing at the private `docker/sandboxes` repo, now points at `https://docs.docker.com/ai/sandboxes/`) and adds a one-line callout near the top that points contributors at `CONTRIBUTING.md` before they start writing commits.

## Test plan

- Visually inspect rendered Markdown on the PR's **Files changed** tab.
- On a fresh machine, follow the verification step from the new section (`git commit -s --allow-empty -m "test: verify signing"` then `git log -1 --show-signature`) and confirm it produces a `Good signature` and a `Signed-off-by:` trailer.
- Confirm the new README link to `CONTRIBUTING.md` resolves and the Docker Sandboxes link no longer 404s for non-Docker-org visitors.
