### PR TITLE
Add task kit

### DIFF
--- a/task/README.md
+++ b/task/README.md
@@ -1,0 +1,34 @@
+# Task
+
+A mixin that installs the [Task](https://taskfile.dev/) CLI in a sandbox so
+agents can run `Taskfile.yml` tasks from the workspace.
+
+## Usage
+
+Run it with any agent kit or built-in agent:
+
+```console
+$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=task" claude
+```
+
+For local development, point `--kit` at this directory:
+
+```console
+$ sbx run --kit ./task/ claude
+```
+
+After the sandbox starts, `task` is available on `PATH`:
+
+```console
+$ task --version
+$ task --list
+```
+
+## Versioning
+
+This kit installs Task v3.50.0 from the upstream GitHub release and verifies
+the release tarball checksum before installing. To update Task, change
+`TASK_VERSION` and the per-architecture SHA256 values in `spec.yaml`.
+
+The initial install supports Linux `amd64` and `arm64`, which cover the normal
+Docker Desktop sandbox architectures.

--- a/task/spec.yaml
+++ b/task/spec.yaml
@@ -1,0 +1,39 @@
+schemaVersion: "1"
+kind: mixin
+name: task
+displayName: Task
+description: Installs the Task CLI so sandbox agents can run Taskfiles.
+
+network:
+  allowedDomains:
+    - github.com
+    - release-assets.githubusercontent.com
+
+commands:
+  install:
+    - command: |
+        set -euo pipefail
+        TASK_VERSION=3.50.0
+        ARCH=$(dpkg --print-architecture)
+        case "$ARCH" in
+          amd64)
+            TARBALL="task_linux_amd64.tar.gz"
+            SHA256="d449ba85ab85a0769989d78f8b9872938e4ba9347f7f4f925f73d98272a0a655"
+            ;;
+          arm64)
+            TARBALL="task_linux_arm64.tar.gz"
+            SHA256="ee67e7d999a4a70711bff1946c70bf76628012c91d9be55626ee90ba976897da"
+            ;;
+          *)
+            echo "unsupported sandbox arch: $ARCH (expected amd64 or arm64)" >&2
+            exit 1
+            ;;
+        esac
+        URL="https://github.com/go-task/task/releases/download/v${TASK_VERSION}/${TARBALL}"
+        curl --proto '=https' --tlsv1.2 -fsSL -o /tmp/task.tgz "$URL"
+        echo "${SHA256}  /tmp/task.tgz" | sha256sum -c -
+        tar -C /usr/local/bin -xzf /tmp/task.tgz task
+        rm /tmp/task.tgz
+        task --version
+      user: "0"
+      description: "Install Task CLI v3.50.0, version+digest pinned"

--- a/task/task_tck_test.go
+++ b/task/task_tck_test.go
@@ -1,0 +1,14 @@
+package task_test
+
+import (
+	"testing"
+
+	"github.com/docker/sbx-kits-contrib/tck"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTaskTCK(t *testing.T) {
+	suite, err := tck.NewSuiteFromDir(".")
+	require.NoError(t, err)
+	suite.RunAll(t)
+}


### PR DESCRIPTION
## Summary
- add a reusable `task` mixin kit
- install Task v3.50.0 from pinned release tarballs
- verify SHA-256 for Linux amd64 and arm64 before installing

## Tests
- `go test -v -count=1 -timeout 10m ./task`
- `go test -v -count=1 ./spec ./tck`

## Notes
- `sbx kit validate ./task/` was not run because `sbx` is not installed in this environment.
- The commit is signed off, but not GPG-signed because no private signing key is available in this environment.