### PR TITLE
Add vale mixin kit

### DIFF
--- a/vale/README.md
+++ b/vale/README.md
@@ -1,0 +1,23 @@
+# vale
+
+A mixin kit (`kind: mixin`) that installs the latest [Vale](https://vale.sh/) prose linter from GitHub releases.
+
+## Usage
+
+```console
+$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=vale" claude
+agent@...$ vale --version
+```
+
+Or with a local clone:
+
+```console
+$ sbx run --kit ./vale/ claude
+```
+
+Vale is on `PATH` after install. To lint a directory:
+
+```console
+agent@...$ vale sync        # download styles referenced by .vale.ini
+agent@...$ vale ./docs/
+```

--- a/vale/spec.yaml
+++ b/vale/spec.yaml
@@ -1,0 +1,42 @@
+schemaVersion: "1"
+kind: mixin
+name: vale
+displayName: Vale
+description: Installs the latest Vale prose linter from GitHub releases.
+
+network:
+  allowedDomains:
+    - api.github.com
+    - github.com
+    - release-assets.githubusercontent.com
+
+commands:
+  install:
+    - command: |
+        set -euo pipefail
+        VALE_VERSION=$(curl -fsSL https://api.github.com/repos/vale-cli/vale/releases/latest \
+          | grep -o '"tag_name": *"[^"]*"' | grep -o '[0-9][^"]*')
+        ARCH=$(dpkg --print-architecture)
+        case "$ARCH" in
+          amd64) TARBALL="vale_${VALE_VERSION}_Linux_64-bit.tar.gz" ;;
+          arm64) TARBALL="vale_${VALE_VERSION}_Linux_arm64.tar.gz" ;;
+          *)
+            echo "unsupported arch: $ARCH" >&2
+            exit 1
+            ;;
+        esac
+        curl --proto '=https' --tlsv1.2 -fsSL \
+          -o /tmp/vale.tgz \
+          "https://github.com/vale-cli/vale/releases/download/v${VALE_VERSION}/${TARBALL}"
+        tar -C /usr/local/bin -xzf /tmp/vale.tgz vale
+        rm /tmp/vale.tgz
+        vale --version
+      user: "0"
+      description: "Install latest Vale CLI"
+
+memory: |
+  ## Vale prose linter
+
+  The `vale` CLI is installed and available on `PATH`. Use it to lint
+  prose in Markdown, AsciiDoc, reStructuredText, and other text formats.
+  Run `vale --version` to confirm, and `vale <file>` to lint a file.

--- a/vale/vale_tck_test.go
+++ b/vale/vale_tck_test.go
@@ -1,0 +1,14 @@
+package vale_test
+
+import (
+	"testing"
+
+	"github.com/docker/sbx-kits-contrib/tck"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValeTCK(t *testing.T) {
+	suite, err := tck.NewSuiteFromDir(".")
+	require.NoError(t, err)
+	suite.RunAll(t)
+}


### PR DESCRIPTION
## Summary

- Adds a `vale/` mixin kit that installs the [Vale](https://vale.sh/) prose linter from the latest GitHub release
- Detects CPU architecture (`amd64` / `arm64`) and downloads the matching tarball
- Allows egress to `api.github.com`, `github.com`, and `release-assets.githubusercontent.com`

## Spec choices worth flagging

- **Latest, not pinned**: installs whatever `releases/latest` resolves to at sandbox creation time; no SHA256 verification. Simple and always current, at the cost of reproducibility.
- **No `extends`**: left as a bare mixin so it can compose with any agent, not just `claude`.

## Test plan

- [x] `sbx kit validate ./vale/`
- [x] `go test -v -count=1 -timeout 10m ./vale/...`
- [x] Manual: `sbx run --kit ./vale/ claude` → `vale --version` returns the latest release

## Origin

New utility mixin for prose linting in sandboxed writing/docs workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)