### PR TITLE
feat(mise): add kit to install dev-tools in a consistent manner

### DIFF
--- a/mise/README.md
+++ b/mise/README.md
@@ -1,0 +1,122 @@
+# mise
+
+A mixin that installs [mise](https://mise.jdx.dev) (mise-en-place), the
+polyglot dev-tool version manager, and wires up shell activation so the
+agent can resolve and install per-project tool versions from
+`.mise.toml` / `.tool-versions` files inside the sandbox.
+
+## Usage
+
+`mise` is agent-agnostic — pair it with whichever agent you're using:
+
+```console
+$ sbx run shell --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=mise" ~/my-project
+$ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=mise" ~/my-project
+```
+
+Once attached, any interactive shell has `mise` on PATH and shell hooks
+active:
+
+```console
+agent@sandbox:~$ mise --version
+2026.5.2 ...
+agent@sandbox:~$ cd ~/my-project   # auto-resolves .mise.toml
+agent@sandbox:~$ mise install      # installs the project's pinned versions
+```
+
+## How the install works
+
+The kit downloads a pinned mise release tarball from GitHub, verifies
+its SHA256 against a digest captured in `spec.yaml`, and extracts only
+the `mise` binary into `/usr/local/bin/`. The version and per-arch
+digest are sourced from the release's `SHASUMS256.txt` and live in git
+— bumping mise is a one-line edit + a digest update.
+
+We avoid the upstream `curl https://mise.run | sh` flow on purpose:
+that pattern is fine on a developer workstation but it gives a sandbox
+no visibility into what binary actually got placed on PATH. Pinning
+lets reviewers see what changed when you bump the kit.
+
+## Shell activation
+
+The install step appends a single line to the agent user's `~/.bashrc`:
+
+```bash
+eval "$(mise activate bash)"
+```
+
+`mise activate` is the canonical hook that puts mise's shims on PATH,
+auto-installs missing versions when you `cd` into a project, and
+re-resolves whenever the active `.mise.toml` changes. The append is
+guarded with `grep -qF` so re-running the install (e.g., during local
+TCK iteration) doesn't duplicate the line.
+
+If you bring your own shell (zsh, fish), wire activation yourself in
+`~/.zshrc` / `~/.config/fish/config.fish` — see the
+[mise getting-started](https://mise.jdx.dev/getting-started.html) page
+for the exact snippets.
+
+## About `MISE_TRUSTED_CONFIG_PATHS=/`
+
+mise normally prompts before sourcing a `.mise.toml` it hasn't seen
+before, since these files can run arbitrary shell. Inside a sandbox
+you've already accepted that boundary by attaching the workspace, so
+the kit pre-trusts the whole filesystem to keep the agent
+non-interactive. If that's too coarse for your threat model, fork the
+kit and narrow `MISE_TRUSTED_CONFIG_PATHS` to the workspace mount
+point (typically the value of `${WORKDIR}`).
+
+## Network policy and runtime tool installs
+
+The kit ships with a baseline that covers the install step **and** the
+GitHub-hosted runtime path that mise's `ubi` backend uses for most
+tools:
+
+- `github.com` — release tag URL for both the kit's pinned mise
+  install and `mise install <github-hosted-tool>` at runtime
+- `api.github.com` — version resolution. mise hits this for any
+  `<tool>@latest`, `<tool>@<major>`, etc., and even validates exact
+  tags through it. Without this, github-hosted tool installs fail at
+  the resolve step with a 403 from the sandbox proxy
+- `release-assets.githubusercontent.com` — 302 target for binary
+  downloads from those release URLs
+
+Note that wildcard subdomains (`*.github.com`) match subdomains only,
+not the apex — so listing the apex and the subdomains explicitly is
+required, not redundant.
+
+`mise install <tool>` at runtime also hits per-language CDNs beyond
+GitHub for non-github-hosted tools, and these vary by what you ask
+for. The kit deliberately doesn't pre-allow all of them — each widens
+the trust footprint. Add what you need in a fork. A starter set
+covering the most common backends:
+
+```yaml
+network:
+  allowedDomains:
+    - github.com
+    - api.github.com
+    - release-assets.githubusercontent.com
+    - objects.githubusercontent.com   # older release asset host
+    - codeload.github.com             # source tarballs (some asdf plugins)
+    - nodejs.org                      # node
+    - registry.npmjs.org              # npm-backed plugins
+    - dl.google.com                   # go (golang.org redirects here)
+    - go.dev
+    - www.python.org                  # python
+    - files.pythonhosted.org          # pip
+    - pypi.org
+    - static.crates.io                # rust
+    - crates.io
+```
+
+If `mise install` fails with a DNS / connection refused error, the
+denied host is almost always in the error message — add it and retry.
+
+## Scope of this kit
+
+This is a thin install-and-activate layer. It does **not** ship a
+default `.mise.toml`, opinionated tool selection, or pre-installed
+language runtimes — those decisions belong in your project repo, not
+in a generic kit. If you want a heavier "batteries-included Python +
+Node" environment, layer this kit underneath your own.

--- a/mise/mise_tck_test.go
+++ b/mise/mise_tck_test.go
@@ -1,0 +1,14 @@
+package mise_test
+
+import (
+	"testing"
+
+	"github.com/docker/sbx-kits-contrib/tck"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMiseTCK(t *testing.T) {
+	suite, err := tck.NewSuiteFromDir(".")
+	require.NoError(t, err)
+	suite.RunAll(t)
+}

--- a/mise/spec.yaml
+++ b/mise/spec.yaml
@@ -1,0 +1,72 @@
+schemaVersion: "1"
+kind: mixin
+name: mise
+displayName: mise (mise-en-place)
+description: "The polyglot dev-tool version manager (https://mise.jdx.dev) — installs the mise CLI and wires up shell activation so the agent can run `mise install`, `mise use`, and per-project `.mise.toml` resolutions in the sandbox."
+
+network:
+  allowedDomains:
+    # github.com — release tag URLs for the install-time tarball AND for mise's `ubi`
+    # backend at runtime (https://github.com/<owner>/<repo>/releases/download/...).
+    # The download then 302-redirects to release-assets.githubusercontent.com.
+    - github.com
+    # api.github.com — mise queries the GitHub releases API to resolve `<tool>@latest`
+    # and similar version selectors for any github-hosted tool. Without this, even
+    # `mise install <github-tool>@<exact-version>` fails because the resolver still
+    # touches the API to validate the tag.
+    - api.github.com
+    - release-assets.githubusercontent.com
+    # Runtime tool installs (`mise install <tool>`) hit per-language hosts beyond GitHub
+    # (nodejs.org, pypi.org, go.dev, crates.io, etc.) that vary by what the user asks
+    # mise to install. Fork and extend `allowedDomains` with the hosts you actually
+    # need — see the README for a starter list.
+
+environment:
+  variables:
+    # Treat the whole sandbox filesystem as trusted so `.mise.toml` files don't trigger an
+    # interactive trust prompt. This is appropriate inside a sandbox: the user has already
+    # opted into running this code by attaching the workspace.
+    MISE_TRUSTED_CONFIG_PATHS: "/"
+
+commands:
+  install:
+    # Install mise from a pinned, digest-verified GitHub release tarball. The official
+    # `curl https://mise.run | sh` flow is fine for a workstation, but inside a sandbox
+    # we want the version and binary digest captured in git. To bump: change MISE_VERSION
+    # and the per-arch SHA256 below (sourced from the release's SHASUMS256.txt).
+    - command: |
+        set -euo pipefail
+        MISE_VERSION=2026.5.2
+        ARCH=$(dpkg --print-architecture)
+        case "$ARCH" in
+          amd64)
+            TARBALL="mise-v${MISE_VERSION}-linux-x64.tar.gz"
+            SHA256="cdf616b3d8554bece574cb1a5c0f19cc0f551dffbecf66037df1cc06569a42ef"
+            ;;
+          arm64)
+            TARBALL="mise-v${MISE_VERSION}-linux-arm64.tar.gz"
+            SHA256="a746ad85fe8a7b62a6c72939da5fb4231074fd16c482f6334a598bd92926f41e"
+            ;;
+          *)
+            echo "unsupported sandbox arch: $ARCH (expected amd64 or arm64)" >&2
+            exit 1
+            ;;
+        esac
+        URL="https://github.com/jdx/mise/releases/download/v${MISE_VERSION}/${TARBALL}"
+        curl --proto '=https' --tlsv1.2 -fsSL -o /tmp/mise.tgz "$URL"
+        echo "${SHA256}  /tmp/mise.tgz" | sha256sum -c -
+        tar -C /tmp -xzf /tmp/mise.tgz mise/bin/mise
+        install -m 0755 /tmp/mise/bin/mise /usr/local/bin/mise
+        rm -rf /tmp/mise /tmp/mise.tgz
+        mise --version
+      user: "0"
+      description: "Install mise CLI v2026.5.2, version+digest pinned"
+    # Wire shell activation into the agent user's bashrc so interactive shells get
+    # `mise activate` (PATH shimming + auto-`mise install` on cd). Append rather than
+    # overwrite so we don't clobber whatever the template image already ships.
+    - command: |
+        set -euo pipefail
+        grep -qF 'mise activate bash' ~/.bashrc 2>/dev/null || \
+          printf '\n# mise (added by sbx-kits-contrib/mise)\neval "$(mise activate bash)"\n' >> ~/.bashrc
+      user: "1000"
+      description: "Hook `mise activate bash` into ~/.bashrc for interactive shells"


### PR DESCRIPTION
## What's changed

Adds a new mixin kit for [mise](https://mise.jdx.dev), the polyglot dev-tool version manager. The kit installs mise v2026.5.2 from a pinned, digest-verified GitHub release, then wires up shell activation so agents can resolve and install per-project tool versions from `.mise.toml` / `.tool-versions` files in the sandbox.

The install uses per-architecture SHA256 verification — version and digest are captured in git, so reviewers can see what changed on every bump.

## Why is this important?

Mise complements language-specific version managers (nvm, pyenv, rbenv): instead of picking one language, it manages *any* tool in a single `.mise.toml` / `.tool-versions` file. This kit makes it easy for sandbox agents to work in polyglot projects without pre-installing every language runtime.

## Changes

- **`mise/spec.yaml`** — mixin manifest with pinned v2026.5.2 install (digest-verified per-arch), shell activation hook, and network policy allowing GitHub release/API hosts. Comments document why each host is needed.
- **`mise/mise_tck_test.go`** — Technology Compatibility Kit boilerplate for validating the kit against a real container.
- **`mise/README.md`** — usage guide, explanation of the install pinning strategy, shell activation behavior, and a curated starter set of per-language `allowedDomains` for fork-time installs.
- **`mise/BUMPING.md`** — plan for a future helper script to automate version bumps (not yet implemented; pick up in a follow-up).

## Test plan

- `sbx kit validate ./mise/` — spec parses correctly ✓
- `go test -v -count=1 -timeout 10m ./mise/...` — TCK passes on Linux (requires Docker)
- Manual E2E: `sbx run claude --kit ./mise/ ~/my-project`, then inside the sandbox:
  - `mise --version` — confirms install worked
  - `mise install task@latest` — demonstrates that `github.com` + `api.github.com` are sufficient for github-hosted tools; other language backends require fork-time allowlist extension (documented in README)

## Spec choices worth flagging for review

**Network policy baseline**: the kit allows `github.com`, `api.github.com`, and `release-assets.githubusercontent.com` — enough for the install and for `mise install <github-tool>` at runtime. Per-language CDNs (nodejs.org, pypi.org, etc.) are deliberately omitted; users fork and extend as needed. This keeps the trust footprint narrow.

**Pinned vs latest**: the install uses a pinned, digest-verified binary rather than `curl https://mise.run | sh`. This gives reviewers visibility into what lands on PATH and lets us treat version bumps as explicit one-line PRs. A future helper script will make bumping cheap.

**Shell activation**: the install appends `eval "$(mise activate bash)"` to `~/.bashrc` (guarded with `grep -qF` to remain idempotent). This is the upstream recommendation for interactive shells.