### PR TITLE
Add packages-through-sfw kit

### DIFF
--- a/packages-through-sfw/README.md
+++ b/packages-through-sfw/README.md
@@ -1,0 +1,89 @@
+# Packages through SFW
+
+A mixin that installs [Socket Firewall Free](https://socket.dev/) (`sfw`)
+and routes `npm`, `pip`, `pip3`, and `python3 -m pip` package-manager
+commands through it inside a Docker Sandbox when they are resolved through
+`PATH`.
+
+Socket Firewall Free runs without Socket API keys or configuration files.
+This kit targets public npm and PyPI package installs. Private registries,
+custom registries, and organization policy features require Socket Firewall
+Enterprise or a forked kit with the right network and credential wiring.
+
+## Usage
+
+Run it with any agent kit or built-in agent:
+
+```console
+$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=packages-through-sfw" <agent>
+```
+
+For local development, point `--kit` at this directory:
+
+```console
+$ sbx run --kit ./packages-through-sfw/ <agent>
+```
+
+After the sandbox starts, package-manager commands invoked by name are routed
+through `sfw`:
+
+```console
+$ sfw --version
+$ npm view is-odd version
+$ python3 -m pip index versions pyfiglet
+$ pip index versions pyfiglet
+```
+
+## How the install works
+
+The kit installs Node.js, npm, Python pip, curl, and CA certificates from
+the base image's apt repositories. It then downloads Socket Firewall Free
+v1.10.0 from the upstream GitHub release, verifies the binary against a
+SHA256 captured in `spec.yaml`, and installs it as `/usr/local/bin/sfw`.
+
+The initial install supports Linux `amd64` and `arm64`, which cover the
+normal Docker Desktop sandbox architectures.
+
+## How the wrappers work
+
+The kit installs PATH shims in `/usr/local/bin` for `npm`, `pip`, `pip3`,
+and `python3`. That catches non-interactive agent tool calls as long as the
+tool is invoked by name:
+
+```sh
+npm:  PATH="/usr/sbin:/usr/bin:/sbin:/bin" /usr/local/bin/sfw npm "$@"
+pip:  exec env -u PIP_CERT -u REQUESTS_CA_BUNDLE -u SSL_CERT_FILE PATH="/usr/sbin:/usr/bin:/sbin:/bin" /usr/local/bin/sfw pip "$@"
+pip3: exec env -u PIP_CERT -u REQUESTS_CA_BUNDLE -u SSL_CERT_FILE PATH="/usr/sbin:/usr/bin:/sbin:/bin" /usr/local/bin/sfw pip3 "$@"
+python3 -m pip: exec env -u PIP_CERT -u REQUESTS_CA_BUNDLE -u SSL_CERT_FILE PATH="/usr/sbin:/usr/bin:/sbin:/bin" /usr/local/bin/sfw pip "$@"
+```
+
+The restricted `PATH` keeps `sfw` from recursively calling the shim. The
+`python3` shim only intercepts `python3 -m pip ...`; all other Python
+commands delegate to the real interpreter. The pip shims clear Python CA
+override variables so Socket Firewall can provide the certificate environment
+for its local wrapper proxy under the sandbox egress proxy.
+
+For interactive shells, the kit also writes shell functions to
+`/etc/profile.d/packages-through-sfw.sh` and sources that file from the agent
+user's `~/.bashrc`. Those functions delegate to the PATH shims.
+
+## Scope and bypasses
+
+Direct absolute paths such as `/usr/bin/npm`, `/usr/bin/python3 -m pip`, or
+`venv/bin/python -m pip` bypass Socket Firewall because they do not resolve
+through `PATH`. Virtualenv entrypoints such as `venv/bin/pip` do the same.
+The kit does not rewrite venv interpreters or entrypoints because that can
+break Python tooling. Docker Sandbox egress policy still controls which hosts
+those commands can reach, but Socket Firewall analysis only applies when the
+package-manager command goes through `sfw`.
+
+## Network policy
+
+The kit's network allowlist covers:
+
+- GitHub release hosts for the pinned `sfw` binary download
+- Socket API hosts used by Socket Firewall Free
+- the public npm registry
+- PyPI package metadata and file hosts
+
+Add any extra package registries in a fork or with a per-sandbox policy rule.

--- a/packages-through-sfw/packages_through_sfw_tck_test.go
+++ b/packages-through-sfw/packages_through_sfw_tck_test.go
@@ -1,0 +1,55 @@
+package packages_through_sfw_test
+
+import (
+	"testing"
+
+	"github.com/docker/sbx-kits-contrib/spec"
+	"github.com/docker/sbx-kits-contrib/tck"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPackagesThroughSFWTCK(t *testing.T) {
+	suite, err := tck.NewSuiteFromDir(".")
+	require.NoError(t, err)
+	suite.RunAll(t)
+}
+
+func TestPackagesThroughSFWSpecPinsReleaseAndWrappers(t *testing.T) {
+	artifact, err := spec.LoadFromDirectory(".")
+	require.NoError(t, err)
+
+	require.Equal(t, "packages-through-sfw", artifact.Manifest.Name)
+	require.NotNil(t, artifact.Commands)
+	require.Len(t, artifact.Commands.Install, 4)
+
+	installSFW := artifact.Commands.Install[1].Command
+	require.Contains(t, installSFW, "SFW_VERSION=1.10.0")
+	require.Contains(t, installSFW, "sfw-free-linux-x86_64")
+	require.Contains(t, installSFW, "1ea16f15f1217bde66ac9c7d0262c7126b7bb1b2d60e14e8fa0982456139ae6e")
+	require.Contains(t, installSFW, "sfw-free-linux-arm64")
+	require.Contains(t, installSFW, "d7e969c17e6d23ac1cb0dea81ff87ef9bca2d83570270d91aab14b2a7fb66ad4")
+
+	wrapperInstall := artifact.Commands.Install[2].Command
+	require.Contains(t, wrapperInstall, "mkdir -p /usr/local/lib/packages-through-sfw/shims")
+	require.Contains(t, wrapperInstall, "install -m 0755 /usr/local/lib/packages-through-sfw/shims/npm /usr/local/bin/npm")
+	require.Contains(t, wrapperInstall, "install -m 0755 /usr/local/lib/packages-through-sfw/shims/pip /usr/local/bin/pip")
+	require.Contains(t, wrapperInstall, "install -m 0755 /usr/local/lib/packages-through-sfw/shims/pip3 /usr/local/bin/pip3")
+	require.Contains(t, wrapperInstall, "install -m 0755 /usr/local/lib/packages-through-sfw/shims/python3 /usr/local/bin/python3")
+	require.Contains(t, wrapperInstall, `PATH="/usr/sbin:/usr/bin:/sbin:/bin" exec /usr/local/bin/sfw npm "$@"`)
+	require.Contains(t, wrapperInstall, `exec env -u PIP_CERT -u REQUESTS_CA_BUNDLE -u SSL_CERT_FILE PATH="/usr/sbin:/usr/bin:/sbin:/bin" /usr/local/bin/sfw pip "$@"`)
+	require.Contains(t, wrapperInstall, `exec env -u PIP_CERT -u REQUESTS_CA_BUNDLE -u SSL_CERT_FILE PATH="/usr/sbin:/usr/bin:/sbin:/bin" /usr/local/bin/sfw pip3 "$@"`)
+	require.Contains(t, wrapperInstall, `if [ "$1" = "-m" ] && [ "$2" = "pip" ]; then`)
+	require.Contains(t, wrapperInstall, `PATH="/usr/sbin:/usr/bin:/sbin:/bin" exec python3 "$@"`)
+	require.Contains(t, wrapperInstall, "/etc/profile.d/packages-through-sfw.sh")
+	require.Contains(t, wrapperInstall, `npm() { /usr/local/bin/npm "$@"; }`)
+	require.Contains(t, wrapperInstall, `pip() { /usr/local/bin/pip "$@"; }`)
+	require.Contains(t, wrapperInstall, `pip3() { /usr/local/bin/pip3 "$@"; }`)
+	require.NotContains(t, wrapperInstall, "/usr/local/lib/packages-through-sfw/real-bin")
+
+	bashrcInstall := artifact.Commands.Install[3]
+	require.Equal(t, "1000", bashrcInstall.User)
+	require.Contains(t, bashrcInstall.Command, "~/.bashrc")
+	require.Contains(t, bashrcInstall.Command, "[ -f /etc/profile.d/packages-through-sfw.sh ] && . /etc/profile.d/packages-through-sfw.sh")
+	require.NotContains(t, bashrcInstall.Command, "/home/agent/.bashrc")
+	require.NotContains(t, bashrcInstall.Command, "chown 1000:1000")
+}

--- a/packages-through-sfw/spec.yaml
+++ b/packages-through-sfw/spec.yaml
@@ -1,0 +1,100 @@
+schemaVersion: "1"
+kind: mixin
+name: packages-through-sfw
+displayName: Packages through SFW
+description: "Installs Socket Firewall Free and routes npm, pip, pip3, and python3 -m pip commands through sfw when resolved through PATH."
+
+network:
+  allowedDomains:
+    - "github.com:443"
+    - "release-assets.githubusercontent.com:443"
+    - "api.socket.dev:443"
+    - "socket.dev:443"
+    - "registry.npmjs.org:443"
+    - "pypi.org:443"
+    - "files.pythonhosted.org:443"
+
+commands:
+  install:
+    - command: "apt-get update && apt-get install -y --no-install-recommends ca-certificates curl nodejs npm python3-pip && rm -rf /var/lib/apt/lists/*"
+      user: "0"
+      description: Install package-manager prerequisites
+    - command: |
+        set -euo pipefail
+        SFW_VERSION=1.10.0
+        case "$(uname -m)" in
+          x86_64|amd64)
+            ASSET="sfw-free-linux-x86_64"
+            SHA256="1ea16f15f1217bde66ac9c7d0262c7126b7bb1b2d60e14e8fa0982456139ae6e"
+            ;;
+          aarch64|arm64)
+            ASSET="sfw-free-linux-arm64"
+            SHA256="d7e969c17e6d23ac1cb0dea81ff87ef9bca2d83570270d91aab14b2a7fb66ad4"
+            ;;
+          *)
+            echo "unsupported sandbox arch: $(uname -m) (expected amd64 or arm64)" >&2
+            exit 1
+            ;;
+        esac
+        URL="https://github.com/SocketDev/sfw-free/releases/download/v${SFW_VERSION}/${ASSET}"
+        curl --proto '=https' --tlsv1.2 -fsSL -o /tmp/sfw "$URL"
+        echo "${SHA256}  /tmp/sfw" | sha256sum -c -
+        install -m 0755 /tmp/sfw /usr/local/bin/sfw
+        rm -f /tmp/sfw
+        sfw --version
+      user: "0"
+      description: "Install Socket Firewall Free v1.10.0, version+digest pinned"
+    - command: |
+        set -euo pipefail
+        mkdir -p /usr/local/lib/packages-through-sfw/shims
+
+        cat > /usr/local/lib/packages-through-sfw/shims/npm <<'SCRIPT'
+        #!/bin/sh
+        PATH="/usr/sbin:/usr/bin:/sbin:/bin" exec /usr/local/bin/sfw npm "$@"
+        SCRIPT
+
+        cat > /usr/local/lib/packages-through-sfw/shims/pip <<'SCRIPT'
+        #!/bin/sh
+        exec env -u PIP_CERT -u REQUESTS_CA_BUNDLE -u SSL_CERT_FILE PATH="/usr/sbin:/usr/bin:/sbin:/bin" /usr/local/bin/sfw pip "$@"
+        SCRIPT
+
+        cat > /usr/local/lib/packages-through-sfw/shims/pip3 <<'SCRIPT'
+        #!/bin/sh
+        exec env -u PIP_CERT -u REQUESTS_CA_BUNDLE -u SSL_CERT_FILE PATH="/usr/sbin:/usr/bin:/sbin:/bin" /usr/local/bin/sfw pip3 "$@"
+        SCRIPT
+
+        cat > /usr/local/lib/packages-through-sfw/shims/python3 <<'SCRIPT'
+        #!/bin/sh
+        if [ "$1" = "-m" ] && [ "$2" = "pip" ]; then
+          shift 2
+          exec env -u PIP_CERT -u REQUESTS_CA_BUNDLE -u SSL_CERT_FILE PATH="/usr/sbin:/usr/bin:/sbin:/bin" /usr/local/bin/sfw pip "$@"
+        fi
+        PATH="/usr/sbin:/usr/bin:/sbin:/bin" exec python3 "$@"
+        SCRIPT
+
+        install -m 0755 /usr/local/lib/packages-through-sfw/shims/npm /usr/local/bin/npm
+        install -m 0755 /usr/local/lib/packages-through-sfw/shims/pip /usr/local/bin/pip
+        install -m 0755 /usr/local/lib/packages-through-sfw/shims/pip3 /usr/local/bin/pip3
+        install -m 0755 /usr/local/lib/packages-through-sfw/shims/python3 /usr/local/bin/python3
+
+        cat > /etc/profile.d/packages-through-sfw.sh <<'SCRIPT'
+        # Route package-manager installs through Socket Firewall Free.
+        if [ -x /usr/local/bin/npm ]; then
+          npm() { /usr/local/bin/npm "$@"; }
+        fi
+        if [ -x /usr/local/bin/pip ]; then
+          pip() { /usr/local/bin/pip "$@"; }
+        fi
+        if [ -x /usr/local/bin/pip3 ]; then
+          pip3() { /usr/local/bin/pip3 "$@"; }
+        fi
+        SCRIPT
+        chmod 0644 /etc/profile.d/packages-through-sfw.sh
+      user: "0"
+      description: Configure sfw PATH shims and shell wrappers
+    - command: |
+        set -euo pipefail
+        grep -qF '/etc/profile.d/packages-through-sfw.sh' ~/.bashrc 2>/dev/null || \
+          printf '\n# Packages through SFW wrappers (added by sbx-kits-contrib/packages-through-sfw)\n[ -f /etc/profile.d/packages-through-sfw.sh ] && . /etc/profile.d/packages-through-sfw.sh\n' >> ~/.bashrc
+      user: "1000"
+      description: Source sfw wrappers from ~/.bashrc for interactive Bash shells


### PR DESCRIPTION
## Summary

  Adds a `socket-firewall` mixin kit that installs Socket Firewall Free (`sfw`) and routes npm/PyPI package-manager commands through it when
  resolved through PATH.

  ## Spec choices worth flagging for review

  - Installs pinned Socket Firewall Free v1.10.0 with per-arch SHA256 checks.
  - Uses PATH shims for `npm`, `pip`, `pip3`, and `python3 -m pip` so non-interactive agent tool calls are covered.
  - Direct paths such as `/usr/bin/npm` and venv paths such as `venv/bin/python -m pip` intentionally bypass Socket Firewall; SBX egress still
  applies.
  - Pip wrappers unset Python CA override variables so `sfw pip` works under the sandbox proxy.

  ## Test plan

  - Fast TCK/spec validation passed.
  - Manual `sbx run --kit ./socket-firewall codex`
  - Verified `npm`, `pip`, `pip3`, and `python3 -m pip` route through Socket Firewall.
  - Full TCK container test was not run locally because rootless Docker was unavailable.

