### PR TITLE
fix(kits): drop version/sourceURL until parser fix ships

### DIFF
--- a/amp/spec.yaml
+++ b/amp/spec.yaml
@@ -1,10 +1,8 @@
 schemaVersion: "1"
 kind: agent
 name: amp
-version: "1.0.0"
 displayName: Amp
 description: The frontier coding agent.
-sourceURL: https://github.com/docker/sbx-kits-contrib/tree/main/amp
 
 agent:
   image: "docker/sandbox-templates:shell-docker"

--- a/claude-model-runner/spec.yaml
+++ b/claude-model-runner/spec.yaml
@@ -1,11 +1,9 @@
 schemaVersion: "1"
 kind: mixin
 name: claude-model-runner
-version: "1.0.0"
 extends: claude
 displayName: Claude Code (Docker Model Runner)
 description: Route Claude Code's Anthropic API calls to a local Docker Model Runner endpoint at host.docker.internal:12434.
-sourceURL: https://github.com/docker/sbx-kits-contrib/tree/main/claude-model-runner
 
 environment:
   variables:

--- a/claude-ollama/spec.yaml
+++ b/claude-ollama/spec.yaml
@@ -1,10 +1,8 @@
 schemaVersion: "1"
 kind: agent
 name: claude-ollama
-version: "1.0.0"
 displayName: Claude Code (Ollama)
 description: Claude Code wired to Ollama Anthropic-compatible API, with configurable model.
-sourceURL: https://github.com/docker/sbx-kits-contrib/tree/main/claude-ollama
 
 agent:
   image: "docker/sandbox-templates:claude-code-docker"

--- a/code-server/spec.yaml
+++ b/code-server/spec.yaml
@@ -1,11 +1,9 @@
 schemaVersion: "1"
 kind: mixin
 name: code-server
-version: "1.0.0"
 extends: claude
 displayName: code-server (web VS Code) with Claude Code
 description: Runs code-server on port 8080, opened on the sandbox workspace, with the Claude Code VS Code extension preinstalled. Pair with the built-in claude agent so the extension inherits the sandbox's Anthropic credentials.
-sourceURL: https://github.com/docker/sbx-kits-contrib/tree/main/code-server
 
 network:
   allowedDomains:

--- a/crush/spec.yaml
+++ b/crush/spec.yaml
@@ -1,10 +1,8 @@
 schemaVersion: "1"
 kind: agent
 name: crush
-version: "1.0.0"
 displayName: Crush
 description: Multi-provider AI coding agent from Charm, with proxy-mediated auth for 15 model providers.
-sourceURL: https://github.com/docker/sbx-kits-contrib/tree/main/crush
 
 agent:
   image: "docker/sandbox-templates:shell-docker"

--- a/git-ssh-sign/spec.yaml
+++ b/git-ssh-sign/spec.yaml
@@ -1,10 +1,8 @@
 schemaVersion: "1"
 kind: mixin
 name: git-ssh-sign
-version: "1.0.0"
 displayName: Git SSH Commit Signing
 description: Configures git to sign commits using the SSH key forwarded from the host's SSH agent.
-sourceURL: https://github.com/docker/sbx-kits-contrib/tree/main/git-ssh-sign
 
 commands:
   initFiles:

--- a/mise/spec.yaml
+++ b/mise/spec.yaml
@@ -1,10 +1,8 @@
 schemaVersion: "1"
 kind: mixin
 name: mise
-version: "1.0.0"
 displayName: mise (mise-en-place)
 description: "The polyglot dev-tool version manager (https://mise.jdx.dev) — installs the mise CLI and wires up shell activation so the agent can run `mise install`, `mise use`, and per-project `.mise.toml` resolutions in the sandbox."
-sourceURL: https://github.com/docker/sbx-kits-contrib/tree/main/mise
 
 network:
   allowedDomains:

--- a/nanobot/spec.yaml
+++ b/nanobot/spec.yaml
@@ -1,10 +1,8 @@
 schemaVersion: "1"
 kind: agent
 name: nanobot
-version: "1.0.0"
 displayName: Nanobot
 description: "Lightweight personal AI assistant with multi-platform chat and multi-provider LLM support"
-sourceURL: https://github.com/docker/sbx-kits-contrib/tree/main/nanobot
 
 agent:
   image: "docker/sandbox-templates:shell-docker"

--- a/nanoclaw/spec.yaml
+++ b/nanoclaw/spec.yaml
@@ -1,10 +1,8 @@
 schemaVersion: "1"
 kind: agent
 name: nanoclaw
-version: "1.0.0"
 displayName: NanoClaw
 description: "Lightweight AI assistant runtime driven by Claude Code; ships the CLI channel — chat platforms (WhatsApp, Telegram, Discord, …) add via upstream skills"
-sourceURL: https://github.com/docker/sbx-kits-contrib/tree/main/nanoclaw
 
 agent:
   image: "docker/sandbox-templates:claude-code-docker"

--- a/openclaw/spec.yaml
+++ b/openclaw/spec.yaml
@@ -1,10 +1,8 @@
 schemaVersion: "1"
 kind: agent
 name: openclaw
-version: "1.0.0"
 displayName: OpenClaw
 description: "Personal AI assistant with multi-platform chat, skills, and gateway support"
-sourceURL: https://github.com/docker/sbx-kits-contrib/tree/main/openclaw
 
 agent:
   image: "docker/sandbox-templates:shell-docker"

--- a/opencode-model-runner/spec.yaml
+++ b/opencode-model-runner/spec.yaml
@@ -1,10 +1,8 @@
 schemaVersion: "1"
 kind: agent
 name: opencode-model-runner
-version: "1.0.0"
 displayName: OpenCode (Docker Model Runner)
 description: OpenCode wired to a local Docker Model Runner instance via its OpenAI-compatible API, with automatic model discovery.
-sourceURL: https://github.com/docker/sbx-kits-contrib/tree/main/opencode-model-runner
 
 agent:
   image: "docker/sandbox-templates:opencode-docker"

--- a/pi/spec.yaml
+++ b/pi/spec.yaml
@@ -1,10 +1,8 @@
 schemaVersion: "1"
 kind: agent
 name: pi
-version: "1.0.0"
 displayName: Pi
 description: "Minimal terminal coding agent with extensible tools, skills, and TUI"
-sourceURL: https://github.com/docker/sbx-kits-contrib/tree/main/pi
 
 agent:
   image: "docker/sandbox-templates:shell-docker"

--- a/task/spec.yaml
+++ b/task/spec.yaml
@@ -1,10 +1,8 @@
 schemaVersion: "1"
 kind: mixin
 name: task
-version: "1.0.0"
 displayName: Task
 description: Installs the Task CLI so sandbox agents can run Taskfiles.
-sourceURL: https://github.com/docker/sbx-kits-contrib/tree/main/task
 
 network:
   allowedDomains:

--- a/trivy/spec.yaml
+++ b/trivy/spec.yaml
@@ -1,10 +1,8 @@
 schemaVersion: "1"
 kind: agent
 name: trivy
-version: "1.0.0"
 displayName: Trivy
 description: "Aqua's open source vulnerability scanner — sandboxed because security scanners shouldn't be able to compromise their hosts (TeamPCP, March 2026)."
-sourceURL: https://github.com/docker/sbx-kits-contrib/tree/main/trivy
 
 agent:
   image: "docker/sandbox-templates:shell-docker"

--- a/vale/spec.yaml
+++ b/vale/spec.yaml
@@ -1,10 +1,8 @@
 schemaVersion: "1"
 kind: mixin
 name: vale
-version: "1.0.0"
 displayName: Vale
 description: Installs the latest Vale prose linter from GitHub releases.
-sourceURL: https://github.com/docker/sbx-kits-contrib/tree/main/vale
 
 network:
   allowedDomains:


### PR DESCRIPTION
## What's changed

Strips the `version` and `sourceURL` fields from all 15 kit `spec.yaml` files. The library-side additions from #44 (`Manifest.Version`, `Manifest.SourceURL`, `LoadFromBytes`) stay in place — only the kit spec files are rolled back.

## Why is this important?

The released sbx CLI (v0.30.0 and earlier) ships a strict YAML decoder that rejects unknown `spec.yaml` keys. Now that #44 has added `version` and `sourceURL` to every kit on `main`, anyone on a released sbx version hits this when referencing a kit by git URL:

```
ERROR: resolve kits: kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=task":
  artifact: invalid spec.yaml: yaml: unmarshal errors:
    line 4: field version not found in type spec.specFile
    line 7: field sourceURL not found in type spec.specFile
```

A parser-side fix (relaxed decoder that ignores unknown optional fields) is in flight, but until it ships in a new sbx release and users update, every consumer pulling these kits via `git+https://...` is broken. Users do not pin to a specific commit, so they get whatever is on `main` — which means the kit-side rollback is the only lever we have today.

The fields can be re-added once the relaxed parser is widely deployed and the dust settles.

## Workaround (until this PR lands)

Users on a released sbx CLI can pin their `--kit` reference to the commit right before `v0.3.0` was tagged — that commit doesn't carry the new fields yet, so the strict parser accepts it:

```bash
# Pin to ea5224d (the commit just before v0.3.0)
sbx create \
  --kit "git+https://github.com/docker/sbx-kits-contrib.git#ref=ea5224d95d77&dir=task" \
  --kit "git+https://github.com/docker/sbx-kits-contrib.git#ref=ea5224d95d77&dir=git-ssh-sign" \
  claude --name fix-fleet --branch fix-fleet .
```

Full SHA: `ea5224d95d7774399af2d9f0eabfc99ef3319d77`. The same pin works for every other kit subdirectory — replace `task`/`git-ssh-sign` with the kit name you need.

This workaround stops being necessary once this PR merges; tracking `main` then works again from a released sbx.

## Changes

All 15 kits stripped of two lines each:

- `version: "1.0.0"`
- `sourceURL: https://github.com/docker/sbx-kits-contrib/tree/main/<kit>`

Affected kits: `amp`, `claude-model-runner`, `claude-ollama`, `code-server`, `crush`, `git-ssh-sign`, `mise`, `nanobot`, `nanoclaw`, `openclaw`, `opencode-model-runner`, `pi`, `task`, `trivy`, `vale`. Every other field in every kit is untouched.

## Test plan

- [x] `go test ./spec/...` passes
- [x] `go test ./tck/...` passes (each per-kit TCK loads its spec)
- [x] `grep -lE '^(version|sourceURL):' */spec.yaml` returns empty
- [x] Manual: `sbx create --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=task" --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=git-ssh-sign" claude --name fix-fleet --branch fix-fleet .` succeeds against a released sbx CLI

## Related issues

Partially reverts #44 — keeps the library-side additions (`Manifest.Version`, `Manifest.SourceURL`, `LoadFromBytes`) but removes the kit-side `spec.yaml` additions until the relaxed parser ships in a new sbx release.
