### PR TITLE
feat(spec)!: drop Persistence/KitDir, add locked/resources, list mounts

### DIFF
--- a/amp/spec.yaml
+++ b/amp/spec.yaml
@@ -7,7 +7,6 @@ description: The frontier coding agent.
 agent:
   image: "docker/sandbox-templates:shell-docker"
   aiFilename: AGENTS.md
-  persistence: persistent
   entrypoint:
     run: [amp, --dangerously-allow-all]
 

--- a/claude-ollama/spec.yaml
+++ b/claude-ollama/spec.yaml
@@ -7,7 +7,6 @@ description: Claude Code wired to Ollama Anthropic-compatible API, with configur
 agent:
   image: "docker/sandbox-templates:claude-code-docker"
   aiFilename: CLAUDE.md
-  persistence: persistent
   entrypoint:
     run: [/home/agent/.local/bin/claude-ollama]
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/docker/sbx-kits-contrib
 go 1.26.2
 
 require (
+	github.com/docker/go-units v0.5.0
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.42.0
 	go.yaml.in/yaml/v3 v3.0.4
@@ -22,7 +23,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-connections v0.6.0 // indirect
-	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect

--- a/nanobot/spec.yaml
+++ b/nanobot/spec.yaml
@@ -7,7 +7,6 @@ description: "Lightweight personal AI assistant with multi-platform chat and mul
 agent:
   image: "docker/sandbox-templates:shell-docker"
   aiFilename: AGENTS.md
-  persistence: persistent
   entrypoint:
     run: ["nanobot", "agent", "--config", "/home/agent/.nanobot/config.json"]
 

--- a/nanoclaw/spec.yaml
+++ b/nanoclaw/spec.yaml
@@ -7,7 +7,6 @@ description: "Lightweight AI assistant runtime driven by Claude Code; ships the 
 agent:
   image: "docker/sandbox-templates:claude-code-docker"
   aiFilename: CLAUDE.md
-  persistence: persistent
   entrypoint:
     run: ["/usr/local/bin/nanoclaw-start"]
 

--- a/openclaw/spec.yaml
+++ b/openclaw/spec.yaml
@@ -7,7 +7,6 @@ description: "Personal AI assistant with multi-platform chat, skills, and gatewa
 agent:
   image: "docker/sandbox-templates:shell-docker"
   aiFilename: AGENTS.md
-  persistence: persistent
   entrypoint:
     run: ["/usr/local/bin/openclaw-start"]
 

--- a/opencode-model-runner/spec.yaml
+++ b/opencode-model-runner/spec.yaml
@@ -7,7 +7,6 @@ description: OpenCode wired to a local Docker Model Runner instance via its Open
 agent:
   image: "docker/sandbox-templates:opencode-docker"
   aiFilename: AGENTS.md
-  persistence: persistent
   entrypoint:
     run: [opencode]
 

--- a/pi/spec.yaml
+++ b/pi/spec.yaml
@@ -7,7 +7,6 @@ description: "Minimal terminal coding agent with extensible tools, skills, and T
 agent:
   image: "docker/sandbox-templates:shell-docker"
   aiFilename: AGENTS.md
-  persistence: persistent
   entrypoint:
     run: [pi]
 

--- a/spec/artifact.go
+++ b/spec/artifact.go
@@ -96,6 +96,7 @@ func parseArtifact(readFile func(string) ([]byte, error)) (*Artifact, error) {
 	return &Artifact{
 		Manifest:    spec.Manifest,
 		Extends:     spec.Extends,
+		Locked:      spec.Locked,
 		Network:     spec.Network,
 		Credentials: spec.Credentials,
 		Environment: spec.Environment,

--- a/spec/artifact.go
+++ b/spec/artifact.go
@@ -1,6 +1,7 @@
 package spec
 
 import (
+	"bytes"
 	"fmt"
 	"io/fs"
 	"os"
@@ -85,7 +86,15 @@ func parseArtifact(readFile func(string) ([]byte, error)) (*Artifact, error) {
 	}
 
 	var spec specFile
-	if err := yaml.Unmarshal(data, &spec); err != nil {
+	// Strict decoding: unknown top-level (or nested) yaml keys are a hard
+	// error. The schema is documented and small enough that any unrecognised
+	// key is almost always a typo or a stale field the kit author hasn't
+	// migrated yet. Surfacing it loudly is the whole point — yaml.Unmarshal
+	// would silently drop the key and let the author think their kit was
+	// being honoured.
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&spec); err != nil {
 		return nil, fmt.Errorf("artifact: invalid %s: %w", specFileName, err)
 	}
 

--- a/spec/artifact_test.go
+++ b/spec/artifact_test.go
@@ -111,6 +111,37 @@ func TestParseArtifact_InvalidYAML(t *testing.T) {
 	require.ErrorContains(t, err, "invalid")
 }
 
+// TestParseArtifact_StrictUnknownField guards the strict-decode behaviour:
+// unknown top-level keys (and unknown nested keys under known blocks) hard-
+// fail rather than getting silently dropped. This is the contract the
+// engine relies on so that removed fields like `persistence:` and
+// `kitDir:` produce a clear diagnostic for kit authors, not a silent no-op.
+func TestParseArtifact_StrictUnknownField(t *testing.T) {
+	t.Run("unknown_top_level_key_rejected", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "spec.yaml"), []byte(`schemaVersion: "1"
+kind: mixin
+name: bogus-toplevel
+persistence: persistent
+`), 0o644))
+		_, err := LoadFromDirectory(dir)
+		require.ErrorContains(t, err, "persistence")
+	})
+
+	t.Run("unknown_nested_key_rejected", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "spec.yaml"), []byte(`schemaVersion: "1"
+kind: agent
+name: bogus-nested
+agent:
+  image: docker/sandbox-templates:shell-docker
+  persistence: persistent
+`), 0o644))
+		_, err := LoadFromDirectory(dir)
+		require.ErrorContains(t, err, "persistence")
+	})
+}
+
 func TestCollectFilesFromDir_SymlinkEscape(t *testing.T) {
 	dir := t.TempDir()
 	homeDir := filepath.Join(dir, "files", "home")

--- a/spec/artifact_test.go
+++ b/spec/artifact_test.go
@@ -35,7 +35,6 @@ func TestLoadFromDirectory(t *testing.T) {
 		require.Equal(t, "sample-bin", a.Manifest.Binary)
 		require.Equal(t, []string{"--verbose", "--task-mode"}, a.Manifest.RunOptions)
 		require.Equal(t, "SAMPLE.md", a.Manifest.AIFilename)
-		require.Equal(t, PersistenceEphemeral, a.Manifest.Persistence)
 		require.NotEmpty(t, a.Memory)
 	})
 

--- a/spec/normalize.go
+++ b/spec/normalize.go
@@ -29,9 +29,6 @@ func (s *specFile) normalizeAgent() error {
 	if s.AIFilename != "" {
 		return fmt.Errorf("use 'agent.aiFilename' instead of flat 'aiFilename' field")
 	}
-	if s.Persistence != "" {
-		return fmt.Errorf("use 'agent.persistence' instead of flat 'persistence' field")
-	}
 
 	if s.Agent != nil && !isAgent {
 		return fmt.Errorf("'agent:' block is only valid for kind %q, not %q", KindAgent, s.Kind)
@@ -46,7 +43,6 @@ func (s *specFile) normalizeAgent() error {
 
 	s.Template = s.Agent.Image
 	s.AIFilename = s.Agent.AIFilename
-	s.Persistence = s.Agent.Persistence
 
 	if s.Agent.Entrypoint != nil {
 		if len(s.Agent.Entrypoint.Run) > 0 {

--- a/spec/normalize.go
+++ b/spec/normalize.go
@@ -43,6 +43,7 @@ func (s *specFile) normalizeAgent() error {
 
 	s.Template = s.Agent.Image
 	s.AIFilename = s.Agent.AIFilename
+	s.Resources = s.Agent.Resources
 
 	if s.Agent.Entrypoint != nil {
 		if len(s.Agent.Entrypoint.Run) > 0 {

--- a/spec/normalize_test.go
+++ b/spec/normalize_test.go
@@ -13,6 +13,7 @@ func TestNormalizeAgent(t *testing.T) {
 			Agent: &agentBlock{
 				Image:      "my-image",
 				AIFilename: "AI.md",
+				Resources:  &Resources{CPU: 4, MemoryMB: 8192, GPU: "1"},
 				Entrypoint: &entrypointBlock{
 					Run:  []string{"bin", "--flag"},
 					Args: []string{"--extra"},
@@ -24,6 +25,10 @@ func TestNormalizeAgent(t *testing.T) {
 		require.Equal(t, "bin", s.Binary)
 		require.Equal(t, []string{"--flag", "--extra"}, s.RunOptions)
 		require.Equal(t, "AI.md", s.AIFilename)
+		require.NotNil(t, s.Resources)
+		require.InDelta(t, 4.0, s.Resources.CPU, 0.0001)
+		require.Equal(t, int64(8192), s.Resources.MemoryMB)
+		require.Equal(t, "1", s.Resources.GPU)
 	})
 
 	t.Run("rejects_agent_block_on_mixin", func(t *testing.T) {

--- a/spec/normalize_test.go
+++ b/spec/normalize_test.go
@@ -11,9 +11,8 @@ func TestNormalizeAgent(t *testing.T) {
 		s := specFile{
 			Manifest: Manifest{Kind: KindAgent, SchemaVersion: SchemaVersion, Name: "a"},
 			Agent: &agentBlock{
-				Image:       "my-image",
-				AIFilename:  "AI.md",
-				Persistence: PersistencePersistent,
+				Image:      "my-image",
+				AIFilename: "AI.md",
 				Entrypoint: &entrypointBlock{
 					Run:  []string{"bin", "--flag"},
 					Args: []string{"--extra"},
@@ -25,7 +24,6 @@ func TestNormalizeAgent(t *testing.T) {
 		require.Equal(t, "bin", s.Binary)
 		require.Equal(t, []string{"--flag", "--extra"}, s.RunOptions)
 		require.Equal(t, "AI.md", s.AIFilename)
-		require.Equal(t, PersistencePersistent, s.Persistence)
 	})
 
 	t.Run("rejects_agent_block_on_mixin", func(t *testing.T) {

--- a/spec/testdata/sample-agent/spec.yaml
+++ b/spec/testdata/sample-agent/spec.yaml
@@ -7,7 +7,6 @@ description: "A test-only agent that exercises agent-specific spec fields"
 agent:
   image: "docker/sandbox-templates:shell-docker"
   aiFilename: SAMPLE.md
-  persistence: ephemeral
   entrypoint:
     run: ["sample-bin", "--verbose"]
     args: ["--task-mode"]

--- a/spec/types.go
+++ b/spec/types.go
@@ -61,6 +61,9 @@ type Manifest struct {
 	// RunOptions are CLI arguments passed to the agent binary at startup.
 	RunOptions []string `json:"runOptions,omitempty" yaml:"runOptions,omitempty"`
 
+	// Resources optionally constrains container CPU, memory, and GPU.
+	Resources *Resources `json:"resources,omitempty" yaml:"resources,omitempty"`
+
 	// Security defines container security settings.
 	Security *Security `json:"security,omitempty" yaml:"security,omitempty"`
 
@@ -75,6 +78,21 @@ type Manifest struct {
 type Security struct {
 	// Privileged runs the container in privileged mode.
 	Privileged bool `json:"privileged,omitempty" yaml:"privileged,omitempty"`
+}
+
+// Resources describes optional container resource limits. All fields are
+// optional; an unset field means "no constraint from the spec".
+type Resources struct {
+	// CPU is the number of CPU cores. Fractional values are allowed
+	// (e.g. 0.5, 2.5).
+	CPU float64 `json:"cpu,omitempty" yaml:"cpu,omitempty"`
+
+	// MemoryMB is the memory limit in mebibytes.
+	MemoryMB int64 `json:"memoryMB,omitempty" yaml:"memoryMB,omitempty"`
+
+	// GPU is the GPU allocation as a string. Format is consumer-defined
+	// (e.g. "1", "all", a vendor-specific selector).
+	GPU string `json:"gpu,omitempty" yaml:"gpu,omitempty"`
 }
 
 // NetworkPolicy defines network rules for which external domains the agent
@@ -364,6 +382,7 @@ type agentBlock struct {
 	Image      string           `yaml:"image,omitempty"`
 	Entrypoint *entrypointBlock `yaml:"entrypoint,omitempty"`
 	AIFilename string           `yaml:"aiFilename,omitempty"`
+	Resources  *Resources       `yaml:"resources,omitempty"`
 }
 
 // entrypointBlock describes the agent's process launch configuration.

--- a/spec/types.go
+++ b/spec/types.go
@@ -236,6 +236,12 @@ type Artifact struct {
 	// Extends is the optional parent kit name for single-parent inheritance.
 	Extends string `json:"extends,omitempty"`
 
+	// Locked lists dotted YAML paths (e.g. "agent.image") on this artifact
+	// that child kits must not override during single-parent inheritance.
+	// The spec library only validates well-formedness; enforcement lives
+	// in the consumer that performs the merge.
+	Locked []string `json:"locked,omitempty"`
+
 	// Network is the optional network policy.
 	Network *NetworkPolicy `json:"network,omitempty"`
 
@@ -340,6 +346,7 @@ func (p *OAuthPolicy) ResolvedResponseFields() OAuthResponseFields {
 type specFile struct {
 	Manifest    `yaml:",inline"`
 	Extends     string             `yaml:"extends,omitempty"`
+	Locked      []string           `yaml:"locked,omitempty"`
 	Agent       *agentBlock        `yaml:"agent,omitempty"`
 	Secrets     []string           `yaml:"secrets,omitempty"`
 	Egress      map[string]string  `yaml:"egress,omitempty"`

--- a/spec/types.go
+++ b/spec/types.go
@@ -61,9 +61,6 @@ type Manifest struct {
 	// RunOptions are CLI arguments passed to the agent binary at startup.
 	RunOptions []string `json:"runOptions,omitempty" yaml:"runOptions,omitempty"`
 
-	// KitDir is the directory under the workspace where kit files are stored.
-	KitDir string `json:"kitDir,omitempty" yaml:"kitDir,omitempty"`
-
 	// Security defines container security settings.
 	Security *Security `json:"security,omitempty" yaml:"security,omitempty"`
 

--- a/spec/types.go
+++ b/spec/types.go
@@ -21,15 +21,6 @@ const (
 	KindMixin = "mixin"
 )
 
-// Persistence constants for volume management.
-const (
-	// PersistenceEphemeral means no persistent state is kept (default).
-	PersistenceEphemeral = "ephemeral"
-
-	// PersistencePersistent means agent state is stored in named Docker volumes.
-	PersistencePersistent = "persistent"
-)
-
 // ArtifactFile target constants.
 const (
 	// TargetHome means the file is copied relative to /home/agent/.
@@ -72,9 +63,6 @@ type Manifest struct {
 
 	// KitDir is the directory under the workspace where kit files are stored.
 	KitDir string `json:"kitDir,omitempty" yaml:"kitDir,omitempty"`
-
-	// Persistence controls volume management: "persistent" or "ephemeral" (default).
-	Persistence string `json:"persistence,omitempty" yaml:"persistence,omitempty"`
 
 	// Security defines container security settings.
 	Security *Security `json:"security,omitempty" yaml:"security,omitempty"`
@@ -369,10 +357,9 @@ type specFile struct {
 
 // agentBlock groups agent-specific configuration.
 type agentBlock struct {
-	Image       string           `yaml:"image,omitempty"`
-	Entrypoint  *entrypointBlock `yaml:"entrypoint,omitempty"`
-	AIFilename  string           `yaml:"aiFilename,omitempty"`
-	Persistence string           `yaml:"persistence,omitempty"`
+	Image      string           `yaml:"image,omitempty"`
+	Entrypoint *entrypointBlock `yaml:"entrypoint,omitempty"`
+	AIFilename string           `yaml:"aiFilename,omitempty"`
 }
 
 // entrypointBlock describes the agent's process launch configuration.

--- a/spec/types.go
+++ b/spec/types.go
@@ -67,17 +67,35 @@ type Manifest struct {
 	// Security defines container security settings.
 	Security *Security `json:"security,omitempty" yaml:"security,omitempty"`
 
-	// Volumes maps container paths to volume options.
-	Volumes map[string]string `json:"volumes,omitempty" yaml:"volumes,omitempty"`
+	// Volumes are block-volume mounts in dash-style list form. Entries are
+	// applied by Path.
+	Volumes []MountSpec `json:"volumes,omitempty" yaml:"volumes,omitempty"`
 
-	// Tmpfs maps container paths to tmpfs mount options.
-	Tmpfs map[string]string `json:"tmpfs,omitempty" yaml:"tmpfs,omitempty"`
+	// Tmpfs are tmpfs mounts in dash-style list form. Entries are applied
+	// by Path.
+	Tmpfs []MountSpec `json:"tmpfs,omitempty" yaml:"tmpfs,omitempty"`
 }
 
 // Security defines container security settings for the sandbox.
 type Security struct {
 	// Privileged runs the container in privileged mode.
 	Privileged bool `json:"privileged,omitempty" yaml:"privileged,omitempty"`
+}
+
+// MountSpec is a single mount entry shared by Manifest.Volumes (persistent
+// block volumes) and Manifest.Tmpfs (in-memory tmpfs). The fields are
+// identical; the semantic distinction lives on the field that holds the
+// slice, not on the entry type.
+type MountSpec struct {
+	// Path is the absolute mount path in the container.
+	Path string `json:"path" yaml:"path"`
+
+	// Size is the mount size as a byte-size string (e.g., "100m", "4g",
+	// "512m"). Optional.
+	Size string `json:"size,omitempty" yaml:"size,omitempty"`
+
+	// Mode is the mount mode in octal (e.g., "1777"). Optional.
+	Mode string `json:"mode,omitempty" yaml:"mode,omitempty"`
 }
 
 // Resources describes optional container resource limits. All fields are

--- a/spec/validate.go
+++ b/spec/validate.go
@@ -57,6 +57,15 @@ func ValidateManifest(m *Manifest) error {
 		}
 	}
 
+	if m.Resources != nil {
+		if m.Resources.CPU < 0 {
+			return fmt.Errorf("manifest: resources.cpu must be non-negative (got %v)", m.Resources.CPU)
+		}
+		if m.Resources.MemoryMB < 0 {
+			return fmt.Errorf("manifest: resources.memoryMB must be non-negative (got %d)", m.Resources.MemoryMB)
+		}
+	}
+
 	return nil
 }
 

--- a/spec/validate.go
+++ b/spec/validate.go
@@ -51,10 +51,6 @@ func ValidateManifest(m *Manifest) error {
 		}
 	}
 
-	if m.Persistence != "" && m.Persistence != PersistenceEphemeral && m.Persistence != PersistencePersistent {
-		return fmt.Errorf("manifest: invalid persistence %q (must be %q or %q)", m.Persistence, PersistenceEphemeral, PersistencePersistent)
-	}
-
 	return nil
 }
 

--- a/spec/validate.go
+++ b/spec/validate.go
@@ -17,6 +17,12 @@ var shellIdentifierPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 // placeholderPattern matches ${...} placeholders in init file content.
 var placeholderPattern = regexp.MustCompile(`\$\{[^}]+\}`)
 
+// lockedPathPattern matches a dotted YAML path: lowercase letter or digit
+// start, then segments of letters/digits separated by single dots, e.g.
+// "agent.image" or "network.allowedDomains". Used only for well-formedness;
+// the consumer that performs the merge decides which paths are meaningful.
+var lockedPathPattern = regexp.MustCompile(`^[a-z][a-zA-Z0-9]*(\.[a-z][a-zA-Z0-9]*)*$`)
+
 // supportedPlaceholders lists the placeholders allowed in initFiles content.
 var supportedPlaceholders = map[string]bool{
 	"${WORKDIR}": true,
@@ -227,6 +233,9 @@ func ValidateArtifact(a *Artifact) error {
 	if err := ValidateTmpfs(a.Manifest.Tmpfs); err != nil {
 		return err
 	}
+	if err := ValidateLocked(a.Locked); err != nil {
+		return err
+	}
 	if err := ValidateNetworkPolicy(a.Network); err != nil {
 		return err
 	}
@@ -259,6 +268,27 @@ func ValidateArtifact(a *Artifact) error {
 		}
 	}
 
+	return nil
+}
+
+// ValidateLocked validates the well-formedness of a locked-paths list.
+// Each entry must be a non-empty dotted YAML path matching
+// lockedPathPattern; duplicates are rejected. Whether a given path is
+// meaningful for inheritance is decided by the merge consumer.
+func ValidateLocked(paths []string) error {
+	seen := make(map[string]struct{}, len(paths))
+	for i, p := range paths {
+		if p == "" {
+			return fmt.Errorf("locked[%d] must not be empty", i)
+		}
+		if !lockedPathPattern.MatchString(p) {
+			return fmt.Errorf("locked[%d] %q is not a well-formed dotted path", i, p)
+		}
+		if _, dup := seen[p]; dup {
+			return fmt.Errorf("locked[%d] %q is duplicated", i, p)
+		}
+		seen[p] = struct{}{}
+	}
 	return nil
 }
 

--- a/spec/validate.go
+++ b/spec/validate.go
@@ -189,6 +189,9 @@ func ValidateCommandsPolicy(c *CommandsPolicy) error {
 		if err := validateInitFileContent(i, f.Content); err != nil {
 			return err
 		}
+		if f.Mode != "" && !octalModePattern.MatchString(f.Mode) {
+			return fmt.Errorf("commands: initFiles[%d].mode must be octal (e.g. \"0755\"), got %q", i, f.Mode)
+		}
 	}
 
 	return nil

--- a/spec/validate.go
+++ b/spec/validate.go
@@ -5,6 +5,8 @@ import (
 	"path"
 	"regexp"
 	"strings"
+
+	"github.com/docker/go-units"
 )
 
 // namePattern matches valid kit names: lowercase alphanumeric with hyphens,
@@ -22,6 +24,10 @@ var placeholderPattern = regexp.MustCompile(`\$\{[^}]+\}`)
 // "agent.image" or "network.allowedDomains". Used only for well-formedness;
 // the consumer that performs the merge decides which paths are meaningful.
 var lockedPathPattern = regexp.MustCompile(`^[a-z][a-zA-Z0-9]*(\.[a-z][a-zA-Z0-9]*)*$`)
+
+// octalModePattern matches file mode strings: 3 or 4 octal digits, with an
+// optional leading "0". Accepts "755", "0755", "1777", "01777".
+var octalModePattern = regexp.MustCompile(`^0?[0-7]{3,4}$`)
 
 // supportedPlaceholders lists the placeholders allowed in initFiles content.
 var supportedPlaceholders = map[string]bool{
@@ -202,27 +208,34 @@ func ValidateSecurity(_ *Security) error {
 	return nil
 }
 
-// ValidateVolumes validates volume mount paths.
-func ValidateVolumes(volumes map[string]string) error {
-	for p := range volumes {
-		if p == "" {
-			return fmt.Errorf("manifest: volume path must not be empty")
-		}
-		if !strings.HasPrefix(p, "/") {
-			return fmt.Errorf("manifest: volume path %q must be an absolute path", p)
-		}
-	}
-	return nil
+// ValidateVolumes validates block-volume mount entries.
+func ValidateVolumes(volumes []MountSpec) error {
+	return validateMounts("volumes", volumes)
 }
 
-// ValidateTmpfs validates tmpfs mount paths.
-func ValidateTmpfs(tmpfs map[string]string) error {
-	for p := range tmpfs {
-		if p == "" {
-			return fmt.Errorf("manifest: tmpfs path must not be empty")
+// ValidateTmpfs validates tmpfs mount entries.
+func ValidateTmpfs(tmpfs []MountSpec) error {
+	return validateMounts("tmpfs", tmpfs)
+}
+
+// validateMounts checks the shared MountSpec invariants: absolute Path,
+// parseable Size if set, octal Mode if set. field is used as the error
+// prefix so volume and tmpfs failures are distinguishable.
+func validateMounts(field string, mounts []MountSpec) error {
+	for i, m := range mounts {
+		if m.Path == "" {
+			return fmt.Errorf("manifest: %s[%d].path must not be empty", field, i)
 		}
-		if !strings.HasPrefix(p, "/") {
-			return fmt.Errorf("manifest: tmpfs path %q must be an absolute path", p)
+		if !strings.HasPrefix(m.Path, "/") {
+			return fmt.Errorf("manifest: %s[%d].path %q must be an absolute path", field, i, m.Path)
+		}
+		if m.Size != "" {
+			if _, err := units.RAMInBytes(m.Size); err != nil {
+				return fmt.Errorf("manifest: %s[%d].size %q is not a valid size: %w", field, i, m.Size, err)
+			}
+		}
+		if m.Mode != "" && !octalModePattern.MatchString(m.Mode) {
+			return fmt.Errorf("manifest: %s[%d].mode %q must be octal (e.g. \"1777\")", field, i, m.Mode)
 		}
 	}
 	return nil

--- a/spec/validate_test.go
+++ b/spec/validate_test.go
@@ -66,6 +66,23 @@ func TestValidateManifest(t *testing.T) {
 		require.ErrorContains(t, ValidateManifest(&m), "template is required")
 	})
 
+	t.Run("resources_valid", func(t *testing.T) {
+		m := valid
+		m.Resources = &Resources{CPU: 2.5, MemoryMB: 4096, GPU: "1"}
+		require.NoError(t, ValidateManifest(&m))
+	})
+
+	t.Run("resources_negative_cpu", func(t *testing.T) {
+		m := valid
+		m.Resources = &Resources{CPU: -1}
+		require.ErrorContains(t, ValidateManifest(&m), "cpu must be non-negative")
+	})
+
+	t.Run("resources_negative_memory", func(t *testing.T) {
+		m := valid
+		m.Resources = &Resources{MemoryMB: -1}
+		require.ErrorContains(t, ValidateManifest(&m), "memoryMB must be non-negative")
+	})
 }
 
 func TestValidateNetworkPolicy(t *testing.T) {

--- a/spec/validate_test.go
+++ b/spec/validate_test.go
@@ -207,6 +207,20 @@ func TestValidateCommandsPolicy(t *testing.T) {
 		}
 		require.ErrorContains(t, ValidateCommandsPolicy(c), "command is required")
 	})
+
+	t.Run("valid_initfile_mode", func(t *testing.T) {
+		c := &CommandsPolicy{
+			InitFiles: []InitFile{{Path: "/tmp/f", Content: "x", Mode: "0644"}},
+		}
+		require.NoError(t, ValidateCommandsPolicy(c))
+	})
+
+	t.Run("invalid_initfile_mode", func(t *testing.T) {
+		c := &CommandsPolicy{
+			InitFiles: []InitFile{{Path: "/tmp/f", Content: "x", Mode: "rwx"}},
+		}
+		require.ErrorContains(t, ValidateCommandsPolicy(c), "must be octal")
+	})
 }
 
 func TestValidateVolumes(t *testing.T) {

--- a/spec/validate_test.go
+++ b/spec/validate_test.go
@@ -66,11 +66,6 @@ func TestValidateManifest(t *testing.T) {
 		require.ErrorContains(t, ValidateManifest(&m), "template is required")
 	})
 
-	t.Run("invalid_persistence", func(t *testing.T) {
-		m := valid
-		m.Persistence = "something-else"
-		require.ErrorContains(t, ValidateManifest(&m), "invalid persistence")
-	})
 }
 
 func TestValidateNetworkPolicy(t *testing.T) {

--- a/spec/validate_test.go
+++ b/spec/validate_test.go
@@ -211,29 +211,53 @@ func TestValidateCommandsPolicy(t *testing.T) {
 
 func TestValidateVolumes(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
-		require.NoError(t, ValidateVolumes(map[string]string{"/data": "size=4G"}))
+		require.NoError(t, ValidateVolumes([]MountSpec{{Path: "/data", Size: "4g", Mode: "0755"}}))
+	})
+
+	t.Run("path_only_is_valid", func(t *testing.T) {
+		require.NoError(t, ValidateVolumes([]MountSpec{{Path: "/data"}}))
 	})
 
 	t.Run("empty_path", func(t *testing.T) {
-		require.ErrorContains(t, ValidateVolumes(map[string]string{"": ""}), "must not be empty")
+		require.ErrorContains(t, ValidateVolumes([]MountSpec{{Path: ""}}), "volumes[0].path must not be empty")
 	})
 
 	t.Run("relative_path", func(t *testing.T) {
-		require.ErrorContains(t, ValidateVolumes(map[string]string{"data": ""}), "must be an absolute path")
+		require.ErrorContains(t, ValidateVolumes([]MountSpec{{Path: "data"}}), "volumes[0].path \"data\" must be an absolute path")
+	})
+
+	t.Run("invalid_size", func(t *testing.T) {
+		require.ErrorContains(t, ValidateVolumes([]MountSpec{{Path: "/data", Size: "huge"}}), "volumes[0].size \"huge\" is not a valid size")
+	})
+
+	t.Run("invalid_mode", func(t *testing.T) {
+		require.ErrorContains(t, ValidateVolumes([]MountSpec{{Path: "/data", Mode: "rwx"}}), "volumes[0].mode \"rwx\" must be octal")
 	})
 }
 
 func TestValidateTmpfs(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
-		require.NoError(t, ValidateTmpfs(map[string]string{"/tmp": "size=1G"}))
+		require.NoError(t, ValidateTmpfs([]MountSpec{{Path: "/tmp", Size: "1g", Mode: "1777"}}))
+	})
+
+	t.Run("path_only_is_valid", func(t *testing.T) {
+		require.NoError(t, ValidateTmpfs([]MountSpec{{Path: "/tmp"}}))
 	})
 
 	t.Run("empty_path", func(t *testing.T) {
-		require.ErrorContains(t, ValidateTmpfs(map[string]string{"": ""}), "must not be empty")
+		require.ErrorContains(t, ValidateTmpfs([]MountSpec{{Path: ""}}), "tmpfs[0].path must not be empty")
 	})
 
 	t.Run("relative_path", func(t *testing.T) {
-		require.ErrorContains(t, ValidateTmpfs(map[string]string{"tmp": ""}), "must be an absolute path")
+		require.ErrorContains(t, ValidateTmpfs([]MountSpec{{Path: "tmp"}}), "tmpfs[0].path \"tmp\" must be an absolute path")
+	})
+
+	t.Run("invalid_size", func(t *testing.T) {
+		require.ErrorContains(t, ValidateTmpfs([]MountSpec{{Path: "/tmp", Size: "huge"}}), "tmpfs[0].size \"huge\" is not a valid size")
+	})
+
+	t.Run("invalid_mode", func(t *testing.T) {
+		require.ErrorContains(t, ValidateTmpfs([]MountSpec{{Path: "/tmp", Mode: "rwx"}}), "tmpfs[0].mode \"rwx\" must be octal")
 	})
 }
 

--- a/spec/validate_test.go
+++ b/spec/validate_test.go
@@ -220,6 +220,44 @@ func TestValidateTmpfs(t *testing.T) {
 	})
 }
 
+func TestValidateLocked(t *testing.T) {
+	t.Run("nil_is_valid", func(t *testing.T) {
+		require.NoError(t, ValidateLocked(nil))
+	})
+
+	t.Run("simple_paths", func(t *testing.T) {
+		require.NoError(t, ValidateLocked([]string{"agent.image", "network.allowedDomains"}))
+	})
+
+	t.Run("single_segment_is_valid", func(t *testing.T) {
+		require.NoError(t, ValidateLocked([]string{"memory"}))
+	})
+
+	t.Run("empty_entry", func(t *testing.T) {
+		require.ErrorContains(t, ValidateLocked([]string{""}), "must not be empty")
+	})
+
+	t.Run("leading_dot", func(t *testing.T) {
+		require.ErrorContains(t, ValidateLocked([]string{".image"}), "not a well-formed dotted path")
+	})
+
+	t.Run("trailing_dot", func(t *testing.T) {
+		require.ErrorContains(t, ValidateLocked([]string{"agent."}), "not a well-formed dotted path")
+	})
+
+	t.Run("double_dot", func(t *testing.T) {
+		require.ErrorContains(t, ValidateLocked([]string{"agent..image"}), "not a well-formed dotted path")
+	})
+
+	t.Run("disallowed_chars", func(t *testing.T) {
+		require.ErrorContains(t, ValidateLocked([]string{"agent.image[0]"}), "not a well-formed dotted path")
+	})
+
+	t.Run("duplicate", func(t *testing.T) {
+		require.ErrorContains(t, ValidateLocked([]string{"agent.image", "agent.image"}), "duplicated")
+	})
+}
+
 func TestValidateOAuthPolicy(t *testing.T) {
 	t.Run("nil_is_valid", func(t *testing.T) {
 		require.NoError(t, ValidateOAuthPolicy(nil))

--- a/tck/derive.go
+++ b/tck/derive.go
@@ -106,14 +106,23 @@ func resolveWorkdir(s string) string {
 	return strings.ReplaceAll(s, "${WORKDIR}", TestWorkDir)
 }
 
-// deriveTmpfs builds the expected tmpfs mounts from the manifest's tmpfs map,
-// always including /run/secrets for the secrets tmpfs.
-func deriveTmpfs(manifestTmpfs map[string]string) map[string]string {
+// deriveTmpfs builds the expected tmpfs mounts from the manifest's tmpfs
+// entries, always including /run/secrets for the secrets tmpfs. The result
+// is a path→option-string map suitable for testcontainers-go's WithTmpfs
+// (Size and Mode compose into the comma-separated value Docker expects).
+func deriveTmpfs(manifestTmpfs []spec.MountSpec) map[string]string {
 	tmpfs := map[string]string{
 		"/run/secrets": "rw,noexec,nosuid",
 	}
-	for k, v := range manifestTmpfs {
-		tmpfs[k] = v
+	for _, t := range manifestTmpfs {
+		var opts []string
+		if t.Size != "" {
+			opts = append(opts, "size="+t.Size)
+		}
+		if t.Mode != "" {
+			opts = append(opts, "mode="+t.Mode)
+		}
+		tmpfs[t.Path] = strings.Join(opts, ",")
 	}
 	return tmpfs
 }

--- a/tck/suite.go
+++ b/tck/suite.go
@@ -264,13 +264,6 @@ func (s *Suite) RunValidationTests(t *testing.T) {
 			}
 		})
 
-		if m.Persistence != "" {
-			t.Run("persistence", func(t *testing.T) {
-				require.Contains(t, []string{spec.PersistenceEphemeral, spec.PersistencePersistent}, m.Persistence,
-					"persistence must be %q or %q", spec.PersistenceEphemeral, spec.PersistencePersistent)
-			})
-		}
-
 		if m.Security != nil {
 			t.Run("security", func(t *testing.T) {
 				// privileged is a bool — just verify the field is reachable

--- a/tck/suite.go
+++ b/tck/suite.go
@@ -300,6 +300,13 @@ func (s *Suite) RunValidationTests(t *testing.T) {
 			})
 		}
 
+		if len(s.Artifact.Locked) > 0 {
+			t.Run("locked", func(t *testing.T) {
+				require.NoError(t, spec.ValidateLocked(s.Artifact.Locked),
+					"locked paths must be well-formed")
+			})
+		}
+
 		if m.AIFilename != "" {
 			t.Run("ai_filename", func(t *testing.T) {
 				require.True(t, strings.HasSuffix(m.AIFilename, ".md") || strings.HasSuffix(m.AIFilename, ".txt"),

--- a/tck/suite.go
+++ b/tck/suite.go
@@ -307,6 +307,15 @@ func (s *Suite) RunValidationTests(t *testing.T) {
 			})
 		}
 
+		if m.Resources != nil {
+			t.Run("resources", func(t *testing.T) {
+				require.GreaterOrEqual(t, m.Resources.CPU, 0.0,
+					"resources.cpu must be non-negative")
+				require.GreaterOrEqual(t, m.Resources.MemoryMB, int64(0),
+					"resources.memoryMB must be non-negative")
+			})
+		}
+
 		if m.AIFilename != "" {
 			t.Run("ai_filename", func(t *testing.T) {
 				require.True(t, strings.HasSuffix(m.AIFilename, ".md") || strings.HasSuffix(m.AIFilename, ".txt"),

--- a/tck/suite.go
+++ b/tck/suite.go
@@ -273,18 +273,18 @@ func (s *Suite) RunValidationTests(t *testing.T) {
 
 		if len(m.Volumes) > 0 {
 			t.Run("volumes", func(t *testing.T) {
-				for p := range m.Volumes {
-					require.True(t, strings.HasPrefix(p, "/"),
-						"volume path %q must be absolute", p)
+				for i, v := range m.Volumes {
+					require.True(t, strings.HasPrefix(v.Path, "/"),
+						"volumes[%d].path %q must be absolute", i, v.Path)
 				}
 			})
 		}
 
 		if len(m.Tmpfs) > 0 {
 			t.Run("tmpfs", func(t *testing.T) {
-				for p := range m.Tmpfs {
-					require.True(t, strings.HasPrefix(p, "/"),
-						"tmpfs path %q must be absolute", p)
+				for i, mnt := range m.Tmpfs {
+					require.True(t, strings.HasPrefix(mnt.Path, "/"),
+						"tmpfs[%d].path %q must be absolute", i, mnt.Path)
 				}
 			})
 		}

--- a/tck/tck_test.go
+++ b/tck/tck_test.go
@@ -66,12 +66,19 @@ func TestDeriveTmpfs(t *testing.T) {
 	})
 
 	t.Run("merges_manifest_tmpfs", func(t *testing.T) {
-		result := deriveTmpfs(map[string]string{
-			"/tmp": "size=1G",
+		result := deriveTmpfs([]spec.MountSpec{
+			{Path: "/tmp", Size: "1g"},
 		})
 		require.Contains(t, result, "/run/secrets")
 		require.Contains(t, result, "/tmp")
-		require.Equal(t, "size=1G", result["/tmp"])
+		require.Equal(t, "size=1g", result["/tmp"])
+	})
+
+	t.Run("composes_size_and_mode", func(t *testing.T) {
+		result := deriveTmpfs([]spec.MountSpec{
+			{Path: "/scratch", Size: "512m", Mode: "1777"},
+		})
+		require.Equal(t, "size=512m,mode=1777", result["/scratch"])
 	})
 }
 

--- a/trivy/spec.yaml
+++ b/trivy/spec.yaml
@@ -7,7 +7,6 @@ description: "Aqua's open source vulnerability scanner — sandboxed because sec
 agent:
   image: "docker/sandbox-templates:shell-docker"
   aiFilename: AGENTS.md
-  persistence: persistent
   # Drop into bash with trivy on PATH and the workspace as cwd. Run `trivy fs .` to scan.
   entrypoint:
     run: [bash, -l]


### PR DESCRIPTION
## What's changed

Six field-scoped, breaking-but-experimental changes to the kit spec, each a separate commit:

- **Remove `Manifest.Persistence`** — declared on the manifest, parsed, inherited, displayed, but no runtime decision consumed it. Volumes are already explicit via `Manifest.Volumes`.
- **Remove `Manifest.KitDir`** — same shape as Persistence: stored, copied during inheritance, rendered by inspect commands, but never consulted at runtime. No kit declares it.
- **Add top-level `locked`** — a list of dotted YAML paths that child kits must not override during `extends:` resolution. The spec library only validates well-formedness; enforcement is the merge consumer's job.
- **Add `agent.resources`** — optional container resource constraints (`cpu` as float64 cores, `memoryMB` as int64, `gpu` as a consumer-defined string).
- **Switch volumes/tmpfs to list form with a shared `MountSpec`** — both `Manifest.Volumes` and `Manifest.Tmpfs` move from `map[string]string` (with packed option strings) to `[]MountSpec{Path, Size, Mode}`. The two fields share one entry type since their per-entry shape is identical; the semantic distinction lives on the slice field.
- **Validate `InitFile.Mode` is octal** — `ValidateCommandsPolicy` now rejects malformed mode strings using the same `octalModePattern` already used for `MountSpec`. The engine has been carrying this check as a local extension; pushing it upstream makes the spec library the single source of truth.

TCK gains pure-logic sub-tests for `locked` and `resources`, and iterates the slice form for `volumes` and `tmpfs`. Agent `ttl` is intentionally deferred — there are unresolved comments on the proposal that need to land first.

## Why is this important?

The kit spec accumulated fields that *looked* configurable but had no effect — `Persistence` and `KitDir` were declared and validated but never read. Removing them clears the kit-author surface and avoids the fiction that they do something.

The two additive fields come from the next phase of kit-author requests: `locked` gives parent kits a way to protect critical fields from being overridden, and `resources` declares container limits that the engine will wire to the runtime (matters most for cloud workloads, where CPU/memory/GPU constraints aren't always inherited from the host).

The mount restructure replaces a flat map whose values had to pack options into a single string (`"size=512m,mode=1777"`) — awkward to validate, awkward to extend — with a discrete list-of-struct form. Volumes and tmpfs share `MountSpec` because their fields are identical; the validators delegate to one shared `validateMounts` helper that supplies the field name as the error prefix, so failures still read `volumes[i]` or `tmpfs[i]`.

The `InitFile.Mode` validation pulls a check the engine had been duplicating locally into the spec, so `ValidateCommandsPolicy` becomes the single source of truth and engine consumers can drop their wrappers.

Kits are documented as experimental, so the removals and shape change don't require a schema bump.

## Changes

### `spec/`

- Drop `PersistenceEphemeral`/`PersistencePersistent` constants, `Manifest.Persistence`, `agentBlock.Persistence`, the flat-field rejection in `normalize`, and the persistence rule in `ValidateManifest`.
- Drop `Manifest.KitDir`.
- Add `Artifact.Locked []string` and `specFile.Locked` parsing; add `ValidateLocked` (rejects empty entries, malformed dotted paths, duplicates).
- Add `Resources` type, `Manifest.Resources`, `agentBlock.Resources`, normalize wiring, and non-negative CPU/memory validation in `ValidateManifest`.
- Introduce `MountSpec{Path, Size, Mode}` used by both `Manifest.Volumes` and `Manifest.Tmpfs`. Collapse `ValidateVolumes`/`ValidateTmpfs` into thin wrappers around a shared `validateMounts(field, mounts)` helper.
- Extend `ValidateCommandsPolicy` to reject malformed `InitFile.Mode` strings, reusing the `octalModePattern` already defined for `MountSpec`.

### `tck/`

- Drop the `persistence` sub-test from `RunValidationTests`.
- Add a `locked` sub-test that mirrors `spec.ValidateLocked`.
- Add a `resources` sub-test asserting `CPU` and `MemoryMB` are non-negative.
- Volumes/tmpfs pure-logic sub-tests iterate the slice form.
- `deriveTmpfs` takes `[]spec.MountSpec` and composes the comma-separated option string Docker expects from `Size`/`Mode`, preserving the existing runtime `assertTmpfs` check unchanged.

Pure-logic only — runtime container assertions for `resources` (applying limits via testcontainers and inspecting `HostConfig`) were considered but kept out of scope. Resource enforcement is the engine's responsibility, and the TCK should not pretend to be the engine.

### Kits

Eight kit specs drop their no-op `persistence: persistent` lines: `amp`, `claude-ollama`, `nanobot`, `nanoclaw`, `openclaw`, `opencode-model-runner`, `pi`, `trivy`. No contrib kit declared `volumes:` or `tmpfs:` in yaml, so kit specs are otherwise unchanged.

## Migration

Downstream consumers of this library will need to:

1. Bump the dep to pick up the new types.
2. Drop their own dead references to `Manifest.Persistence` and `Manifest.KitDir`.
3. Adapt their volume and tmpfs customizers from `map[string]string` to `[]spec.MountSpec`. The packed option string (`"size=10g"`) is now discrete fields; the consumer composes whatever runtime form Docker expects.
4. Wire `agent.resources` to the container runtime when ready to enforce limits.
5. Wire `locked` into the inheritance merge step to actually reject child overrides.
6. Drop any local `InitFile.Mode` octal validation now that the spec library enforces it in `ValidateCommandsPolicy`.

## Test plan

- [x] `go test ./...` passes across all 15 packages in this repo (spec, tck, and every kit's integration tests).
- [x] All five commits are GPG-signed and DCO signed-off.
- [ ] Downstream consumer adapter PRs follow separately.