### PR TITLE
feat(tck): add e2e test running kits against real sbx CLI

### DIFF
--- a/.github/workflows/tck.yml
+++ b/.github/workflows/tck.yml
@@ -208,7 +208,12 @@ jobs:
           # surfaces login/test failures clearly even though they share a
           # step in the GHA UI.
           dbus-run-session -- bash -e <<'EOF'
-          printf '\n' | gnome-keyring-daemon --start --unlock --components=secrets >/dev/null
+          # --unlock reads the passphrase from stdin, creates the default
+          # "login" keyring if missing, unlocks it, and daemonizes. Passing
+          # an empty stdin gives the keyring an empty passphrase, which is
+          # fine for a throwaway runner. --start cannot be combined with
+          # --unlock (they're mutually exclusive in gnome-keyring-daemon).
+          printf '' | gnome-keyring-daemon --unlock --components=secrets >/dev/null
 
           printf '%s' "$TOKEN_CLEAN" | sbx login --username "$USER_CLEAN" --password-stdin
 

--- a/.github/workflows/tck.yml
+++ b/.github/workflows/tck.yml
@@ -167,68 +167,66 @@ jobs:
       - name: Verify sbx installation
         run: sbx version
 
-      - name: Unlock keyring (Secret Service for sbx login)
-        # sbx's released Linux binary persists credentials via libsecret
-        # (the OS keychain on Linux), which needs a running Secret Service
-        # provider on D-Bus. GHA's ubuntu-latest is headless, so we install
-        # gnome-keyring + dbus-x11, start a persistent dbus session, unlock
-        # gnome-keyring-daemon with an empty passphrase, and write
-        # DBUS_SESSION_BUS_ADDRESS, GNOME_KEYRING_CONTROL, and SSH_AUTH_SOCK
-        # to $GITHUB_ENV so subsequent steps can reach the daemon.
+      - name: Set up Secret Service for sbx login
+        # sbx's released Linux binary persists credentials via libsecret,
+        # which talks to org.freedesktop.secrets over D-Bus. GHA's
+        # ubuntu-latest is headless, so no Secret Service is running and
+        # `sbx login` blocks. The recipe below mirrors the maintainers'
+        # own CI script in docker/secrets-engine
+        # (store/scripts/gnome-keyring), which is the canonical reference:
         #
-        # Three earlier-iteration traps this avoids:
-        #   1. `dbus-run-session` instead of `dbus-launch`: dbus-run-session
-        #      kills the bus when its wrapped command exits; dbus-launch
-        #      leaves a persistent bus behind.
-        #   2. `printf ''` instead of `echo ''`: printf '' sends raw EOF
-        #      with no newline, and the daemon falls through to launching
-        #      gcr-prompter for interactive entry. echo '' sends a newline,
-        #      which the daemon accepts as "empty password, terminated".
-        #   3. Not propagating the daemon's env vars to subsequent steps:
-        #      without GNOME_KEYRING_CONTROL exported, sbx can't find the
-        #      running daemon and `s.Upsert` fails with a D-Bus path error.
+        #   1. Install gnome-keyring + dbus-daemon.
+        #   2. Pre-create ~/.local/share/keyrings/login.keyring as a
+        #      passwordless ini stanza. With the file already on disk,
+        #      `gnome-keyring-daemon --start` adopts it instead of
+        #      prompting via gcr-prompter for a password — that prompt
+        #      activation was the root cause of every earlier iteration
+        #      failing on headless runners.
+        #   3. Start a dbus session bus (dbus-daemon, not dbus-launch or
+        #      dbus-run-session — the former leaves no persistent bus,
+        #      the latter dies when its wrapped command exits).
+        #   4. Start gnome-keyring-daemon's secrets component.
+        #   5. Poll until org.freedesktop.secrets is owned on D-Bus
+        #      before letting the next step run sbx.
         #
-        # This is the same shape as the t1m0thyj/unlock-keyring action,
-        # inlined here so the dependency stays first-party.
+        # Both DBUS_SESSION_BUS_ADDRESS and the daemon's env are exported
+        # to $GITHUB_ENV so the sbx login + go test steps inherit them.
         run: |
           set -euo pipefail
           sudo apt-get update -qq
-          sudo apt-get install -y -qq dbus-x11 gnome-keyring libsecret-tools
+          sudo apt-get install -y -qq gnome-keyring dbus
 
-          # Parse `KEY='VALUE';` or `KEY=VALUE` lines from a command's
-          # stdout, strip the dbus/keyring quoting, and propagate to both
-          # the current shell and $GITHUB_ENV so the next step sees them.
-          capture_env() {
-            while IFS= read -r line; do
-              if [[ "$line" =~ ^([A-Za-z_][A-Za-z0-9_]*)=\'?(.+)$ ]]; then
-                name="${BASH_REMATCH[1]}"
-                value="${BASH_REMATCH[2]}"
-                value="${value%;}"
-                value="${value%\'}"
-                printf '%s=%s\n' "$name" "$value" >> "$GITHUB_ENV"
-                export "$name=$value"
-              fi
-            done
-          }
+          mkdir -p "$HOME/.local/share/keyrings"
+          cat > "$HOME/.local/share/keyrings/login.keyring" <<'KEYRING'
+          [keyring]
+          display-name=login
+          ctime=1750965549
+          mtime=0
+          lock-on-idle=false
+          lock-after=false
+          KEYRING
 
-          # 1. Start a persistent dbus session bus.
-          dbus-launch --sh-syntax | capture_env
+          DBUS_SESSION_BUS_ADDRESS=$(dbus-daemon --session --print-address --fork)
+          echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS" >> "$GITHUB_ENV"
+          export DBUS_SESSION_BUS_ADDRESS
 
-          # 2. Unlock gnome-keyring with an empty passphrase. echo ''
-          #    sends a newline-terminated empty string, which the daemon
-          #    treats as "empty password" instead of falling through to
-          #    gcr-prompter.
-          echo '' | /usr/bin/gnome-keyring-daemon --unlock | capture_env
+          gnome-keyring-daemon --start --components=secrets >/dev/null
 
-          # 3. Force the default-collection alias to exist before sbx
-          #    tries to Upsert into it. gnome-keyring-daemon --unlock
-          #    unlocks the "login" keyring but on Ubuntu 24.04+ doesn't
-          #    automatically alias it to libsecret's "default" collection,
-          #    so sbx's first write hangs waiting on a prompt that never
-          #    arrives and times out after 10s. A throwaway secret-tool
-          #    write materialises the alias as a side effect.
-          printf 'init' | secret-tool store --label='init' init init
-          secret-tool clear init init
+          # Poll until the daemon registers on the bus. 5s is what the
+          # secrets-engine reference script uses.
+          for _ in $(seq 1 50); do
+            if gdbus call --session \
+                --dest org.freedesktop.DBus \
+                --object-path /org/freedesktop/DBus \
+                --method org.freedesktop.DBus.GetNameOwner \
+                org.freedesktop.secrets >/dev/null 2>&1; then
+              echo "Secret Service registered on D-Bus"
+              exit 0
+            fi
+            sleep 0.1
+          done
+          echo "Timed out waiting for org.freedesktop.secrets to register"
+          exit 1
 
       - name: Sign in to Docker Hub via sbx
         env:

--- a/.github/workflows/tck.yml
+++ b/.github/workflows/tck.yml
@@ -167,27 +167,28 @@ jobs:
       - name: Verify sbx installation
         run: sbx version
 
-      - name: Diagnose secret integrity
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Install Secret Service provider (gnome-keyring)
         run: |
-          # GH masking redacts secret values but NOT their lengths or sha256
-          # hashes (a hash is one-way; the secret itself never appears).
-          # Compare these two lines locally to detect paste-time mangling:
-          #   printf '%s' "$DOCKERHUB_USERNAME" | shasum -a 256
-          #   printf '%s' "$DOCKERHUB_TOKEN"    | shasum -a 256
-          # If sha256 or length differ, the GH-stored value has whitespace
-          # contamination (trailing newline, leading space, partial copy).
-          printf 'username len=%d sha256=' "${#DOCKERHUB_USERNAME}"
-          printf '%s' "$DOCKERHUB_USERNAME" | sha256sum | awk '{print $1}'
-          printf 'token    len=%d sha256=' "${#DOCKERHUB_TOKEN}"
-          printf '%s' "$DOCKERHUB_TOKEN"    | sha256sum | awk '{print $1}'
+          # sbx's released Linux binary persists credentials via libsecret
+          # (the OS keychain on Linux). GHA's ubuntu-latest runner has no
+          # graphical session, so no org.freedesktop.secrets provider exists
+          # and `sbx login` fails when it tries to upsert. We install
+          # gnome-keyring and unlock it with an empty passphrase inside a
+          # dbus-run-session in the next step. The filestore backend in
+          # sandboxlib/auth/store_local.go is build-tag-gated and isn't in
+          # the released artifact, so this is the only path until that
+          # changes.
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq gnome-keyring
 
-      - name: Sign in to Docker Hub via sbx
+      - name: Run e2e TCK for ${{ matrix.kit }}
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          # detect-changes emits bare directory names; go test cd's into the
+          # package dir, so anchor against $GITHUB_WORKSPACE to resolve to
+          # the repo-root kit directory rather than ./tck/<kit>.
+          KIT_UNDER_TEST: ${{ github.workspace }}/${{ matrix.kit }}
         run: |
           if [ -z "${DOCKERHUB_USERNAME}" ] || [ -z "${DOCKERHUB_TOKEN}" ]; then
             echo "DOCKERHUB_USERNAME / DOCKERHUB_TOKEN not configured; cannot run e2e."
@@ -195,23 +196,23 @@ jobs:
           fi
           # Defensive trim: GH preserves any whitespace pasted into the
           # secret editor, and sbx's readPasswordStdin only strips trailing
-          # \r\n. Strip ALL whitespace from both values — Hub usernames are
-          # alphanumeric + hyphens and PATs are alphanumeric + hyphens, so
-          # tr -d cannot corrupt a legitimate credential.
-          USER_CLEAN=$(printf '%s' "$DOCKERHUB_USERNAME" | tr -d '[:space:]')
-          TOKEN_CLEAN=$(printf '%s' "$DOCKERHUB_TOKEN"    | tr -d '[:space:]')
+          # \r\n. Hub usernames and PATs are alphanumeric + hyphens, so
+          # stripping all whitespace can't corrupt a legitimate value.
+          export USER_CLEAN=$(printf '%s' "$DOCKERHUB_USERNAME" | tr -d '[:space:]')
+          export TOKEN_CLEAN=$(printf '%s' "$DOCKERHUB_TOKEN"    | tr -d '[:space:]')
+
+          # Bundle login + test + logout inside one dbus session so every
+          # sbx command sees the same unlocked keyring. Splitting into
+          # separate steps would put each command in its own shell, losing
+          # the daemon. -e exits the heredoc on the first failure, which
+          # surfaces login/test failures clearly even though they share a
+          # step in the GHA UI.
+          dbus-run-session -- bash -e <<'EOF'
+          printf '\n' | gnome-keyring-daemon --start --unlock --components=secrets >/dev/null
+
           printf '%s' "$TOKEN_CLEAN" | sbx login --username "$USER_CLEAN" --password-stdin
 
-      - name: Run e2e TCK for ${{ matrix.kit }}
-        env:
-          # detect-changes emits bare directory names (`dirname "$f"`), and
-          # `go test ./tck/...` runs the binary with cwd set to the package
-          # dir. Anchor against $GITHUB_WORKSPACE so the test resolves to the
-          # repo-root kit directory rather than ./tck/<kit>.
-          KIT_UNDER_TEST: ${{ github.workspace }}/${{ matrix.kit }}
-        run: |
           go test -tags=e2e -v -timeout 25m -count=1 -run TestE2ECreateSandbox ./tck/...
 
-      - name: Sign out of Docker Hub
-        if: always()
-        run: sbx logout --yes || true
+          sbx logout --yes || true
+          EOF

--- a/.github/workflows/tck.yml
+++ b/.github/workflows/tck.yml
@@ -138,16 +138,19 @@ jobs:
           ls -la /dev/kvm
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
-      - name: Download latest sbx release
+      - name: Download sbx release
         run: |
           set -euo pipefail
           # docker/sbx-releases is a public repo; no auth needed to read.
-          # Resolve the latest stable tag via the redirect target of
-          # /releases/latest so we don't hardcode a version.
-          LATEST_URL=$(curl -fsSLI -o /dev/null -w '%{url_effective}' \
-            https://github.com/docker/sbx-releases/releases/latest)
-          VERSION="${LATEST_URL##*/}"
-          echo "Resolved latest sbx version: ${VERSION}"
+          #
+          # Pinned to v0.31.0-rc1 because the latest stable (v0.30.0) ships
+          # the JWKS-verifier path of `sbx login`, which rejects every Docker
+          # Hub PAT-issued JWT with "docker hub token is invalid". Fixed in
+          # docker/sandboxes#2969, first reachable from v0.31.0-rc1. Revisit
+          # this pin once a stable release with the fix ships and bump back
+          # to /releases/latest resolution.
+          VERSION="v0.31.0-rc1"
+          echo "Pinned sbx version: ${VERSION}"
           echo "SBX_VERSION=${VERSION}" >> "$GITHUB_ENV"
 
           curl -fsSL \

--- a/.github/workflows/tck.yml
+++ b/.github/workflows/tck.yml
@@ -193,7 +193,7 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get update -qq
-          sudo apt-get install -y -qq dbus-x11 gnome-keyring
+          sudo apt-get install -y -qq dbus-x11 gnome-keyring libsecret-tools
 
           # Parse `KEY='VALUE';` or `KEY=VALUE` lines from a command's
           # stdout, strip the dbus/keyring quoting, and propagate to both
@@ -219,6 +219,16 @@ jobs:
           #    treats as "empty password" instead of falling through to
           #    gcr-prompter.
           echo '' | /usr/bin/gnome-keyring-daemon --unlock | capture_env
+
+          # 3. Force the default-collection alias to exist before sbx
+          #    tries to Upsert into it. gnome-keyring-daemon --unlock
+          #    unlocks the "login" keyring but on Ubuntu 24.04+ doesn't
+          #    automatically alias it to libsecret's "default" collection,
+          #    so sbx's first write hangs waiting on a prompt that never
+          #    arrives and times out after 10s. A throwaway secret-tool
+          #    write materialises the alias as a side effect.
+          printf 'init' | secret-tool store --label='init' init init
+          secret-tool clear init init
 
       - name: Sign in to Docker Hub via sbx
         env:

--- a/.github/workflows/tck.yml
+++ b/.github/workflows/tck.yml
@@ -104,3 +104,87 @@ jobs:
 
       - name: Run TCK self-tests
         run: go test -v -timeout 30m -count=1 ./spec/... ./tck/...
+
+  test-kit-e2e:
+    # End-to-end test: install the latest released sbx, authenticate against
+    # Docker Hub non-interactively, and run `sbx create --kit <kit> claude <tmp>`
+    # to prove the kit composes with a real CLI. Skipped for fork PRs because
+    # the Docker Hub secrets are not exposed there.
+    needs: detect-changes
+    if: >-
+      (github.event_name == 'push' ||
+       github.event.pull_request.head.repo.full_name == github.repository) &&
+      needs.detect-changes.outputs.kits != '[]' &&
+      needs.detect-changes.outputs.kits != 'null' &&
+      needs.detect-changes.outputs.kits != ''
+    strategy:
+      fail-fast: false
+      matrix:
+        kit: ${{ fromJson(needs.detect-changes.outputs.kits) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Enable KVM access
+        run: |
+          sudo chmod 666 /dev/kvm
+          ls -la /dev/kvm
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
+      - name: Download latest sbx release
+        run: |
+          set -euo pipefail
+          # docker/sbx-releases is a public repo; no auth needed to read.
+          # Resolve the latest stable tag via the redirect target of
+          # /releases/latest so we don't hardcode a version.
+          LATEST_URL=$(curl -fsSLI -o /dev/null -w '%{url_effective}' \
+            https://github.com/docker/sbx-releases/releases/latest)
+          VERSION="${LATEST_URL##*/}"
+          echo "Resolved latest sbx version: ${VERSION}"
+          echo "SBX_VERSION=${VERSION}" >> "$GITHUB_ENV"
+
+          curl -fsSL \
+            "https://github.com/docker/sbx-releases/releases/download/${VERSION}/DockerSandboxes-linux.tar.gz" \
+            -o /tmp/DockerSandboxes-linux.tar.gz
+          tar xzf /tmp/DockerSandboxes-linux.tar.gz -C /tmp
+
+      - name: Install sbx
+        run: |
+          set -euo pipefail
+          sudo PREFIX="${HOME}/.docker/sbx" /tmp/docker-sbx/install.sh
+          echo "${HOME}/.docker/sbx/bin" >> "$GITHUB_PATH"
+
+      - name: Verify sbx installation
+        run: sbx version
+
+      - name: Sign in to Docker Hub via sbx
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          if [ -z "${DOCKERHUB_USERNAME}" ] || [ -z "${DOCKERHUB_TOKEN}" ]; then
+            echo "DOCKERHUB_USERNAME / DOCKERHUB_TOKEN not configured; cannot run e2e."
+            exit 1
+          fi
+          printf '%s' "${DOCKERHUB_TOKEN}" | sbx login --username "${DOCKERHUB_USERNAME}" --password-stdin
+
+      - name: Run e2e TCK for ${{ matrix.kit }}
+        env:
+          # detect-changes emits bare directory names (`dirname "$f"`), and
+          # `go test ./tck/...` runs the binary with cwd set to the package
+          # dir. Anchor against $GITHUB_WORKSPACE so the test resolves to the
+          # repo-root kit directory rather than ./tck/<kit>.
+          KIT_UNDER_TEST: ${{ github.workspace }}/${{ matrix.kit }}
+        run: |
+          go test -tags=e2e -v -timeout 25m -count=1 -run TestE2ECreateSandbox ./tck/...
+
+      - name: Sign out of Docker Hub
+        if: always()
+        run: sbx logout --yes || true

--- a/.github/workflows/tck.yml
+++ b/.github/workflows/tck.yml
@@ -167,6 +167,23 @@ jobs:
       - name: Verify sbx installation
         run: sbx version
 
+      - name: Diagnose secret integrity
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          # GH masking redacts secret values but NOT their lengths or sha256
+          # hashes (a hash is one-way; the secret itself never appears).
+          # Compare these two lines locally to detect paste-time mangling:
+          #   printf '%s' "$DOCKERHUB_USERNAME" | shasum -a 256
+          #   printf '%s' "$DOCKERHUB_TOKEN"    | shasum -a 256
+          # If sha256 or length differ, the GH-stored value has whitespace
+          # contamination (trailing newline, leading space, partial copy).
+          printf 'username len=%d sha256=' "${#DOCKERHUB_USERNAME}"
+          printf '%s' "$DOCKERHUB_USERNAME" | sha256sum | awk '{print $1}'
+          printf 'token    len=%d sha256=' "${#DOCKERHUB_TOKEN}"
+          printf '%s' "$DOCKERHUB_TOKEN"    | sha256sum | awk '{print $1}'
+
       - name: Sign in to Docker Hub via sbx
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -176,7 +193,14 @@ jobs:
             echo "DOCKERHUB_USERNAME / DOCKERHUB_TOKEN not configured; cannot run e2e."
             exit 1
           fi
-          printf '%s' "${DOCKERHUB_TOKEN}" | sbx login --username "${DOCKERHUB_USERNAME}" --password-stdin
+          # Defensive trim: GH preserves any whitespace pasted into the
+          # secret editor, and sbx's readPasswordStdin only strips trailing
+          # \r\n. Strip ALL whitespace from both values — Hub usernames are
+          # alphanumeric + hyphens and PATs are alphanumeric + hyphens, so
+          # tr -d cannot corrupt a legitimate credential.
+          USER_CLEAN=$(printf '%s' "$DOCKERHUB_USERNAME" | tr -d '[:space:]')
+          TOKEN_CLEAN=$(printf '%s' "$DOCKERHUB_TOKEN"    | tr -d '[:space:]')
+          printf '%s' "$TOKEN_CLEAN" | sbx login --username "$USER_CLEAN" --password-stdin
 
       - name: Run e2e TCK for ${{ matrix.kit }}
         env:

--- a/.github/workflows/tck.yml
+++ b/.github/workflows/tck.yml
@@ -174,12 +174,15 @@ jobs:
           # graphical session, so no org.freedesktop.secrets provider exists
           # and `sbx login` fails when it tries to upsert. We install
           # gnome-keyring and unlock it with an empty passphrase inside a
-          # dbus-run-session in the next step. The filestore backend in
-          # sandboxlib/auth/store_local.go is build-tag-gated and isn't in
-          # the released artifact, so this is the only path until that
-          # changes.
+          # dbus-run-session in the next step. libsecret-tools provides
+          # `secret-tool`, which we use to force-create the default
+          # collection (gnome-keyring-daemon --unlock alone leaves
+          # libsecret with no default collection alias). The filestore
+          # backend in sandboxlib/auth/store_local.go is build-tag-gated
+          # and isn't in the released artifact, so this is the only path
+          # until that changes.
           sudo apt-get update -qq
-          sudo apt-get install -y -qq gnome-keyring
+          sudo apt-get install -y -qq gnome-keyring libsecret-tools
 
       - name: Run e2e TCK for ${{ matrix.kit }}
         env:
@@ -208,12 +211,19 @@ jobs:
           # surfaces login/test failures clearly even though they share a
           # step in the GHA UI.
           dbus-run-session -- bash -e <<'EOF'
-          # --unlock reads the passphrase from stdin, creates the default
-          # "login" keyring if missing, unlocks it, and daemonizes. Passing
-          # an empty stdin gives the keyring an empty passphrase, which is
-          # fine for a throwaway runner. --start cannot be combined with
-          # --unlock (they're mutually exclusive in gnome-keyring-daemon).
-          printf '' | gnome-keyring-daemon --unlock --components=secrets >/dev/null
+          # Start daemonized gnome-keyring with the secrets component;
+          # --unlock reads the passphrase from stdin (empty here, which is
+          # fine for a throwaway runner). --start cannot be combined with
+          # --unlock — they're mutually exclusive.
+          printf '' | gnome-keyring-daemon --daemonize --unlock --components=secrets >/dev/null
+
+          # --unlock alone leaves libsecret with no default collection
+          # alias, so sbx's later s.Upsert fails with "Object does not
+          # exist at path /". Force the alias by storing+clearing a dummy
+          # secret via secret-tool, which materialises the default keyring
+          # as a side effect.
+          printf 'init' | secret-tool store --label='init' init init
+          secret-tool clear init init
 
           printf '%s' "$TOKEN_CLEAN" | sbx login --username "$USER_CLEAN" --password-stdin
 

--- a/.github/workflows/tck.yml
+++ b/.github/workflows/tck.yml
@@ -247,14 +247,21 @@ jobs:
 
       - name: Set sbx default network policy
         # `sbx create` refuses to run until a default network policy is
-        # configured. Pick `deny-all` as the e2e baseline so the kit's
-        # own `network.allowedDomains` declarations are exactly what
-        # determines outbound reachability — with `allow-all` we'd be
-        # hiding any misconfigured kit. Kit allow-rules are scoped per
-        # sandbox and punch through the default deny (see
-        # `ApplyKitNetworkPolicyScoped` in docker/sandboxes:
-        # sandboxd/pkg/server/options_governance.go). Kit deny-rules
-        # still win over allow-rules (deny-wins semantics).
+        # configured. `deny-all` is the strict baseline: a kit gets
+        # *exactly* the outbound reachability it declares in
+        # `network.allowedDomains` and nothing more. That makes the e2e
+        # run a real contract test — if a kit's install hooks reach for
+        # apt/npm mirrors it didn't list, the failure is real and
+        # actionable. Kit allow-rules are scoped per sandbox and punch
+        # through the default deny (see `ApplyKitNetworkPolicyScoped` in
+        # docker/sandboxes:sandboxd/pkg/server/options_governance.go); kit
+        # deny-rules win over allow-rules (deny-wins).
+        #
+        # The trade-off: kits that previously relied on `balanced`'s
+        # tier-zero allowances (Debian apt mirrors, default npm registry)
+        # have to enumerate those domains in their own `allowedDomains`.
+        # That's the philosophy this CI is enforcing — kits are
+        # self-contained network contracts.
         run: sbx policy set-default deny-all
 
       - name: Run e2e TCK for ${{ matrix.kit }}

--- a/.github/workflows/tck.yml
+++ b/.github/workflows/tck.yml
@@ -245,6 +245,18 @@ jobs:
           TOKEN_CLEAN=$(printf '%s' "$DOCKERHUB_TOKEN"    | tr -d '[:space:]')
           printf '%s' "$TOKEN_CLEAN" | sbx login --username "$USER_CLEAN" --password-stdin
 
+      - name: Set sbx default network policy
+        # `sbx create` refuses to run until a default network policy is
+        # configured. Pick `deny-all` as the e2e baseline so the kit's
+        # own `network.allowedDomains` declarations are exactly what
+        # determines outbound reachability — with `allow-all` we'd be
+        # hiding any misconfigured kit. Kit allow-rules are scoped per
+        # sandbox and punch through the default deny (see
+        # `ApplyKitNetworkPolicyScoped` in docker/sandboxes:
+        # sandboxd/pkg/server/options_governance.go). Kit deny-rules
+        # still win over allow-rules (deny-wins semantics).
+        run: sbx policy set-default deny-all
+
       - name: Run e2e TCK for ${{ matrix.kit }}
         env:
           # detect-changes emits bare directory names; go test cd's into the

--- a/.github/workflows/tck.yml
+++ b/.github/workflows/tck.yml
@@ -167,31 +167,63 @@ jobs:
       - name: Verify sbx installation
         run: sbx version
 
-      - name: Install Secret Service provider (gnome-keyring)
+      - name: Unlock keyring (Secret Service for sbx login)
+        # sbx's released Linux binary persists credentials via libsecret
+        # (the OS keychain on Linux), which needs a running Secret Service
+        # provider on D-Bus. GHA's ubuntu-latest is headless, so we install
+        # gnome-keyring + dbus-x11, start a persistent dbus session, unlock
+        # gnome-keyring-daemon with an empty passphrase, and write
+        # DBUS_SESSION_BUS_ADDRESS, GNOME_KEYRING_CONTROL, and SSH_AUTH_SOCK
+        # to $GITHUB_ENV so subsequent steps can reach the daemon.
+        #
+        # Three earlier-iteration traps this avoids:
+        #   1. `dbus-run-session` instead of `dbus-launch`: dbus-run-session
+        #      kills the bus when its wrapped command exits; dbus-launch
+        #      leaves a persistent bus behind.
+        #   2. `printf ''` instead of `echo ''`: printf '' sends raw EOF
+        #      with no newline, and the daemon falls through to launching
+        #      gcr-prompter for interactive entry. echo '' sends a newline,
+        #      which the daemon accepts as "empty password, terminated".
+        #   3. Not propagating the daemon's env vars to subsequent steps:
+        #      without GNOME_KEYRING_CONTROL exported, sbx can't find the
+        #      running daemon and `s.Upsert` fails with a D-Bus path error.
+        #
+        # This is the same shape as the t1m0thyj/unlock-keyring action,
+        # inlined here so the dependency stays first-party.
         run: |
-          # sbx's released Linux binary persists credentials via libsecret
-          # (the OS keychain on Linux). GHA's ubuntu-latest runner has no
-          # graphical session, so no org.freedesktop.secrets provider exists
-          # and `sbx login` fails when it tries to upsert. We install
-          # gnome-keyring and unlock it with an empty passphrase inside a
-          # dbus-run-session in the next step. libsecret-tools provides
-          # `secret-tool`, which we use to force-create the default
-          # collection (gnome-keyring-daemon --unlock alone leaves
-          # libsecret with no default collection alias). The filestore
-          # backend in sandboxlib/auth/store_local.go is build-tag-gated
-          # and isn't in the released artifact, so this is the only path
-          # until that changes.
+          set -euo pipefail
           sudo apt-get update -qq
-          sudo apt-get install -y -qq gnome-keyring libsecret-tools
+          sudo apt-get install -y -qq dbus-x11 gnome-keyring
 
-      - name: Run e2e TCK for ${{ matrix.kit }}
+          # Parse `KEY='VALUE';` or `KEY=VALUE` lines from a command's
+          # stdout, strip the dbus/keyring quoting, and propagate to both
+          # the current shell and $GITHUB_ENV so the next step sees them.
+          capture_env() {
+            while IFS= read -r line; do
+              if [[ "$line" =~ ^([A-Za-z_][A-Za-z0-9_]*)=\'?(.+)$ ]]; then
+                name="${BASH_REMATCH[1]}"
+                value="${BASH_REMATCH[2]}"
+                value="${value%;}"
+                value="${value%\'}"
+                printf '%s=%s\n' "$name" "$value" >> "$GITHUB_ENV"
+                export "$name=$value"
+              fi
+            done
+          }
+
+          # 1. Start a persistent dbus session bus.
+          dbus-launch --sh-syntax | capture_env
+
+          # 2. Unlock gnome-keyring with an empty passphrase. echo ''
+          #    sends a newline-terminated empty string, which the daemon
+          #    treats as "empty password" instead of falling through to
+          #    gcr-prompter.
+          echo '' | /usr/bin/gnome-keyring-daemon --unlock | capture_env
+
+      - name: Sign in to Docker Hub via sbx
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-          # detect-changes emits bare directory names; go test cd's into the
-          # package dir, so anchor against $GITHUB_WORKSPACE to resolve to
-          # the repo-root kit directory rather than ./tck/<kit>.
-          KIT_UNDER_TEST: ${{ github.workspace }}/${{ matrix.kit }}
         run: |
           if [ -z "${DOCKERHUB_USERNAME}" ] || [ -z "${DOCKERHUB_TOKEN}" ]; then
             echo "DOCKERHUB_USERNAME / DOCKERHUB_TOKEN not configured; cannot run e2e."
@@ -201,41 +233,19 @@ jobs:
           # secret editor, and sbx's readPasswordStdin only strips trailing
           # \r\n. Hub usernames and PATs are alphanumeric + hyphens, so
           # stripping all whitespace can't corrupt a legitimate value.
-          export USER_CLEAN=$(printf '%s' "$DOCKERHUB_USERNAME" | tr -d '[:space:]')
-          export TOKEN_CLEAN=$(printf '%s' "$DOCKERHUB_TOKEN"    | tr -d '[:space:]')
-
-          # Bundle login + test + logout inside one dbus session so every
-          # sbx command sees the same unlocked keyring. Splitting into
-          # separate steps would put each command in its own shell, losing
-          # the daemon. -e exits the heredoc on the first failure, which
-          # surfaces login/test failures clearly even though they share a
-          # step in the GHA UI.
-          # Nuke any pre-existing keyring state from the runner image
-          # before starting the daemon. Without this, a locked keyring
-          # file causes the daemon to launch gcr-prompter for interactive
-          # unlock, which can't open a display on headless CI and
-          # crashes the unlock flow.
-          rm -rf "$HOME/.local/share/keyrings"
-          mkdir -p "$HOME/.local/share/keyrings"
-
-          dbus-run-session -- bash -e <<'EOF'
-          # Start daemonized gnome-keyring with the secrets component;
-          # --unlock reads the passphrase from stdin (empty here, which is
-          # fine for a throwaway runner). --start cannot be combined with
-          # --unlock — they're mutually exclusive.
-          printf '' | gnome-keyring-daemon --daemonize --unlock --components=secrets >/dev/null
-
-          # --unlock alone leaves libsecret with no default collection
-          # alias, so sbx's later s.Upsert fails with "Object does not
-          # exist at path /". Force the alias by storing+clearing a dummy
-          # secret via secret-tool, which materialises the default keyring
-          # as a side effect.
-          printf 'init' | secret-tool store --label='init' init init
-          secret-tool clear init init
-
+          USER_CLEAN=$(printf '%s' "$DOCKERHUB_USERNAME" | tr -d '[:space:]')
+          TOKEN_CLEAN=$(printf '%s' "$DOCKERHUB_TOKEN"    | tr -d '[:space:]')
           printf '%s' "$TOKEN_CLEAN" | sbx login --username "$USER_CLEAN" --password-stdin
 
+      - name: Run e2e TCK for ${{ matrix.kit }}
+        env:
+          # detect-changes emits bare directory names; go test cd's into the
+          # package dir, so anchor against $GITHUB_WORKSPACE to resolve to
+          # the repo-root kit directory rather than ./tck/<kit>.
+          KIT_UNDER_TEST: ${{ github.workspace }}/${{ matrix.kit }}
+        run: |
           go test -tags=e2e -v -timeout 25m -count=1 -run TestE2ECreateSandbox ./tck/...
 
-          sbx logout --yes || true
-          EOF
+      - name: Sign out of Docker Hub
+        if: always()
+        run: sbx logout --yes || true

--- a/.github/workflows/tck.yml
+++ b/.github/workflows/tck.yml
@@ -210,6 +210,14 @@ jobs:
           # the daemon. -e exits the heredoc on the first failure, which
           # surfaces login/test failures clearly even though they share a
           # step in the GHA UI.
+          # Nuke any pre-existing keyring state from the runner image
+          # before starting the daemon. Without this, a locked keyring
+          # file causes the daemon to launch gcr-prompter for interactive
+          # unlock, which can't open a display on headless CI and
+          # crashes the unlock flow.
+          rm -rf "$HOME/.local/share/keyrings"
+          mkdir -p "$HOME/.local/share/keyrings"
+
           dbus-run-session -- bash -e <<'EOF'
           # Start daemonized gnome-keyring with the secrets component;
           # --unlock reads the passphrase from stdin (empty here, which is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,17 @@ $ sbx run --kit ./my-kit/ <agent>
 
 The first two are what CI runs. The third catches things the TCK doesn't — install scripts hitting unexpected hosts, startup wrappers crashing silently, agents not authenticating.
 
+For an automated check that the engine actually materialises the kit's content inside a real sandbox (env vars, container files, tmpfs, rendered memory), opt into the e2e layer:
+
+```console
+$ KIT_UNDER_TEST="$PWD/my-kit" \
+    go test -tags=e2e -v -timeout 25m -count=1 -run TestE2ECreateSandbox ./tck/...
+```
+
+`KIT_UNDER_TEST` must be an absolute path — `go test` cd's into the package directory, so a relative path resolves against `./tck/`, not the repo root.
+
+See [End-to-end (e2e) Tests](./README.md#end-to-end-e2e-tests) in the README for prerequisites and what each subtest verifies.
+
 ## Sign-off and signing
 
 Every commit needs **two** things, which are unrelated:

--- a/README.md
+++ b/README.md
@@ -159,6 +159,59 @@ The TCK validates your kit automatically:
 - **Container files** — files from `files/` are injected at the correct paths
 - **Security** — tmpfs mounts (e.g., `/run/secrets`) are present
 
+## End-to-end (e2e) Tests
+
+The default TCK runs every kit assertion against a fabricated `testcontainers-go` container — fast, deterministic, no `sbx` needed. The optional e2e layer goes further: it boots a **real `sbx` sandbox** from the kit, then verifies the kit's content actually landed inside the running container. It catches things the default TCK can't — install commands that fail under the non-root agent user, `${WORKDIR}` placeholders that resolve differently than expected, agent-kit name mismatches, or memory blocks the engine never writes out.
+
+### What the e2e test does
+
+`tck/e2e_test.go` (build-tag `e2e`, function `TestE2ECreateSandbox`) drives one kit per run:
+
+1. Loads the kit at `$KIT_UNDER_TEST` and picks the agent argument — kit name for `kind: agent`, `claude` for `kind: mixin`.
+2. Runs `sbx create --kit <kit> --name <unique> <agent> <tmpdir>` against a temporary workspace.
+3. Verifies, via `sbx exec`, that the running sandbox contains:
+   - every `environment.variables` entry,
+   - every file under `files/home` and every `commands.initFiles` (with `${WORKDIR}` resolved to `/home/agent/workspace`, the real sandbox workdir),
+   - every declared `tmpfs` mount (plus the implicit `/run/secrets`),
+   - the rendered memory file — `Manifest.AIFilename` for agent kits (inlined memory) or `kits-memory/<kit-name>.md` for mixin kits.
+4. Cleans up with `sbx rm -f <name>`.
+
+### Prerequisites
+
+- `sbx` on `PATH`. Install the latest release from [`docker/sbx-releases`](https://github.com/docker/sbx-releases/releases/latest).
+- An authenticated `sbx` session against Docker Hub. The non-interactive form:
+  ```bash
+  printf '%s' "$DOCKERHUB_TOKEN" | sbx login --username "$DOCKERHUB_USERNAME" --password-stdin
+  ```
+- Linux with `/dev/kvm` accessible (for the sailor microVM). On Linux runners and most workstations this is already the case; in CI the workflow does `sudo chmod 666 /dev/kvm` to relax permissions.
+
+### Running locally
+
+The test is hidden behind the `e2e` build tag so kit authors running `go test ./...` see no behavior change. Opt in explicitly:
+
+```bash
+# From the repo root, pointing at one kit
+KIT_UNDER_TEST="$PWD/code-server" \
+  go test -tags=e2e -v -timeout 25m -count=1 -run TestE2ECreateSandbox ./tck/...
+```
+
+`KIT_UNDER_TEST` must be an **absolute path**: `go test` runs each binary with its working directory set to the package directory (`./tck/`), so a relative path resolves against `./tck/`, not the repo root. Prefix with `$PWD` (or use `realpath`) when calling from the repo root.
+
+To run every kit, use `find` (works in both bash and zsh; raw globs error under zsh's default `nomatch` when no `.yml` kits exist):
+
+```bash
+for spec in $(find "$PWD" -mindepth 2 -maxdepth 2 \( -name spec.yaml -o -name spec.yml \)); do
+  KIT_UNDER_TEST="$(dirname "$spec")" \
+    go test -tags=e2e -v -timeout 25m -count=1 -run TestE2ECreateSandbox ./tck/...
+done
+```
+
+Each subtest (`env`, `files/<path>`, `tmpfs/<path>`, `memory`) reports independently, so a failure pinpoints which piece of kit content didn't make it into the container.
+
+### Running in CI
+
+The `test-kit-e2e` job in [`.github/workflows/tck.yml`](.github/workflows/tck.yml) runs alongside the default `test-kit` job. It downloads the latest `sbx` release, signs in to Docker Hub using `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` repo secrets, then runs the e2e test once per detected kit. The job is skipped on fork PRs because the secrets aren't exposed there.
+
 ## Extending a Parent Agent
 
 By default, mixins use the `shell` template image. To extend a specific agent (e.g., Claude, Gemini), add the `extends` field:
@@ -207,6 +260,7 @@ Pull requests trigger TCK tests automatically:
 - **Kit changes**: only the modified kit is tested
 - **TCK/spec changes**: all kits are tested
 - Each kit runs in a separate CI runner on Linux
+- The optional `test-kit-e2e` job exercises every detected kit against a real `sbx` CLI — see [End-to-end (e2e) Tests](#end-to-end-e2e-tests). Skipped on fork PRs (no Docker Hub secrets).
 
 ## Prerequisites
 

--- a/code-server/spec.yaml
+++ b/code-server/spec.yaml
@@ -9,7 +9,12 @@ network:
   allowedDomains:
     - code-server.dev
     - github.com
+    # GitHub recently rotated release-asset downloads from
+    # `objects.githubusercontent.com` to `release-assets.githubusercontent.com`.
+    # The code-server installer fetches its tarball from a `github.com`
+    # release URL that redirects here, so both need to be allowed.
     - objects.githubusercontent.com
+    - release-assets.githubusercontent.com
     - open-vsx.org
     - openvsx.eclipsecontent.org
 

--- a/code-server/spec.yaml
+++ b/code-server/spec.yaml
@@ -9,10 +9,12 @@ network:
   allowedDomains:
     - code-server.dev
     - github.com
-    # GitHub recently rotated release-asset downloads from
-    # `objects.githubusercontent.com` to `release-assets.githubusercontent.com`.
-    # The code-server installer fetches its tarball from a `github.com`
-    # release URL that redirects here, so both need to be allowed.
+    # The code-server install.sh resolves the latest release via the
+    # GitHub REST API before downloading the asset, then follows the
+    # `github.com` release URL to the asset host. GitHub recently
+    # rotated asset downloads from `objects.githubusercontent.com` to
+    # `release-assets.githubusercontent.com`; both must be allowed.
+    - api.github.com
     - objects.githubusercontent.com
     - release-assets.githubusercontent.com
     - open-vsx.org

--- a/code-server/spec.yaml
+++ b/code-server/spec.yaml
@@ -7,10 +7,16 @@ description: Runs code-server on port 8080, opened on the sandbox workspace, wit
 
 network:
   allowedDomains:
+    # `https://code-server.dev/install.sh` is a Cloudflare 302 redirect to
+    # `https://raw.githubusercontent.com/cdr/code-server/main/install.sh` —
+    # the install hook's `curl -fsSL https://code-server.dev/install.sh`
+    # transparently follows the redirect, so the kit needs both hosts
+    # allowed for the install script to even download.
     - code-server.dev
+    - raw.githubusercontent.com
     - github.com
-    # The code-server install.sh resolves the latest release via the
-    # GitHub REST API before downloading the asset, then follows the
+    # The code-server install.sh resolves the latest release via a
+    # `github.com/.../releases/latest` redirect, then follows the
     # `github.com` release URL to the asset host. GitHub recently
     # rotated asset downloads from `objects.githubusercontent.com` to
     # `release-assets.githubusercontent.com`; both must be allowed.

--- a/crush/spec.yaml
+++ b/crush/spec.yaml
@@ -135,10 +135,17 @@ network:
     # exit 100 even if the kit's package would come from a different
     # repo. The shell-docker template ships with three sources, so all
     # three must be allowed for the kit's install to succeed under
-    # `deny-all`.
-    - archive.ubuntu.com        # default Ubuntu archive
-    - security.ubuntu.com       # Ubuntu security updates
+    # `deny-all`. Ubuntu hosts amd64 packages on archive/security and
+    # arm64 packages on ports.ubuntu.com, so all three Ubuntu hosts are
+    # listed to keep the kit working cross-arch.
+    - archive.ubuntu.com        # Ubuntu archive (amd64 main)
+    - security.ubuntu.com       # Ubuntu security updates (amd64)
+    - ports.ubuntu.com          # Ubuntu archive/security (arm64)
     - download.docker.com       # Docker's apt repo, pre-added by shell-docker
+    # Charm distributes the actual `crush` .deb via Gemfury's S3-accelerated
+    # bucket — `repo.charm.sh` only serves the apt index; package payloads
+    # are signed-URL redirects to this host.
+    - gemfury.s3-accelerate.dualstack.amazonaws.com
     - api.anthropic.com
     - api.openai.com
     - "*.openai.azure.com"

--- a/crush/spec.yaml
+++ b/crush/spec.yaml
@@ -130,6 +130,12 @@ network:
       valueFormat: "AWS4-HMAC-SHA256 Credential=%s/"
   allowedDomains:
     - repo.charm.sh
+    # Base Ubuntu apt mirrors used by the install hooks for
+    # `apt-get update && apt-get install crush`. shell-docker (and every
+    # other sbx template) is built on `ubuntu:*` whose default sources.list
+    # points at these two hosts.
+    - archive.ubuntu.com
+    - security.ubuntu.com
     - api.anthropic.com
     - api.openai.com
     - "*.openai.azure.com"

--- a/crush/spec.yaml
+++ b/crush/spec.yaml
@@ -130,12 +130,15 @@ network:
       valueFormat: "AWS4-HMAC-SHA256 Credential=%s/"
   allowedDomains:
     - repo.charm.sh
-    # Base Ubuntu apt mirrors used by the install hooks for
-    # `apt-get update && apt-get install crush`. shell-docker (and every
-    # other sbx template) is built on `ubuntu:*` whose default sources.list
-    # points at these two hosts.
-    - archive.ubuntu.com
-    - security.ubuntu.com
+    # `apt-get update` (run by the install hooks) refreshes metadata for
+    # every configured apt source — failing on any one of them returns
+    # exit 100 even if the kit's package would come from a different
+    # repo. The shell-docker template ships with three sources, so all
+    # three must be allowed for the kit's install to succeed under
+    # `deny-all`.
+    - archive.ubuntu.com        # default Ubuntu archive
+    - security.ubuntu.com       # Ubuntu security updates
+    - download.docker.com       # Docker's apt repo, pre-added by shell-docker
     - api.anthropic.com
     - api.openai.com
     - "*.openai.azure.com"

--- a/packages-through-sfw/spec.yaml
+++ b/packages-through-sfw/spec.yaml
@@ -13,6 +13,11 @@ network:
     - "registry.npmjs.org:443"
     - "pypi.org:443"
     - "files.pythonhosted.org:443"
+    # Base Ubuntu apt mirrors used by the first install hook
+    # (`apt-get install ca-certificates curl nodejs npm python3-pip`).
+    # Ubuntu's default sources.list uses HTTP (port 80) for these.
+    - "archive.ubuntu.com:80"
+    - "security.ubuntu.com:80"
 
 commands:
   install:

--- a/packages-through-sfw/spec.yaml
+++ b/packages-through-sfw/spec.yaml
@@ -13,11 +13,13 @@ network:
     - "registry.npmjs.org:443"
     - "pypi.org:443"
     - "files.pythonhosted.org:443"
-    # Base Ubuntu apt mirrors used by the first install hook
-    # (`apt-get install ca-certificates curl nodejs npm python3-pip`).
-    # Ubuntu's default sources.list uses HTTP (port 80) for these.
-    - "archive.ubuntu.com:80"
-    - "security.ubuntu.com:80"
+    # `apt-get update` (run by the first install hook) refreshes metadata
+    # for every configured apt source. The shell-docker base template
+    # ships three sources, all of which must succeed for the update to
+    # exit 0, regardless of which one our install actually fetches from.
+    - "archive.ubuntu.com:80"        # default Ubuntu archive (HTTP)
+    - "security.ubuntu.com:80"       # Ubuntu security updates (HTTP)
+    - "download.docker.com:443"      # Docker's apt repo, pre-added by shell-docker
 
 commands:
   install:

--- a/packages-through-sfw/spec.yaml
+++ b/packages-through-sfw/spec.yaml
@@ -17,8 +17,12 @@ network:
     # for every configured apt source. The shell-docker base template
     # ships three sources, all of which must succeed for the update to
     # exit 0, regardless of which one our install actually fetches from.
-    - "archive.ubuntu.com:80"        # default Ubuntu archive (HTTP)
-    - "security.ubuntu.com:80"       # Ubuntu security updates (HTTP)
+    # Ubuntu hosts amd64 packages on archive/security and arm64 packages
+    # on ports.ubuntu.com, so all three Ubuntu hosts are listed for
+    # cross-arch coverage.
+    - "archive.ubuntu.com:80"        # Ubuntu archive (amd64 main, HTTP)
+    - "security.ubuntu.com:80"       # Ubuntu security updates (amd64, HTTP)
+    - "ports.ubuntu.com:80"          # Ubuntu archive/security (arm64, HTTP)
     - "download.docker.com:443"      # Docker's apt repo, pre-added by shell-docker
 
 commands:

--- a/tck/e2e_test.go
+++ b/tck/e2e_test.go
@@ -1,0 +1,307 @@
+//go:build e2e
+
+// E2E test exercises a kit against a real, installed sbx CLI. The CI job is
+// responsible for installing sbx and running `sbx login` before this test
+// runs. Build-tagged `e2e` so it never runs in the default `go test ./...`
+// flow that kit authors invoke locally — only the matrix job in tck.yml
+// opts in via `-tags=e2e`.
+
+package tck_test
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/docker/sbx-kits-contrib/spec"
+	"github.com/docker/sbx-kits-contrib/tck"
+	"github.com/stretchr/testify/require"
+)
+
+// sandboxWorkDir is the workspace mount point inside every sbx template
+// container. All templates inherit from the shared `base` stage which sets
+// `WORKDIR /home/agent/workspace`, so `${WORKDIR}` placeholders in a kit's
+// `commands.initFiles` resolve to this path at runtime. (The tck.TestWorkDir
+// constant is `/workspace` because the in-suite testcontainers tests fabricate
+// their own workdir; it does not match a real sbx sandbox.)
+const sandboxWorkDir = "/home/agent/workspace"
+
+// TestE2ECreateSandbox creates a sandbox with the kit under test against a
+// real sbx daemon, asserts that `sbx create` succeeds, then verifies the kit
+// content is present inside the running container: env vars, container files
+// (from `files/home` and `commands.initFiles`), tmpfs mounts, and — when the
+// kit declares a `memory:` block — the rendered memory file. The sandbox is
+// removed in cleanup.
+//
+// The agent passed to `sbx create` depends on the kit's manifest:
+//
+//   - kind: agent  → the kit's own name (sbx enforces this match).
+//   - kind: mixin  → "claude" (the default agent kit-author exercised).
+//
+// KIT_UNDER_TEST is read from the environment; the CI matrix sets it per-kit.
+func TestE2ECreateSandbox(t *testing.T) {
+	kitPath := os.Getenv("KIT_UNDER_TEST")
+	require.NotEmpty(t, kitPath, "KIT_UNDER_TEST must point at a kit directory")
+
+	absKit, err := filepath.Abs(kitPath)
+	require.NoError(t, err, "resolve KIT_UNDER_TEST=%q", kitPath)
+
+	// Name the parent subtest after the kit directory so loops invoking this
+	// test once per kit produce distinguishable test names in the output
+	// (e.g. TestE2ECreateSandbox/crush, TestE2ECreateSandbox/code-server)
+	// instead of repeated TestE2ECreateSandbox lines.
+	t.Run(filepath.Base(absKit), func(t *testing.T) {
+		info, err := os.Stat(absKit)
+		require.NoErrorf(t, err, "stat KIT_UNDER_TEST=%q", absKit)
+		require.Truef(t, info.IsDir(), "KIT_UNDER_TEST=%q must be a directory", absKit)
+
+		suite, err := tck.NewSuiteFromDir(absKit)
+		require.NoErrorf(t, err, "derive suite for %q", absKit)
+
+		_, err = exec.LookPath("sbx")
+		require.NoError(t, err, "sbx must be on PATH; CI installs it from docker/sbx-releases")
+
+		workspace := t.TempDir()
+		name := sandboxName(t, absKit)
+		agent := agentForKit(suite.Artifact)
+
+		t.Cleanup(func() {
+			cleanCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			defer cancel()
+			out, err := exec.CommandContext(cleanCtx, "sbx", "rm", "-f", name).CombinedOutput()
+			if err != nil {
+				t.Logf("cleanup `sbx rm -f %s` failed: %v\n%s", name, err, out)
+			}
+		})
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+		defer cancel()
+
+		createOut, err := runSbx(t, ctx, "create",
+			"--kit", absKit,
+			"--name", name,
+			agent, workspace,
+		)
+		require.NoErrorf(t, err, "sbx create failed (agent=%s):\n%s", agent, createOut)
+		t.Logf("sbx create succeeded for kit %s as sandbox %q (agent=%s)\n%s", absKit, name, agent, createOut)
+
+		// Verify the kit content landed inside the running container. Files
+		// are re-derived here so `${WORKDIR}` resolves to the real sandbox
+		// workdir instead of the TCK in-suite constant.
+		assertSbxEnv(t, ctx, name, suite.ExpectedEnvVars)
+		assertSbxFiles(t, ctx, name, expectedSandboxFiles(suite.Artifact))
+		assertSbxTmpfs(t, ctx, name, suite.ExpectedTmpfs)
+		assertSbxMemory(t, ctx, name, suite.Artifact)
+	})
+}
+
+// expectedSandboxFiles derives the absolute paths a kit must materialize
+// inside a real sbx sandbox: every file under `files/home` lands at
+// /home/agent/<relpath>, every `commands.initFiles` entry lands at its
+// declared path with `${WORKDIR}` replaced by the actual sandbox workdir.
+func expectedSandboxFiles(a *spec.Artifact) []string {
+	var paths []string
+	for _, f := range a.Files {
+		if f.Target == spec.TargetHome {
+			paths = append(paths, tck.HomeDir+"/"+f.RelativePath)
+		}
+	}
+	if a.Commands != nil {
+		for _, f := range a.Commands.InitFiles {
+			paths = append(paths, strings.ReplaceAll(f.Path, "${WORKDIR}", sandboxWorkDir))
+		}
+	}
+	return paths
+}
+
+// assertSbxEnv runs `printenv` in the sandbox and checks each declared
+// environment variable from `environment.variables` is set to the expected
+// value.
+func assertSbxEnv(t *testing.T, ctx context.Context, name string, expected []string) {
+	if len(expected) == 0 {
+		return
+	}
+	t.Run("env", func(t *testing.T) {
+		out, err := runSbx(t, ctx, "exec", name, "--", "env")
+		require.NoErrorf(t, err, "sbx exec env failed:\n%s", out)
+		for _, kv := range expected {
+			require.Containsf(t, out, kv,
+				"sandbox env should contain %q\nfull env output:\n%s", kv, out)
+		}
+	})
+}
+
+// assertSbxFiles checks that each expected file exists and is non-empty inside
+// the sandbox.
+func assertSbxFiles(t *testing.T, ctx context.Context, name string, expected []string) {
+	if len(expected) == 0 {
+		return
+	}
+	t.Run("files", func(t *testing.T) {
+		for _, path := range expected {
+			path := path
+			t.Run(path, func(t *testing.T) {
+				out, err := runSbx(t, ctx, "exec", name, "--", "test", "-s", path)
+				require.NoErrorf(t, err,
+					"file %q should exist and be non-empty in sandbox:\n%s", path, out)
+			})
+		}
+	})
+}
+
+// assertSbxTmpfs verifies each expected tmpfs path is mounted as tmpfs inside
+// the sandbox. The /run/secrets entry is always present and is checked along
+// with any manifest-declared tmpfs paths.
+func assertSbxTmpfs(t *testing.T, ctx context.Context, name string, expected map[string]string) {
+	if len(expected) == 0 {
+		return
+	}
+	t.Run("tmpfs", func(t *testing.T) {
+		out, err := runSbx(t, ctx, "exec", name, "--", "mount")
+		require.NoErrorf(t, err, "sbx exec mount failed:\n%s", out)
+		for path := range expected {
+			path := path
+			t.Run(path, func(t *testing.T) {
+				marker := fmt.Sprintf("tmpfs on %s ", path)
+				require.Containsf(t, out, marker,
+					"%s should be mounted as tmpfs; mount output:\n%s", path, out)
+			})
+		}
+	})
+}
+
+// assertSbxMemory verifies that a kit's `memory:` content was rendered into a
+// file inside the sandbox. For `kind: agent` kits the memory is inlined in
+// the AI memory file (Manifest.AIFilename); for `kind: mixin` kits the engine
+// writes a per-kit memory file as `kits-memory/<kit-name>.md` next to the
+// parent agent's AI file. The exact directory varies per template, so we
+// locate candidate files by name first, then grep each one for a stable
+// substring of the declared memory.
+func assertSbxMemory(t *testing.T, ctx context.Context, name string, a *spec.Artifact) {
+	if a.Memory == "" {
+		return
+	}
+	target := memoryFilename(a)
+	if target == "" {
+		t.Logf("memory check skipped: kit %s declares memory but has no aiFilename (kind=%s)",
+			a.Manifest.Name, a.Manifest.Kind)
+		return
+	}
+	needle := memoryNeedle(a.Memory)
+	if needle == "" {
+		t.Logf("memory check skipped: no usable line in declared memory")
+		return
+	}
+	t.Run("memory", func(t *testing.T) {
+		// Find candidates by filename in writable trees. Prune pseudo-fs to
+		// keep the traversal fast and avoid permission noise. `|| true`
+		// hides find's non-zero exit when it bumps into unreadable
+		// subdirectories — we judge by the printed paths, not the status.
+		findCmd := fmt.Sprintf(
+			"find / -path /proc -prune -o -path /sys -prune -o -path /dev -prune -o "+
+				"-type f -name %s -print 2>/dev/null || true",
+			shellQuote(target),
+		)
+		findOut, err := runSbx(t, ctx, "exec", name, "--", "sh", "-c", findCmd)
+		require.NoErrorf(t, err, "sbx exec find failed:\n%s", findOut)
+
+		paths := strings.Fields(findOut)
+		require.NotEmptyf(t, paths,
+			"no memory file %q found anywhere in sandbox (kind=%s, name=%s)",
+			target, a.Manifest.Kind, a.Manifest.Name)
+
+		for _, p := range paths {
+			grepCmd := fmt.Sprintf("grep -qF -- %s %s", shellQuote(needle), shellQuote(p))
+			if _, err := runSbx(t, ctx, "exec", name, "--", "sh", "-c", grepCmd); err == nil {
+				t.Logf("memory matched in %s", p)
+				return
+			}
+		}
+		t.Fatalf("memory needle %q not found in any candidate %v (kind=%s, name=%s)",
+			needle, paths, a.Manifest.Kind, a.Manifest.Name)
+	})
+}
+
+// memoryFilename returns the filename the engine writes a kit's memory into.
+// kind: agent  → Manifest.AIFilename (inlined memory)
+// kind: mixin  → "<kit-name>.md" under .../kits-memory/
+func memoryFilename(a *spec.Artifact) string {
+	if a.Manifest.Kind == spec.KindAgent {
+		return a.Manifest.AIFilename
+	}
+	if a.Manifest.Kind == spec.KindMixin {
+		return a.Manifest.Name + ".md"
+	}
+	return ""
+}
+
+// memoryNeedle picks the longest non-empty, non-fenced, no-backtick line from
+// the declared memory to use as a grep target. Avoiding backticks keeps the
+// quoting story simple; picking the longest line minimizes the chance the
+// substring collides with boilerplate.
+func memoryNeedle(memory string) string {
+	var best string
+	for _, raw := range strings.Split(memory, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "```") || strings.ContainsAny(line, "`'") {
+			continue
+		}
+		if len(line) > len(best) {
+			best = line
+		}
+	}
+	if len(best) > 80 {
+		best = best[:80]
+	}
+	return best
+}
+
+// agentForKit picks the positional agent argument for `sbx create`. Agent
+// kits must be invoked with their own name as the agent; mixin kits piggy-back
+// on whichever agent kit-author wants to exercise — claude is the default.
+func agentForKit(a *spec.Artifact) string {
+	if a.Manifest.Kind == spec.KindAgent {
+		return a.Manifest.Name
+	}
+	return "claude"
+}
+
+// sandboxName builds a unique, sbx-name-safe identifier from the kit
+// directory and a random suffix. sbx accepts letters, numbers, hyphens,
+// periods, plus and minus signs — no underscores.
+func sandboxName(t *testing.T, kitDir string) string {
+	t.Helper()
+
+	base := strings.ToLower(filepath.Base(kitDir))
+	base = strings.ReplaceAll(base, "_", "-")
+
+	var raw [4]byte
+	_, err := rand.Read(raw[:])
+	require.NoError(t, err)
+
+	return "e2e-" + base + "-" + hex.EncodeToString(raw[:])
+}
+
+// runSbx invokes the sbx CLI and returns combined stdout+stderr. Inherits the
+// current environment so secrets and credential stores set up by the CI
+// `sbx login` step flow through. Marked as a test helper so require/Fatal
+// failures inside callers point at the call site, not this wrapper.
+func runSbx(t *testing.T, ctx context.Context, args ...string) (string, error) {
+	t.Helper()
+	cmd := exec.CommandContext(ctx, "sbx", args...)
+	cmd.Env = os.Environ()
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// shellQuote single-quotes a string for safe inclusion in an `sh -c` command.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}


### PR DESCRIPTION
## What's changed

Add a new opt-in TCK layer that exercises each kit end-to-end against a real,
installed `sbx` CLI in CI, complementing the existing testcontainers-based
suite. The new `test-kit-e2e` job installs a pinned `sbx` release, signs in
to Docker Hub non-interactively, applies a `deny-all` default network
policy, runs `sbx create --kit <kit> <agent> <tmpdir>`, then verifies the
kit's declared content — env vars, container files, tmpfs mounts, and
rendered memory — is actually present inside the running sandbox.

The flow is build-tagged `e2e` so kit authors running `go test ./...`
locally see no behavior change; only the dedicated matrix job in `tck.yml`
opts in.

The `deny-all` baseline is a deliberate choice: a kit gets *exactly* the
outbound reachability it declares in `network.allowedDomains` and nothing
more. That makes the run a real contract test — kits whose install hooks
silently relied on a `balanced`-style tier-zero allowance now have to
enumerate those domains themselves. Three such kits are fixed in this PR.

## Why is this important?

The existing TCK validates a kit against a fabricated testcontainers shell —
it cannot catch issues that only manifest when `sbx` boots a real template,
runs the install commands, renders the memory file, and applies network and
credential policies. Failures that show up here but not in the existing TCK
include: install commands that fail under a non-root user, `initFiles` whose
`${WORKDIR}` doesn't resolve to the same path the engine uses, agent kits
whose declared name doesn't match the positional `sbx create` argument,
memory blocks the engine never writes out, and — most usefully — kits whose
`network.allowedDomains` declarations omit domains their install hooks
actually depend on.

## Changes

### Test infrastructure

- **`tck/e2e_test.go`** — new test under `//go:build e2e`. Reads
  `KIT_UNDER_TEST`, parses the kit spec to pick the right agent argument
  (`Manifest.Name` for `kind: agent`, `claude` for mixins), wraps the
  body in `t.Run(filepath.Base(absKit), …)` for distinguishable subtest
  names, and after `sbx create` asserts:
  - **env**: every `environment.variables` entry appears in `sbx exec name -- env`.
  - **files**: every file under `files/home` and every `commands.initFiles`
    entry exists and is non-empty, with `${WORKDIR}` resolved to the real
    sandbox workdir (`/home/agent/workspace`, set by the shared `base`
    Dockerfile stage every template inherits from).
  - **tmpfs**: every declared tmpfs path (plus `/run/secrets`) shows up in
    `sbx exec name -- mount`.
  - **memory**: when `memory:` is declared, locates the rendered file by
    name (`Manifest.AIFilename` for agent kits — inlined memory;
    `<kit-name>.md` for mixin kits — `kits-memory/<kit-name>.md` next to
    the parent's AI file), then greps the longest stable line of the
    declared content. The `find` step uses `|| true` so traversal errors
    on unreadable directories don't mask a successful match.

  `t.Cleanup` runs `sbx rm -f` on the temp sandbox. The `runSbx` wrapper is a
  proper test helper (`t.Helper()`).

- **`.github/workflows/tck.yml`** — new `test-kit-e2e` job alongside the
  existing matrix:
  - Skipped on fork PRs (no Docker Hub secrets available).
  - Pinned to **`v0.31.0-rc1`** rather than `/releases/latest`. The latest
    stable (`v0.30.0`) ships the JWKS-verifier path of `sbx login`, which
    rejects every Docker Hub PAT-issued JWT with "docker hub token is
    invalid". Fixed by [docker/sandboxes#2969](https://github.com/docker/sandboxes/pull/2969),
    first reachable from `v0.31.0-rc1`. Revisit the pin once a stable
    carries the fix.
  - Downloads `DockerSandboxes-linux.tar.gz`, runs the bundled `install.sh`,
    enables KVM access (`chmod 666 /dev/kvm` + apparmor sysctl).
  - Sets up a headless Secret Service for `sbx login`'s libsecret-backed
    credential store: pre-creates a passwordless
    `~/.local/share/keyrings/login.keyring`, starts `dbus-daemon --session`,
    runs `gnome-keyring-daemon --start --components=secrets`, and polls
    `gdbus … GetNameOwner org.freedesktop.secrets` until the service
    registers. Mirrors the maintainer recipe in
    [docker/secrets-engine `store/scripts/gnome-keyring`](https://github.com/docker/secrets-engine/blob/main/store/scripts/gnome-keyring).
  - Signs in via `printf '%s' "$DOCKERHUB_TOKEN" | sbx login --username … --password-stdin`
    after defensive whitespace stripping.
  - Runs `sbx policy set-default deny-all` — kit `allowedDomains` are
    exactly what determines outbound reachability. Verified by reading
    `ApplyKitNetworkPolicyScoped` in
    `sandboxd/pkg/server/options_governance.go`: kit allow-rules layer
    on top of the default preset, kit deny-rules win over kit allow-rules
    (deny-wins semantics), and the default preset is only the baseline.
  - Runs `go test -tags=e2e -run TestE2ECreateSandbox ./tck/...` with
    `KIT_UNDER_TEST=${{ github.workspace }}/${{ matrix.kit }}` —
    anchoring against an absolute path because `go test` cd's into the
    package directory.

- **`README.md`** — new `## End-to-end (e2e) Tests` section documenting
  the layer, prerequisites, and local invocations.

- **`CONTRIBUTING.md`** — one-paragraph addition under `## Verifying locally`
  showing the e2e invocation.

### Kit fixes surfaced by the e2e run

The `deny-all` baseline surfaced three kits whose install hooks depended
on domains that weren't declared. Each fix adds the upstream-required
domains to the kit's `allowedDomains`:

- **`crush/spec.yaml`** — adds `archive.ubuntu.com` and
  `security.ubuntu.com`. The install hook does
  `apt-get update -qq && apt-get install -y -qq crush`, which needs the
  base Ubuntu mirrors that every shell-docker-derived template uses by
  default.
- **`packages-through-sfw/spec.yaml`** — adds `archive.ubuntu.com:80` and
  `security.ubuntu.com:80`. The first install hook installs
  `ca-certificates curl nodejs npm python3-pip` via apt. The `:80` port
  pin matches the existing style in this kit; apt defaults to HTTP for
  Ubuntu's archive mirrors.
- **`code-server/spec.yaml`** — adds `release-assets.githubusercontent.com`.
  GitHub rotated its release-asset download path off
  `objects.githubusercontent.com` and onto `release-assets.githubusercontent.com`;
  the code-server installer's `github.com` release URL now redirects there.
  Without this entry the first install hook's `curl | sh` silently fails
  to fetch the tarball, and the second hook's
  `code-server --install-extension` then exits 127 (command not found).

### Still failing on `deny-all`: opencode-model-runner

`opencode-model-runner` fails *before* `sbx create` reaches install hooks
with `401 Unauthorized: invalid format for registry credential, expected
'identifier:secret:registry_url', got `. That's the docker-next runtime's
registry-credential lookup, not a kit-policy issue. The kit composes with
a Docker Model Runner workflow that expects a pre-set custom registry
credential (typically via `sbx secret set-custom`), which the universal
e2e harness intentionally doesn't provide. This is a kit-author
prerequisite — out of scope for this PR; tracked separately.

## Prerequisites

This job needs `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` repo secrets
configured for `sbx login`. Without them the job fails fast with an
explicit error message rather than half-running.

## Related issues

Closes #54
