### PR TITLE
feat(spec): add Version/SourceURL fields and LoadFromBytes

### DIFF
--- a/amp/spec.yaml
+++ b/amp/spec.yaml
@@ -1,8 +1,10 @@
 schemaVersion: "1"
 kind: agent
 name: amp
+version: "1.0.0"
 displayName: Amp
 description: The frontier coding agent.
+sourceURL: https://github.com/docker/sbx-kits-contrib/tree/main/amp
 
 agent:
   image: "docker/sandbox-templates:shell-docker"

--- a/claude-model-runner/spec.yaml
+++ b/claude-model-runner/spec.yaml
@@ -1,9 +1,11 @@
 schemaVersion: "1"
 kind: mixin
 name: claude-model-runner
+version: "1.0.0"
 extends: claude
 displayName: Claude Code (Docker Model Runner)
 description: Route Claude Code's Anthropic API calls to a local Docker Model Runner endpoint at host.docker.internal:12434.
+sourceURL: https://github.com/docker/sbx-kits-contrib/tree/main/claude-model-runner
 
 environment:
   variables:

--- a/claude-ollama/spec.yaml
+++ b/claude-ollama/spec.yaml
@@ -1,8 +1,10 @@
 schemaVersion: "1"
 kind: agent
 name: claude-ollama
+version: "1.0.0"
 displayName: Claude Code (Ollama)
 description: Claude Code wired to Ollama Anthropic-compatible API, with configurable model.
+sourceURL: https://github.com/docker/sbx-kits-contrib/tree/main/claude-ollama
 
 agent:
   image: "docker/sandbox-templates:claude-code-docker"

--- a/code-server/spec.yaml
+++ b/code-server/spec.yaml
@@ -1,9 +1,11 @@
 schemaVersion: "1"
 kind: mixin
 name: code-server
+version: "1.0.0"
 extends: claude
 displayName: code-server (web VS Code) with Claude Code
 description: Runs code-server on port 8080, opened on the sandbox workspace, with the Claude Code VS Code extension preinstalled. Pair with the built-in claude agent so the extension inherits the sandbox's Anthropic credentials.
+sourceURL: https://github.com/docker/sbx-kits-contrib/tree/main/code-server
 
 network:
   allowedDomains:

--- a/crush/spec.yaml
+++ b/crush/spec.yaml
@@ -1,8 +1,10 @@
 schemaVersion: "1"
 kind: agent
 name: crush
+version: "1.0.0"
 displayName: Crush
 description: Multi-provider AI coding agent from Charm, with proxy-mediated auth for 15 model providers.
+sourceURL: https://github.com/docker/sbx-kits-contrib/tree/main/crush
 
 agent:
   image: "docker/sandbox-templates:shell-docker"

--- a/git-ssh-sign/spec.yaml
+++ b/git-ssh-sign/spec.yaml
@@ -1,8 +1,10 @@
 schemaVersion: "1"
 kind: mixin
 name: git-ssh-sign
+version: "1.0.0"
 displayName: Git SSH Commit Signing
 description: Configures git to sign commits using the SSH key forwarded from the host's SSH agent.
+sourceURL: https://github.com/docker/sbx-kits-contrib/tree/main/git-ssh-sign
 
 commands:
   initFiles:

--- a/mise/spec.yaml
+++ b/mise/spec.yaml
@@ -1,8 +1,10 @@
 schemaVersion: "1"
 kind: mixin
 name: mise
+version: "1.0.0"
 displayName: mise (mise-en-place)
 description: "The polyglot dev-tool version manager (https://mise.jdx.dev) — installs the mise CLI and wires up shell activation so the agent can run `mise install`, `mise use`, and per-project `.mise.toml` resolutions in the sandbox."
+sourceURL: https://github.com/docker/sbx-kits-contrib/tree/main/mise
 
 network:
   allowedDomains:

--- a/nanobot/spec.yaml
+++ b/nanobot/spec.yaml
@@ -1,8 +1,10 @@
 schemaVersion: "1"
 kind: agent
 name: nanobot
+version: "1.0.0"
 displayName: Nanobot
 description: "Lightweight personal AI assistant with multi-platform chat and multi-provider LLM support"
+sourceURL: https://github.com/docker/sbx-kits-contrib/tree/main/nanobot
 
 agent:
   image: "docker/sandbox-templates:shell-docker"

--- a/nanoclaw/spec.yaml
+++ b/nanoclaw/spec.yaml
@@ -1,8 +1,10 @@
 schemaVersion: "1"
 kind: agent
 name: nanoclaw
+version: "1.0.0"
 displayName: NanoClaw
 description: "Lightweight AI assistant runtime driven by Claude Code; ships the CLI channel — chat platforms (WhatsApp, Telegram, Discord, …) add via upstream skills"
+sourceURL: https://github.com/docker/sbx-kits-contrib/tree/main/nanoclaw
 
 agent:
   image: "docker/sandbox-templates:claude-code-docker"

--- a/openclaw/spec.yaml
+++ b/openclaw/spec.yaml
@@ -1,8 +1,10 @@
 schemaVersion: "1"
 kind: agent
 name: openclaw
+version: "1.0.0"
 displayName: OpenClaw
 description: "Personal AI assistant with multi-platform chat, skills, and gateway support"
+sourceURL: https://github.com/docker/sbx-kits-contrib/tree/main/openclaw
 
 agent:
   image: "docker/sandbox-templates:shell-docker"

--- a/opencode-model-runner/spec.yaml
+++ b/opencode-model-runner/spec.yaml
@@ -1,8 +1,10 @@
 schemaVersion: "1"
 kind: agent
 name: opencode-model-runner
+version: "1.0.0"
 displayName: OpenCode (Docker Model Runner)
 description: OpenCode wired to a local Docker Model Runner instance via its OpenAI-compatible API, with automatic model discovery.
+sourceURL: https://github.com/docker/sbx-kits-contrib/tree/main/opencode-model-runner
 
 agent:
   image: "docker/sandbox-templates:opencode-docker"

--- a/pi/spec.yaml
+++ b/pi/spec.yaml
@@ -1,8 +1,10 @@
 schemaVersion: "1"
 kind: agent
 name: pi
+version: "1.0.0"
 displayName: Pi
 description: "Minimal terminal coding agent with extensible tools, skills, and TUI"
+sourceURL: https://github.com/docker/sbx-kits-contrib/tree/main/pi
 
 agent:
   image: "docker/sandbox-templates:shell-docker"

--- a/spec/artifact.go
+++ b/spec/artifact.go
@@ -75,7 +75,22 @@ func LoadFromFS(fsys fs.FS, dir string) (*Artifact, error) {
 	return artifact, nil
 }
 
-// parseArtifact parses a spec.yaml (or spec.yml) file from an artifact source.
+// LoadFromBytes parses spec.yaml bytes into an Artifact, leaving Files
+// unset and skipping validation. Intended for callers that obtain the
+// spec.yaml separately from the file payload — e.g., the v2 OCI puller,
+// which reads spec.yaml from the manifest's config blob and the files
+// from a tar layer.
+//
+// Callers must populate Artifact.Files from their own source and then
+// call ValidateArtifact to verify the result. LoadFromDirectory and
+// LoadFromFS do this automatically; LoadFromBytes does not because it
+// has no notion of a file source.
+func LoadFromBytes(yamlBytes []byte) (*Artifact, error) {
+	return parseArtifactBytes(yamlBytes)
+}
+
+// parseArtifact reads spec.yaml (or spec.yml as fallback) via readFile and
+// delegates to parseArtifactBytes.
 func parseArtifact(readFile func(string) ([]byte, error)) (*Artifact, error) {
 	data, err := readFile(specFileName)
 	if err != nil {
@@ -84,7 +99,14 @@ func parseArtifact(readFile func(string) ([]byte, error)) (*Artifact, error) {
 			return nil, fmt.Errorf("artifact: %s (or %s) is required: %w", specFileName, specFileNameAlt, err)
 		}
 	}
+	return parseArtifactBytes(data)
+}
 
+// parseArtifactBytes decodes spec.yaml bytes and applies normalization.
+// It does not validate; callers that need a validated Artifact must call
+// ValidateArtifact themselves (LoadFromDirectory and LoadFromFS already
+// do, after populating Files).
+func parseArtifactBytes(data []byte) (*Artifact, error) {
 	var spec specFile
 	// Strict decoding: unknown top-level (or nested) yaml keys are a hard
 	// error. The schema is documented and small enough that any unrecognised

--- a/spec/artifact_test.go
+++ b/spec/artifact_test.go
@@ -16,6 +16,8 @@ func TestLoadFromDirectory(t *testing.T) {
 
 		require.Equal(t, "sample-mixin", a.Manifest.Name)
 		require.Equal(t, KindMixin, a.Manifest.Kind)
+		require.Equal(t, "1.0.0", a.Manifest.Version)
+		require.Equal(t, "https://example.com/sample-mixin", a.Manifest.SourceURL)
 		require.Empty(t, a.Manifest.Template, "mixins have no template")
 		require.NotNil(t, a.Network)
 		require.NotNil(t, a.Credentials)
@@ -31,6 +33,8 @@ func TestLoadFromDirectory(t *testing.T) {
 
 		require.Equal(t, "sample-agent", a.Manifest.Name)
 		require.Equal(t, KindAgent, a.Manifest.Kind)
+		require.Equal(t, "1.0.0", a.Manifest.Version)
+		require.Equal(t, "https://example.com/sample-agent", a.Manifest.SourceURL)
 		require.NotEmpty(t, a.Manifest.Template, "agents must have a template")
 		require.Equal(t, "sample-bin", a.Manifest.Binary)
 		require.Equal(t, []string{"--verbose", "--task-mode"}, a.Manifest.RunOptions)
@@ -155,4 +159,65 @@ func TestCollectFilesFromDir_SymlinkEscape(t *testing.T) {
 
 	_, err := collectFilesFromDir(dir)
 	require.ErrorContains(t, err, "escapes the artifact directory")
+}
+
+func TestLoadFromBytes(t *testing.T) {
+	t.Run("happy_path", func(t *testing.T) {
+		a, err := LoadFromBytes([]byte(`schemaVersion: "1"
+kind: mixin
+name: bytes-kit
+displayName: Bytes Kit
+description: loaded directly from bytes
+`))
+		require.NoError(t, err)
+		require.Equal(t, "bytes-kit", a.Manifest.Name)
+		require.Equal(t, KindMixin, a.Manifest.Kind)
+		require.Empty(t, a.Files, "LoadFromBytes never populates Files")
+	})
+
+	t.Run("does_not_validate_files", func(t *testing.T) {
+		// LoadFromBytes is deliberately validation-free for Files — the
+		// caller is expected to populate Artifact.Files from a separate
+		// source (e.g. an OCI tar layer) and then call ValidateArtifact.
+		// Here we synthesize an Artifact that parses cleanly, then attach
+		// a malformed Files entry that only ValidateArtifact catches.
+		a, err := LoadFromBytes([]byte(`schemaVersion: "1"
+kind: mixin
+name: deferred-validate
+`))
+		require.NoError(t, err)
+
+		a.Files = []ArtifactFile{
+			{Target: "bogus-target", RelativePath: "x"},
+		}
+		require.ErrorContains(t, ValidateArtifact(a), "invalid target")
+	})
+
+	t.Run("invalid_yaml", func(t *testing.T) {
+		_, err := LoadFromBytes([]byte(`{{{ broken`))
+		require.ErrorContains(t, err, "invalid")
+	})
+
+	t.Run("unknown_field_rejected", func(t *testing.T) {
+		// Strict-decode behaviour applies to LoadFromBytes the same way it
+		// does to LoadFromDirectory.
+		_, err := LoadFromBytes([]byte(`schemaVersion: "1"
+kind: mixin
+name: typo-kit
+mystery: 42
+`))
+		require.Error(t, err)
+	})
+}
+
+func TestManifest_VersionAndSourceURL(t *testing.T) {
+	a, err := LoadFromBytes([]byte(`schemaVersion: "1"
+kind: mixin
+name: versioned-kit
+version: "2.3.1"
+sourceURL: https://example.com/versioned-kit
+`))
+	require.NoError(t, err)
+	require.Equal(t, "2.3.1", a.Manifest.Version)
+	require.Equal(t, "https://example.com/versioned-kit", a.Manifest.SourceURL)
 }

--- a/spec/testdata/sample-agent/spec.yaml
+++ b/spec/testdata/sample-agent/spec.yaml
@@ -1,8 +1,10 @@
 schemaVersion: "1"
 kind: agent
 name: sample-agent
+version: "1.0.0"
 displayName: Sample Agent
 description: "A test-only agent that exercises agent-specific spec fields"
+sourceURL: https://example.com/sample-agent
 
 agent:
   image: "docker/sandbox-templates:shell-docker"

--- a/spec/testdata/sample-mixin/spec.yaml
+++ b/spec/testdata/sample-mixin/spec.yaml
@@ -1,8 +1,10 @@
 schemaVersion: "1"
 kind: mixin
 name: sample-mixin
+version: "1.0.0"
 displayName: Sample Mixin
 description: "A test-only mixin that exercises every spec field the TCK validates"
+sourceURL: https://example.com/sample-mixin
 
 network:
   allowedDomains:

--- a/spec/types.go
+++ b/spec/types.go
@@ -41,11 +41,21 @@ type Manifest struct {
 	// Name is a unique identifier (lowercase, alphanumeric + hyphens).
 	Name string `json:"name" yaml:"name"`
 
+	// Version is the kit's release version (e.g. "1.0", "2.3.1"). Optional;
+	// when set, it is the source for the OCI annotation
+	// vnd.docker.sandbox.kit.version at pack time.
+	Version string `json:"version,omitempty" yaml:"version,omitempty"`
+
 	// DisplayName is a human-readable name for display purposes.
 	DisplayName string `json:"displayName,omitempty" yaml:"displayName,omitempty"`
 
 	// Description is a short description of the agent or mixin.
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	// SourceURL is an optional URL to the kit's source repository or
+	// documentation. When set, it is the source for the standard OCI
+	// annotation org.opencontainers.image.source at pack time.
+	SourceURL string `json:"sourceURL,omitempty" yaml:"sourceURL,omitempty"`
 
 	// Binary is the executable binary name to run in the container.
 	// Required for kind "agent", not used for kind "mixin".

--- a/task/spec.yaml
+++ b/task/spec.yaml
@@ -1,8 +1,10 @@
 schemaVersion: "1"
 kind: mixin
 name: task
+version: "1.0.0"
 displayName: Task
 description: Installs the Task CLI so sandbox agents can run Taskfiles.
+sourceURL: https://github.com/docker/sbx-kits-contrib/tree/main/task
 
 network:
   allowedDomains:

--- a/trivy/spec.yaml
+++ b/trivy/spec.yaml
@@ -1,8 +1,10 @@
 schemaVersion: "1"
 kind: agent
 name: trivy
+version: "1.0.0"
 displayName: Trivy
 description: "Aqua's open source vulnerability scanner — sandboxed because security scanners shouldn't be able to compromise their hosts (TeamPCP, March 2026)."
+sourceURL: https://github.com/docker/sbx-kits-contrib/tree/main/trivy
 
 agent:
   image: "docker/sandbox-templates:shell-docker"

--- a/vale/spec.yaml
+++ b/vale/spec.yaml
@@ -1,8 +1,10 @@
 schemaVersion: "1"
 kind: mixin
 name: vale
+version: "1.0.0"
 displayName: Vale
 description: Installs the latest Vale prose linter from GitHub releases.
+sourceURL: https://github.com/docker/sbx-kits-contrib/tree/main/vale
 
 network:
   allowedDomains:


### PR DESCRIPTION
## What's changed

`Manifest` gains two optional fields (`Version`, `SourceURL`) and the package exposes a new bytes-based loader (`LoadFromBytes`). Backward-compatible additions only — existing kits parse unchanged, existing callers of `LoadFromDirectory` / `LoadFromFS` are unaffected.

## Why is this important?

Distribution formats that ship the spec separately from the file payload — for example, packaging `spec.yaml` as an OCI config blob alongside a tar layer for the files — need:

1. Identity fields they can surface in distribution metadata: a release version and a link to the kit's source or documentation.
2. A way to parse a `Manifest` from in-memory bytes, then populate `Files` from a separate source (e.g. a tar stream), then validate the combined `Artifact`.

The spec library stays neutral about *which* consumer does the packaging or distribution. These additions just give consumers the surface area they need.

## Changes

**`spec/types.go`** — `Manifest` adds two optional fields:

- `Version string` — kit release version (e.g. `"1.0.0"`).
- `SourceURL string` — link to the kit's source or documentation.

Both are `omitempty` and unvalidated; future tightening can layer on later.

**`spec/artifact.go`** — refactors the parser to expose a bytes-only loader:

- New public `LoadFromBytes(yamlBytes []byte) (*Artifact, error)`.
- Internal `parseArtifactBytes` is extracted from `parseArtifact`; the latter now delegates after reading the file.
- `LoadFromBytes` does **not** validate. Callers must populate `Artifact.Files` from their own source and then call `ValidateArtifact`. This mirrors `LoadFromDirectory` / `LoadFromFS`, which already defer validation until after `Files` are collected.

**`spec/testdata/`** — both sample fixtures (`sample-mixin`, `sample-agent`) gain `version` and `sourceURL` so the file-based loader is exercised end-to-end.

**`spec/artifact_test.go`** — adds:

- `TestLoadFromBytes` — happy path, validation deferral (a malformed `Files` entry attached after parse must still fail `ValidateArtifact`), invalid YAML, and unknown-field rejection (strict-decode parity with `parseArtifact`).
- `TestManifest_VersionAndSourceURL` — round-trip of the two new fields via the bytes loader.
- Assertions added to the existing `TestLoadFromDirectory` subtests so the testdata changes are actually checked.

## Test plan

- [x] `go test ./spec/...` passes
- [x] `go test ./tck/...` passes (the TCK loads `spec/testdata/sample-*` and must keep working with the added fields)
- [x] Manual: load a kit *without* `version` / `sourceURL` set and confirm both fields are empty strings (existing kits keep behaving as before)
- [x] Manual: load a kit with both fields set and confirm they round-trip via `LoadFromDirectory` and `LoadFromBytes`
