### PR TITLE
Make git-ssh-sign hookless

### DIFF
--- a/git-ssh-sign/README.md
+++ b/git-ssh-sign/README.md
@@ -31,8 +31,8 @@ ssh-ed25519 AAAA... you@example.com
 ```
 
 If it returns nothing, the key isn't loaded on the host yet — re-run
-`ssh-add` there and try again. The pre-commit hook will block commits
-with a clear error if no key is available.
+`ssh-add` there and try again. Git signing will fail with a clear error
+if no key is available.
 
 ## Verifying
 
@@ -47,36 +47,34 @@ If signing fails, see Docker's
 
 ## How it works
 
-Git signing requires two things to be in place before `git commit` runs:
-the signing *config* (which key to use, what format) and the actual
-*key material* (the public key file). These have different timing
-constraints, so the kit handles them separately.
+Git signing requires two things to be available when Git signs the
+commit: signing *config* (what format to use and how to resolve a key)
+and the actual *key material* from the forwarded SSH agent.
 
 **Signing config — written at install time to `/etc/gitconfig`**
 
 The install command writes `gpg.format`, `commit.gpgSign`,
-`tag.gpgSign`, `user.signingKey`, and `gpg.ssh.allowedSignersFile` to
-the system-level git config. This file is read by git at process
-startup and is never overwritten by the sandbox infrastructure, so the
-config is always present when `git commit` begins.
+`tag.gpgSign`, `gpg.ssh.defaultKeyCommand`, and
+`gpg.ssh.allowedSignersFile` to the system-level git config. This file
+is read by git at process startup and is never overwritten by the
+sandbox infrastructure, so the config is always present when
+`git commit` begins.
 
-**Key material — written by a pre-commit hook**
+**Key material — resolved at signing time**
 
-`user.signingKey` points to `/home/agent/.config/git/signing_key.pub`.
-A global pre-commit hook (registered via `core.hooksPath` in
-`/etc/gitconfig`) writes the SSH public key from the agent to that file
-before each commit. Git reads the key file at signing time, which
-happens after the pre-commit hook completes, so the file is always
-ready when git needs it.
+`gpg.ssh.defaultKeyCommand` points to
+`/home/agent/.config/git/ssh-signing-key-command`. When Git needs a
+signing key, it runs that command. The command reads the first public key
+from `ssh-add -L`, writes `/home/agent/.config/git/allowed_signers` for
+signature verification, and prints the key in Git's inline `key::...`
+format.
 
-This split is necessary because the public key isn't known until
-runtime (it comes from `ssh-add -L`), and writing it at install or
-startup time risks the SSH agent not yet being connected.
+This avoids writing key material at install or startup time, when the
+forwarded SSH agent may not be connected yet. It also avoids relying on
+Git hooks for signing.
 
-**Chaining repo-local hooks**
+**Composing with repo-local hooks**
 
-The global pre-commit hook checks for a `.git/hooks/pre-commit` in the
-current repo and chains to it if present, so project-level hooks
-(husky, lint-staged, etc.) continue to work. Projects that manage
-hooks with their own `core.hooksPath` in the local git config are
-unaffected — the local setting takes precedence over the system one.
+This kit does not set `core.hooksPath` and does not install a
+pre-commit hook. Project-level hooks, hook managers, and repo-local
+`core.hooksPath` settings can run independently of commit signing.

--- a/git-ssh-sign/git_ssh_sign_tck_test.go
+++ b/git-ssh-sign/git_ssh_sign_tck_test.go
@@ -1,8 +1,13 @@
 package git_ssh_sign_test
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/docker/sbx-kits-contrib/spec"
 	"github.com/docker/sbx-kits-contrib/tck"
 	"github.com/stretchr/testify/require"
 )
@@ -11,4 +16,120 @@ func TestGitSSHSignTCK(t *testing.T) {
 	suite, err := tck.NewSuiteFromDir(".")
 	require.NoError(t, err)
 	suite.RunAll(t)
+}
+
+func TestInstallUsesDynamicKeyCommandWithoutHooksPath(t *testing.T) {
+	artifact, err := spec.LoadFromDirectory(".")
+	require.NoError(t, err)
+	require.Len(t, artifact.Commands.Install, 1)
+
+	systemConfig := filepath.Join(t.TempDir(), "gitconfig")
+	gitConfigFile(t, systemConfig, "user.signingKey", "/home/agent/.config/git/signing_key.pub")
+	gitConfigFile(t, systemConfig, "core.hooksPath", "/home/agent/.config/git/hooks")
+
+	cmd := exec.Command("sh", "-c", artifact.Commands.Install[0].Command)
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_SYSTEM="+systemConfig)
+	output, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "install command failed:\n%s", output)
+
+	require.Equal(t, "ssh", gitConfigFile(t, systemConfig, "gpg.format"))
+	require.Equal(t, "true", gitConfigFile(t, systemConfig, "commit.gpgSign"))
+	require.Equal(t, "true", gitConfigFile(t, systemConfig, "tag.gpgSign"))
+	require.Equal(t, "/home/agent/.config/git/ssh-signing-key-command", gitConfigFile(t, systemConfig, "gpg.ssh.defaultKeyCommand"))
+	require.Equal(t, "/home/agent/.config/git/allowed_signers", gitConfigFile(t, systemConfig, "gpg.ssh.allowedSignersFile"))
+	require.Empty(t, gitConfigFile(t, systemConfig, "user.signingKey"))
+	require.Empty(t, gitConfigFile(t, systemConfig, "core.hooksPath"))
+}
+
+func TestSigningKeyCommandPrintsInlineKeyAndAllowedSigners(t *testing.T) {
+	script := writeSigningKeyCommand(t)
+	key := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestKey user@example.com"
+	fakeBin := writeFakeSSHAdd(t, key)
+	configDir := t.TempDir()
+	repoDir := t.TempDir()
+
+	runGit(t, repoDir, "init", "-q")
+	runGit(t, repoDir, "config", "user.email", "dev@example.com")
+
+	cmd := exec.Command(script)
+	cmd.Dir = repoDir
+	cmd.Env = append(os.Environ(),
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"SSH_AUTH_SOCK=/tmp/fake-agent.sock",
+		"GIT_SSH_SIGN_CONFIG_DIR="+configDir,
+	)
+	output, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "signing key command failed:\n%s", output)
+
+	require.Equal(t, "key::"+key+"\n", string(output))
+	allowedSigners, err := os.ReadFile(filepath.Join(configDir, "allowed_signers"))
+	require.NoError(t, err)
+	require.Equal(t, "dev@example.com "+key+"\n", string(allowedSigners))
+}
+
+func TestSigningKeyCommandFailsWithoutAgent(t *testing.T) {
+	script := writeSigningKeyCommand(t)
+
+	cmd := exec.Command(script)
+	cmd.Env = append(os.Environ(), "SSH_AUTH_SOCK=")
+	output, err := cmd.CombinedOutput()
+	require.Error(t, err)
+	require.Contains(t, string(output), "[git-ssh-sign] no SSH agent - cannot sign commits")
+}
+
+func gitConfigFile(t *testing.T, config string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.Command("git", append([]string{"config", "--file", config}, args...)...)
+	output, err := cmd.CombinedOutput()
+	if len(args) >= 2 {
+		require.NoErrorf(t, err, "git config --file failed:\n%s", output)
+		return strings.TrimSpace(string(output))
+	}
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(output))
+}
+
+func writeSigningKeyCommand(t *testing.T) string {
+	t.Helper()
+
+	artifact, err := spec.LoadFromDirectory(".")
+	require.NoError(t, err)
+	require.NotNil(t, artifact.Commands)
+
+	for _, file := range artifact.Commands.InitFiles {
+		if file.Path == "/home/agent/.config/git/ssh-signing-key-command" {
+			path := filepath.Join(t.TempDir(), "ssh-signing-key-command")
+			require.NoError(t, os.WriteFile(path, []byte(file.Content), 0o755))
+			return path
+		}
+	}
+
+	t.Fatal("ssh-signing-key-command initFile not found")
+	return ""
+}
+
+func writeFakeSSHAdd(t *testing.T, key string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ssh-add")
+	content := "#!/bin/sh\nif [ \"$1\" = \"-L\" ]; then\n  printf '%s\\n' " + shellQuote(key) + "\n  exit 0\nfi\nexit 1\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o755))
+	return dir
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "git %s failed:\n%s", strings.Join(args, " "), output)
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
 }

--- a/git-ssh-sign/spec.yaml
+++ b/git-ssh-sign/spec.yaml
@@ -5,16 +5,48 @@ displayName: Git SSH Commit Signing
 description: Configures git to sign commits using the SSH key forwarded from the host's SSH agent.
 
 commands:
+  initFiles:
+    - path: /home/agent/.config/git/ssh-signing-key-command
+      mode: "0755"
+      description: Resolve the forwarded SSH agent key for Git SSH signing
+      content: |
+        #!/bin/sh
+        set -e
+
+        if [ -z "$SSH_AUTH_SOCK" ]; then
+            echo "[git-ssh-sign] no SSH agent - cannot sign commits" >&2
+            exit 1
+        fi
+
+        key=$(ssh-add -L 2>/dev/null | head -n 1)
+        if [ -z "$key" ]; then
+            echo "[git-ssh-sign] no keys in SSH agent - cannot sign commits" >&2
+            exit 1
+        fi
+
+        config_dir="$GIT_SSH_SIGN_CONFIG_DIR"
+        if [ -z "$config_dir" ]; then
+            config_dir="/home/agent/.config/git"
+        fi
+        mkdir -p "$config_dir"
+
+        email=$(git config user.email 2>/dev/null || printf '%s' "agent@sandbox.local")
+        printf '%s %s\n' "$email" "$key" > "$config_dir/allowed_signers"
+        printf 'key::%s\n' "$key"
+
   install:
     - command: |
         git config --system gpg.format ssh
-        git config --system user.signingKey /home/agent/.config/git/signing_key.pub
+        git config --system --unset-all user.signingKey || true
         git config --system commit.gpgSign true
         git config --system tag.gpgSign true
+        git config --system gpg.ssh.defaultKeyCommand /home/agent/.config/git/ssh-signing-key-command
         git config --system gpg.ssh.allowedSignersFile /home/agent/.config/git/allowed_signers
-        git config --system core.hooksPath /home/agent/.config/git/hooks
+        if [ "$(git config --system --get core.hooksPath || true)" = "/home/agent/.config/git/hooks" ]; then
+            git config --system --unset-all core.hooksPath
+        fi
       user: "0"
-      description: Configure SSH commit signing and global hooks directory
+      description: Configure SSH commit signing with a dynamic key command
 
 memory: |
   ## Git commit signing


### PR DESCRIPTION
## Summary
- replace the git-ssh-sign pre-commit hook dependency with gpg.ssh.defaultKeyCommand
- stop configuring core.hooksPath and clean up the old kit-owned hook path on upgrade
- document the hookless signing flow and add focused tests for install config and key resolution

## Testing
- go test ./git-ssh-sign -count=1
- git diff --check
- manual temp-repo smoke test: signed commit and tag verified with repo-local core.hooksPath=.githooks