### PR TITLE
feat(crush): add crush agent kit

### DIFF
--- a/crush/README.md
+++ b/crush/README.md
@@ -1,0 +1,67 @@
+# crush
+
+A standalone agent kit (`kind: agent`) for [Crush](https://github.com/charmbracelet/crush),
+Charm's multi-provider AI coding agent. The kit installs Crush from the
+official Charm apt repository, wires API auth for 15 model providers
+through the sandbox proxy, and runs `crush --yolo` as the entrypoint when
+you attach.
+
+## Prerequisites
+
+At least one provider API key exported on your host. Crush supports:
+
+- Anthropic (`ANTHROPIC_API_KEY`)
+- OpenAI (`OPENAI_API_KEY`)
+- Azure OpenAI (`AZURE_OPENAI_API_KEY`)
+- Google Gemini (`GEMINI_API_KEY` or `GOOGLE_GENERATIVE_AI_API_KEY`)
+- Mistral (`MISTRAL_API_KEY`)
+- Groq (`GROQ_API_KEY`)
+- Cerebras (`CEREBRAS_API_KEY`)
+- OpenRouter (`OPENROUTER_API_KEY`)
+- Hugging Face (`HF_TOKEN`)
+- io.net (`IONET_API_KEY`)
+- MiniMax (`MINIMAX_API_KEY`)
+- Synthetic (`SYNTHETIC_API_KEY`)
+- Vercel v0 (`VERCEL_API_KEY`)
+- Z.ai (`ZAI_API_KEY`)
+- AWS Bedrock (`AWS_ACCESS_KEY_ID`)
+
+You only need keys for the providers you intend to use.
+
+## Usage
+
+```console
+$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=crush" crush
+```
+
+Or with a local clone of this repo:
+
+```console
+$ sbx run --kit ./crush/ crush
+```
+
+The first launch installs Crush via the Charm apt repository and applies
+the kit's network and proxy auth wiring. Subsequent launches reuse the
+sandbox.
+
+## How auth works
+
+The kit's `network` block declares a `serviceDomain` for every supported
+provider's API host and a matching `serviceAuth` entry describing the
+auth header (`Authorization: Bearer …`, `x-api-key: …`, etc). The
+`credentials.sources` block tells the proxy which host env var holds
+each provider's secret.
+
+When Crush makes a request to (say) `api.openai.com`, the proxy:
+
+1. Looks up the service for the domain (`openai`).
+2. Looks up the credential source for that service (`OPENAI_API_KEY` on
+   the host).
+3. Injects `Authorization: Bearer <real-key>` on the outbound request.
+
+The real key never enters the sandbox. The `environment.proxyManaged`
+list exposes a placeholder value for each `*_API_KEY` env var inside the
+container so Crush sees the variables it expects to find.
+
+`allowedDomains` covers the install repo (`repo.charm.sh`) and every
+provider API host.

--- a/crush/crush_tck_test.go
+++ b/crush/crush_tck_test.go
@@ -1,0 +1,14 @@
+package crush_test
+
+import (
+	"testing"
+
+	"github.com/docker/sbx-kits-contrib/tck"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCrushTCK(t *testing.T) {
+	suite, err := tck.NewSuiteFromDir(".")
+	require.NoError(t, err)
+	suite.RunAll(t)
+}

--- a/crush/spec.yaml
+++ b/crush/spec.yaml
@@ -1,0 +1,178 @@
+schemaVersion: "1"
+kind: agent
+name: crush
+displayName: Crush
+description: Multi-provider AI coding agent from Charm, with proxy-mediated auth for 15 model providers.
+
+agent:
+  image: "docker/sandbox-templates:shell-docker"
+  aiFilename: AGENTS.md
+  entrypoint:
+    run: [crush]
+    args: ["--yolo"]
+
+environment:
+  proxyManaged:
+    - ANTHROPIC_API_KEY
+    - AWS_ACCESS_KEY_ID
+    - AZURE_OPENAI_API_KEY
+    - CEREBRAS_API_KEY
+    - GEMINI_API_KEY
+    - GOOGLE_GENERATIVE_AI_API_KEY
+    - GROQ_API_KEY
+    - HF_TOKEN
+    - IONET_API_KEY
+    - MINIMAX_API_KEY
+    - MISTRAL_API_KEY
+    - OPENAI_API_KEY
+    - OPENROUTER_API_KEY
+    - SYNTHETIC_API_KEY
+    - VERCEL_API_KEY
+    - ZAI_API_KEY
+
+credentials:
+  sources:
+    anthropic:
+      env: [ANTHROPIC_API_KEY]
+    aws:
+      env: [AWS_ACCESS_KEY_ID]
+    azure-openai:
+      env: [AZURE_OPENAI_API_KEY]
+    cerebras:
+      env: [CEREBRAS_API_KEY]
+    google:
+      env: [GEMINI_API_KEY, GOOGLE_GENERATIVE_AI_API_KEY]
+    groq:
+      env: [GROQ_API_KEY]
+    huggingface:
+      env: [HF_TOKEN]
+    ionet:
+      env: [IONET_API_KEY]
+    minimax:
+      env: [MINIMAX_API_KEY]
+    mistral:
+      env: [MISTRAL_API_KEY]
+    openai:
+      env: [OPENAI_API_KEY]
+    openrouter:
+      env: [OPENROUTER_API_KEY]
+    synthetic:
+      env: [SYNTHETIC_API_KEY]
+    vercel:
+      env: [VERCEL_API_KEY]
+    zai:
+      env: [ZAI_API_KEY]
+
+network:
+  serviceDomains:
+    api.anthropic.com: anthropic
+    api.openai.com: openai
+    "*.openai.azure.com": azure-openai
+    generativelanguage.googleapis.com: google
+    api.mistral.ai: mistral
+    api.groq.com: groq
+    groq.com: groq
+    api.cerebras.ai: cerebras
+    openrouter.ai: openrouter
+    api-inference.huggingface.co: huggingface
+    api.io.net: ionet
+    api.minimax.chat: minimax
+    api.synthetic.com: synthetic
+    api.zai.com: zai
+    v0.dev: vercel
+    "bedrock-runtime.*.amazonaws.com": aws
+    "bedrock.*.amazonaws.com": aws
+  serviceAuth:
+    anthropic:
+      headerName: x-api-key
+      valueFormat: "%s"
+    openai:
+      headerName: Authorization
+      valueFormat: "Bearer %s"
+    azure-openai:
+      headerName: api-key
+      valueFormat: "%s"
+    google:
+      headerName: x-goog-api-key
+      valueFormat: "%s"
+    mistral:
+      headerName: Authorization
+      valueFormat: "Bearer %s"
+    groq:
+      headerName: Authorization
+      valueFormat: "Bearer %s"
+    cerebras:
+      headerName: Authorization
+      valueFormat: "Bearer %s"
+    openrouter:
+      headerName: Authorization
+      valueFormat: "Bearer %s"
+    huggingface:
+      headerName: Authorization
+      valueFormat: "Bearer %s"
+    ionet:
+      headerName: Authorization
+      valueFormat: "Bearer %s"
+    minimax:
+      headerName: Authorization
+      valueFormat: "Bearer %s"
+    synthetic:
+      headerName: Authorization
+      valueFormat: "Bearer %s"
+    vercel:
+      headerName: Authorization
+      valueFormat: "Bearer %s"
+    zai:
+      headerName: Authorization
+      valueFormat: "Bearer %s"
+    aws:
+      headerName: Authorization
+      valueFormat: "AWS4-HMAC-SHA256 Credential=%s/"
+  allowedDomains:
+    - repo.charm.sh
+    - api.anthropic.com
+    - api.openai.com
+    - "*.openai.azure.com"
+    - generativelanguage.googleapis.com
+    - api.mistral.ai
+    - api.groq.com
+    - groq.com
+    - api.cerebras.ai
+    - openrouter.ai
+    - api-inference.huggingface.co
+    - api.io.net
+    - api.minimax.chat
+    - api.synthetic.com
+    - api.zai.com
+    - v0.dev
+    - "bedrock-runtime.*.amazonaws.com"
+    - "bedrock.*.amazonaws.com"
+
+commands:
+  install:
+    - command: |
+        set -euo pipefail
+        mkdir -p /etc/apt/keyrings
+        curl -fsSL https://repo.charm.sh/apt/gpg.key | gpg --dearmor -o /etc/apt/keyrings/charm.gpg
+      user: "0"
+      description: Add Charm GPG key
+    - command: |
+        echo 'deb [signed-by=/etc/apt/keyrings/charm.gpg] https://repo.charm.sh/apt/ * *' \
+          > /etc/apt/sources.list.d/charm.list
+      user: "0"
+      description: Add Charm apt repository
+    - command: apt-get update -qq && apt-get install -y -qq crush
+      user: "0"
+      description: Install Crush from Charm apt repository
+
+memory: |
+  ## Crush
+
+  Crush is a multi-provider AI coding agent from Charm. It is installed
+  as `crush` on `PATH` and started with `--yolo` so it skips interactive
+  permission prompts (the sandbox itself is the safety boundary).
+
+  Set any of the provider API keys on your host (e.g. `ANTHROPIC_API_KEY`,
+  `OPENAI_API_KEY`, `GROQ_API_KEY`) and the sandbox proxy will inject them
+  on outbound requests to the matching provider. See
+  <https://github.com/charmbracelet/crush> for usage.


### PR DESCRIPTION
## Summary

Adds a standalone agent kit for [Crush](https://github.com/charmbracelet/crush), Charm's multi-provider AI coding agent.

- `kind: agent` on `docker/sandbox-templates:shell-docker`, entrypoint `crush --yolo`
- Installs via the official Charm apt repository (`repo.charm.sh`)
- 16 proxy-managed provider env vars and 15 credential sources covering Anthropic, OpenAI, Azure OpenAI, Google Gemini, Mistral, Groq, Cerebras, OpenRouter, Hugging Face, io.net, MiniMax, Synthetic, Vercel, Z.ai, and AWS Bedrock
- Matching `serviceDomains` + `serviceAuth` so the proxy injects the right header per provider; `allowedDomains` covers the install repo and every provider API host

## Test plan

- [x] `go test -short ./crush/...` — pure-logic TCK passes
- [x] `go test ./crush/...` — full TCK passes, including live install of `crush` from `repo.charm.sh`
- [x] `go vet` and `gofmt` clean
- [x] Manually verified end-to-end on a temporary sandbox