### PR TITLE
spec: add MCPClient schema

### DIFF
--- a/spec/artifact.go
+++ b/spec/artifact.go
@@ -112,6 +112,7 @@ func parseArtifact(readFile func(string) ([]byte, error)) (*Artifact, error) {
 		Settings:    spec.Settings,
 		Commands:    spec.Commands,
 		OAuth:       spec.OAuth,
+		MCPClient:   spec.MCPClient,
 		Memory:      spec.Memory,
 	}, nil
 }

--- a/spec/mcp_client.go
+++ b/spec/mcp_client.go
@@ -1,0 +1,47 @@
+package spec
+
+// MCPClientSpec declares how a kit configures its agent to talk to the
+// sandbox's aggregate MCP gateway. The consuming engine reads this spec
+// when a runtime starts the gateway and applies the declared files and
+// commands inside the container.
+//
+// The spec is intentionally declarative: paths, contents, and command
+// argv elements are Go text/template strings rendered against a context
+// supplied by the engine (gateway URL, sentinel token, runtime/workspace
+// dirs). The spec library only defines the data shape; template parsing
+// and rendering live in the consumer.
+type MCPClientSpec struct {
+	// Files to write inside the container after the gateway is up. Each
+	// file's Path and Content are rendered as Go templates by the
+	// consumer.
+	Files []MCPClientFile `json:"files,omitempty" yaml:"files,omitempty"`
+
+	// Commands to exec inside the container after the files are written.
+	// Use sparingly — most agents need only a config file write.
+	Commands []MCPClientCommand `json:"commands,omitempty" yaml:"commands,omitempty"`
+}
+
+// MCPClientFile describes one file the kit needs the engine to write
+// inside the container.
+type MCPClientFile struct {
+	// Path is the absolute path inside the container where the file
+	// should be written. Rendered as a Go template by the consumer.
+	Path string `json:"path" yaml:"path"`
+
+	// Content is the file body. Rendered as a Go template by the consumer.
+	Content string `json:"content" yaml:"content"`
+
+	// Mode is the file mode (octal). Zero falls back to 0o644 at apply
+	// time.
+	Mode int `json:"mode,omitempty" yaml:"mode,omitempty"`
+}
+
+// MCPClientCommand describes one command the kit wants the engine to
+// exec inside the container after the files are written. Run via exec,
+// not via a shell, so each argv element is rendered independently and
+// no shell interpolation occurs.
+type MCPClientCommand struct {
+	// Argv is the exec argv. Each element is rendered as a Go template
+	// by the consumer.
+	Argv []string `json:"argv" yaml:"argv"`
+}

--- a/spec/types.go
+++ b/spec/types.go
@@ -296,6 +296,12 @@ type Artifact struct {
 	// OAuth is the optional OAuth configuration.
 	OAuth *OAuthPolicy `json:"oauth,omitempty"`
 
+	// MCPClient is the optional declarative MCP-client config for this
+	// kit. When set, the consuming engine applies the declared files
+	// and commands inside the container after the aggregate MCP
+	// gateway starts. Nil means the kit has no MCP-client hook.
+	MCPClient *MCPClientSpec `json:"mcpClient,omitempty"`
+
 	// Files are static files from the files/ directory to copy into the container.
 	Files []ArtifactFile `json:"files,omitempty"`
 
@@ -392,6 +398,7 @@ type specFile struct {
 	Settings    *SettingsPolicy    `yaml:"settings,omitempty"`
 	Commands    *CommandsPolicy    `yaml:"commands,omitempty"`
 	OAuth       *OAuthPolicy       `yaml:"oauth,omitempty"`
+	MCPClient   *MCPClientSpec     `yaml:"mcpClient,omitempty"`
 	Memory      string             `yaml:"memory,omitempty"`
 }
 

--- a/spec/validate.go
+++ b/spec/validate.go
@@ -276,6 +276,9 @@ func ValidateArtifact(a *Artifact) error {
 	if err := ValidateOAuthPolicy(a.OAuth); err != nil {
 		return err
 	}
+	if err := ValidateMCPClientSpec(a.MCPClient); err != nil {
+		return err
+	}
 
 	for i, f := range a.Files {
 		if f.Target != TargetHome && f.Target != TargetWorkspace {
@@ -313,6 +316,44 @@ func ValidateLocked(paths []string) error {
 			return fmt.Errorf("locked[%d] %q is duplicated", i, p)
 		}
 		seen[p] = struct{}{}
+	}
+	return nil
+}
+
+// ValidateMCPClientSpec checks an MCPClientSpec for the structural
+// rules the engine relies on:
+//
+//   - every file has a non-empty Path (after trimming whitespace) and a
+//     non-empty Content;
+//   - every command has a non-empty Argv with a non-empty first
+//     element;
+//   - Mode, if set, is a valid Unix permission (low 12 bits only).
+//
+// Template syntax is not parsed here — the consumer's Parse() failures
+// surface at render time. The validator only catches the kinds of
+// authoring mistakes that would silently produce empty/broken hooks.
+func ValidateMCPClientSpec(s *MCPClientSpec) error {
+	if s == nil {
+		return nil
+	}
+	for i, f := range s.Files {
+		if strings.TrimSpace(f.Path) == "" {
+			return fmt.Errorf("mcpClient: files[%d].path is required", i)
+		}
+		if f.Content == "" {
+			return fmt.Errorf("mcpClient: files[%d].content is required", i)
+		}
+		if f.Mode != 0 && (f.Mode < 0 || f.Mode > 0o7777) {
+			return fmt.Errorf("mcpClient: files[%d].mode %o is out of range (expected 0..07777)", i, f.Mode)
+		}
+	}
+	for i, c := range s.Commands {
+		if len(c.Argv) == 0 {
+			return fmt.Errorf("mcpClient: commands[%d].argv is required", i)
+		}
+		if strings.TrimSpace(c.Argv[0]) == "" {
+			return fmt.Errorf("mcpClient: commands[%d].argv[0] must not be empty", i)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Adds `MCPClientSpec`, `MCPClientFile`, and `MCPClientCommand` to the
`spec/` package so agent kits can declare how the consuming engine
should configure the agent to talk to a sandbox's aggregate MCP
gateway.

The schema is intentionally data-only — Go `text/template` rendering
and the template-error type stay engine-side because they depend on
engine-only context (gateway URL, sentinel token, runtime / workspace
dirs). Kits describe the *what* (file paths, file content, exec argv,
all as template strings); the engine decides the *when, where, and as
whom*.

### What lands here

- `spec/mcp_client.go` — `MCPClientSpec`, `MCPClientFile`, `MCPClientCommand` with `json` + `yaml` tags.
- `spec/types.go` — `MCPClient *MCPClientSpec` on `Artifact` and the on-disk `specFile`.
- `spec/artifact.go` — round-trip `MCPClient` through `parseArtifact`.
- `spec/validate.go` — `ValidateMCPClientSpec` (rejects empty paths/contents, empty argv, out-of-range modes) and wires it into `ValidateArtifact`.

### Why now

The `docker/sandboxes` engine has a `mcp-kit-hooks` branch landing
soon that consumes this schema. The engine ships an executor-agnostic
`applyMCPClientHook` that:

1. Looks up the kit's `MCPClientSpec` when the gateway starts.
2. Renders each `Files[i].Path` / `Files[i].Content` and each
   `Commands[i].Argv[j]` as a Go template with a fixed context
   (`GatewayURL`, `SentinelToken`, `RuntimeID`, `WorkspaceDir`,
   `HomeDir`).
3. Writes the rendered files inside the running container, then
   execs the rendered commands.

A claude kit using it looks like:

```yaml
mcpClient:
  commands:
    - argv:
        - sh
        - -c
        - |
          set -e
          cd "{{.WorkspaceDir}}"
          claude mcp add mcp-gateway "{{.GatewayURL}}" --transport http --header "Authorization: Bearer {{.SentinelToken}}"
```

### Compatibility

Purely additive. `MCPClient` is a pointer; existing kits decode and
validate unchanged. Engines that don't know about the field ignore
it.

## Test plan

- [x] `go build ./spec/` passes
- [x] `go test ./spec/` passes (existing suite unaffected)
- [ ] Reviewer: confirm json/yaml field names match the
      sandboxes-side consumer (`docker/sandboxes` branch
      `mcp-kit-hooks`).
- [ ] Reviewer: confirm `ValidateMCPClientSpec` bounds (mode range,
      whitespace-only path rejection) feel right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)