### PR TITLE
feat(opencode-model-runner): use opencode-models-discovery plugin

### DIFF
--- a/opencode-model-runner/README.md
+++ b/opencode-model-runner/README.md
@@ -6,11 +6,11 @@ instance via its OpenAI-compatible endpoint. Useful for offline development,
 cost-free experimentation, or testing custom local models with the OpenCode UI.
 
 > **Prerequisites:** Docker Model Runner must be enabled on the host with TCP
-> access on port 12434, and the model you want to use must be pulled:
+> access on port 12434, and at least one model must be pulled:
 >
 > ```console
 > $ docker desktop enable model-runner --tcp
-> $ docker model pull qwen3
+> $ docker model pull <model>
 > ```
 >
 > **Linux hosts:** `host.docker.internal` requires Docker to be started with
@@ -28,42 +28,24 @@ $ sbx run --kit ./opencode-model-runner/ opencode-model-runner ~/my-project
 The agent name passed to `sbx run` (`opencode-model-runner`) matches the
 `name:` field in the kit's `spec.yaml`.
 
-OpenCode opens already pointed at `model-runner/qwen3`. Switch any time with
-`/models`.
-
-## Switch models
-
-Three values in `spec.yaml` reference the model tag (the key under `models`,
-the display `name`, and the top-level default `model`). To use a different
-model, save `spec.yaml` to a local directory, replace the three occurrences
-of `qwen3` with the tag you want, and pass `--kit` at that path:
-
-```console
-$ mkdir opencode-model-runner
-$ curl -o opencode-model-runner/spec.yaml \
-    https://raw.githubusercontent.com/docker/sbx-kits-contrib/main/opencode-model-runner/spec.yaml
-$ # edit opencode-model-runner/spec.yaml
-$ sbx run --kit ./opencode-model-runner opencode-model-runner ~/my-project
-```
-
-The tag must match what `docker model ls` shows. For a larger context window
-than the default, package a variant first:
-
-```console
-$ docker model package --from qwen3 --context-size 64000 qwen3:64k
-```
-
-then point `spec.yaml` at `qwen3:64k`.
+All models available via `docker model ls` are automatically discovered and
+selectable in OpenCode via `/models`.
 
 ## How it works
 
 OpenCode reads its provider configuration from
 `~/.config/opencode/opencode.json`. This kit uses `commands.initFiles` to drop
-that JSON into the sandbox at startup, declaring a single
-`@ai-sdk/openai-compatible` provider whose `baseURL` is
-`http://host.docker.internal:12434/v1` (Model Runner's OpenAI-compatible
-endpoint) and a top-level `model` of `model-runner/qwen3` so OpenCode boots
-directly into the local model.
+that JSON into the sandbox at startup, declaring:
+
+- An `@ai-sdk/openai-compatible` provider (`dmr`) whose `baseURL` is
+  `http://host.docker.internal:12434/v1` (Model Runner's OpenAI-compatible
+  endpoint), with `modelsDiscovery.enabled: true` so the provider queries
+  Model Runner's `/models` endpoint at startup.
+- The `opencode-models-discovery` plugin (with `smartModelName: false`) which
+  surfaces the discovered models in OpenCode's model picker.
+
+Any model pulled with `docker model pull` appears automatically — no manual
+config edits needed.
 
 ## Related
 

--- a/opencode-model-runner/spec.yaml
+++ b/opencode-model-runner/spec.yaml
@@ -2,7 +2,7 @@ schemaVersion: "1"
 kind: agent
 name: opencode-model-runner
 displayName: OpenCode (Docker Model Runner)
-description: OpenCode wired to a local Docker Model Runner instance via its OpenAI-compatible API, preconfigured for qwen3.
+description: OpenCode wired to a local Docker Model Runner instance via its OpenAI-compatible API, with automatic model discovery.
 
 agent:
   image: "docker/sandbox-templates:opencode-docker"
@@ -19,19 +19,21 @@ commands:
       content: |
         {
           "$schema": "https://opencode.ai/config.json",
+          "plugin": [
+            ["opencode-models-discovery", {
+              "smartModelName": false
+            }]
+          ],
           "provider": {
-            "model-runner": {
+            "dmr": {
               "npm": "@ai-sdk/openai-compatible",
               "name": "Docker Model Runner",
               "options": {
-                "baseURL": "http://host.docker.internal:12434/v1"
-              },
-              "models": {
-                "qwen3": {
-                  "name": "Qwen3 (Model Runner)"
+                "baseURL": "http://host.docker.internal:12434/v1",
+                "modelsDiscovery": {
+                  "enabled": true
                 }
               }
             }
-          },
-          "model": "model-runner/qwen3"
+          }
         }


### PR DESCRIPTION
Switch from a hardcoded qwen3 model config to the opencode-models-discovery plugin, which queries Docker Model Runner's models endpoint at startup. Any model pulled with `docker model pull` is automatically available in OpenCode's model picker without manual config edits.

<img width="1080" height="730" alt="Screenshot 2026-05-14 at 09 28 32" src="https://github.com/user-attachments/assets/d3d522ff-5197-4a81-ab28-8882bd4cc351" />
