### PR TITLE
feat(spec): accept schemaVersion 1 and 2

### DIFF
--- a/spec/types.go
+++ b/spec/types.go
@@ -7,8 +7,21 @@
 // based) and the internal sandboxes engine.
 package spec
 
-// Supported schema version for kit artifacts.
+// SchemaVersion is the default schemaVersion used when a tool scaffolds
+// a new kit. Stays at "1" while sbx releases v2-capable engines into
+// the field; flip to "2" once enough consumers can read v2 artifacts to
+// make it safe as a default. Authors who want v2 today set schemaVersion:
+// "2" in their spec.yaml explicitly.
 const SchemaVersion = "1"
+
+// SupportedSchemaVersions enumerates every schemaVersion value the
+// loader accepts. "1" is the legacy shape (the current default); "2"
+// opts the kit into the v2 OCI artifact format at distribution time —
+// the spec fields themselves are unchanged across the two versions.
+//
+// New entries should be appended (never reordered) so existing kits
+// continue to validate.
+var SupportedSchemaVersions = []string{"1", "2"}
 
 // Kind constants for manifest types.
 const (

--- a/spec/validate.go
+++ b/spec/validate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/docker/go-units"
@@ -39,8 +40,8 @@ func ValidateManifest(m *Manifest) error {
 	if m.SchemaVersion == "" {
 		return fmt.Errorf("manifest: schemaVersion is required")
 	}
-	if m.SchemaVersion != SchemaVersion {
-		return fmt.Errorf("manifest: unsupported schemaVersion %q (supported: %q)", m.SchemaVersion, SchemaVersion)
+	if !slices.Contains(SupportedSchemaVersions, m.SchemaVersion) {
+		return fmt.Errorf("manifest: unsupported schemaVersion %q (supported: %v)", m.SchemaVersion, SupportedSchemaVersions)
 	}
 
 	if m.Kind == "" {

--- a/spec/validate_test.go
+++ b/spec/validate_test.go
@@ -33,6 +33,34 @@ func TestValidateManifest(t *testing.T) {
 		require.ErrorContains(t, ValidateManifest(&m), "schemaVersion")
 	})
 
+	t.Run("schema_version_1_accepted", func(t *testing.T) {
+		// "1" is the legacy schema version and must keep validating so
+		// existing kits in the wild continue to load after the bump.
+		m := valid
+		m.SchemaVersion = "1"
+		require.NoError(t, ValidateManifest(&m))
+	})
+
+	t.Run("schema_version_2_accepted", func(t *testing.T) {
+		// "2" opts a kit into the v2 OCI distribution format at pack
+		// time. The spec library accepts it; downstream tooling reads
+		// the value to decide which OCI format to emit.
+		m := valid
+		m.SchemaVersion = "2"
+		require.NoError(t, ValidateManifest(&m))
+	})
+
+	t.Run("unsupported_schema_version", func(t *testing.T) {
+		// Anything outside SupportedSchemaVersions must hard-fail with a
+		// message that names the value seen and the values accepted, so
+		// kit authors can spot a typo without grepping the spec library.
+		m := valid
+		m.SchemaVersion = "99"
+		err := ValidateManifest(&m)
+		require.ErrorContains(t, err, "unsupported schemaVersion")
+		require.ErrorContains(t, err, `"99"`)
+	})
+
 	t.Run("missing_kind", func(t *testing.T) {
 		m := valid
 		m.Kind = ""


### PR DESCRIPTION
## What's changed

The loader now accepts both `schemaVersion: "1"` (the current default) and `schemaVersion: "2"` (opt-in). The default `SchemaVersion` constant stays at `"1"` — kit authors who want to opt into the v2 OCI distribution format set `schemaVersion: "2"` in their spec.yaml explicitly.

## Why is this important?

Downstream consumers are landing v2 OCI artifact support and need a way to know which format to emit when packing a kit. The natural lever is the kit's own `schemaVersion`. Without this change, the spec library would reject `schemaVersion: "2"` at validation, blocking the rollout.

The default stays at `"1"` so kits authored today don't start emitting v2 artifacts that older consumers in the wild can't read. Once enough consumers ship v2-capable releases, a follow-up PR flips the default to `"2"`.

## Changes

**`spec/types.go`** — adds `SupportedSchemaVersions = []string{"1", "2"}` and updates the `SchemaVersion` doc comment to spell out the rollout plan (default stays `"1"`; `"2"` is opt-in until consumers catch up).

**`spec/validate.go`** — `ValidateManifest` switches from equality (`m.SchemaVersion != SchemaVersion`) to membership (`slices.Contains(SupportedSchemaVersions, m.SchemaVersion)`). The error message lists every supported value so a typo is easy to spot.

**`spec/validate_test.go`** — three new subtests:

- `schema_version_1_accepted` — legacy `"1"` still validates.
- `schema_version_2_accepted` — `"2"` now validates.
- `unsupported_schema_version` — anything else hard-fails with a message that names both the offending value and the supported list.

## Backward compatibility

Additive only. Existing kits with `schemaVersion: "1"` validate unchanged. The `SchemaVersion` const value is unchanged so any external code reading it (scaffolding tools, etc.) keeps seeing `"1"`. No existing call sites of `ValidateManifest` need updating.

## Test plan

- [x] `go test ./spec/...` passes (loader + validation + normalize)
- [x] `go test ./tck/...` passes (TCK fixtures stay at `schemaVersion: "1"` — matches the unchanged default)
- [x] Manual: a kit with `schemaVersion: "2"` loads without error
- [x] Manual: a kit with `schemaVersion: "99"` errors with a message naming the supported list
