### PR TITLE
docs: add Documentation section with links to docs.docker.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ Community-contributed kits for [Docker Sandboxes](https://docs.docker.com/ai/san
 
 Each top-level directory is a **kit** — a declarative artifact containing a `spec.yaml` and optional `files/` directory that extends sandbox agents with additional capabilities.
 
+## Documentation
+
+- [Kits overview](https://docs.docker.com/ai/sandboxes/customize/kits/) — what kits are and how to use them
+- [Kit examples](https://docs.docker.com/ai/sandboxes/customize/kit-examples/) — reference examples for common kit patterns
+- [Build your own agent kit](https://docs.docker.com/ai/sandboxes/customize/build-an-agent/) — step-by-step tutorial using the `amp` kit in this repo
+
 Contributing a kit or a fix? Read [`CONTRIBUTING.md`](./CONTRIBUTING.md) first — this repo enforces verified commit signatures, so you'll need GPG or SSH signing set up before your PR can be merged.
 
 > [!NOTE]


### PR DESCRIPTION
## Summary

- Adds a **Documentation** section near the top of the README with direct links to the three key docs.docker.com pages: kits overview, kit examples, and the build-an-agent tutorial.

## Test plan

- [ ] Verify links resolve correctly in the rendered README

🤖 Generated with [Claude Code](https://claude.com/claude-code)