### PR TITLE
spec: redesign volumes (add MountSpec.Type, drop Manifest.Tmpfs) — v2 Phase 2

### DIFF
--- a/spec/types.go
+++ b/spec/types.go
@@ -104,16 +104,16 @@ type Manifest struct {
 	Volumes []MountSpec `json:"volumes,omitempty" yaml:"volumes,omitempty"`
 }
 
-// TmpfsVolumes returns the subset of m.Volumes whose Type is "tmpfs".
-// Convenience for call-sites that previously read the separate
-// Manifest.Tmpfs field.
+// TmpfsVolumes returns the subset of m.Volumes whose Type is
+// MountTypeTmpfs. Convenience for call-sites that previously read the
+// separate Manifest.Tmpfs field.
 func (m *Manifest) TmpfsVolumes() []MountSpec {
 	if len(m.Volumes) == 0 {
 		return nil
 	}
 	out := make([]MountSpec, 0, len(m.Volumes))
 	for _, v := range m.Volumes {
-		if v.Type == "tmpfs" {
+		if v.Type == MountTypeTmpfs {
 			out = append(out, v)
 		}
 	}
@@ -129,17 +129,33 @@ type Security struct {
 	Privileged bool `json:"privileged,omitempty" yaml:"privileged,omitempty"`
 }
 
+// MountType selects the backing storage for a MountSpec entry. Defined
+// as a named type so downstream tooling (kit-generation helpers, etc.)
+// can declare typed parameters instead of passing raw strings.
+type MountType string
+
+// Recognized MountType values.
+const (
+	// MountTypeBlock is the default block-backed volume. Encoded as the
+	// empty string in YAML/JSON so existing entries that omit `type:`
+	// continue to decode unchanged.
+	MountTypeBlock MountType = ""
+
+	// MountTypeTmpfs is a RAM-backed mount.
+	MountTypeTmpfs MountType = "tmpfs"
+)
+
 // MountSpec is a single mount entry on Manifest.Volumes. Type selects
-// the backing storage: omit or set "" for the default block-backed
-// volume; set "tmpfs" for a RAM-backed mount.
+// the backing storage.
 type MountSpec struct {
 	// Path is the absolute mount path in the container.
 	Path string `json:"path" yaml:"path"`
 
-	// Type selects the backing storage. Omit (or set "") for the default
-	// block-backed volume; set "tmpfs" for a RAM-backed mount. Added in
-	// schemaVersion "2" to replace the separate top-level `tmpfs:` block.
-	Type string `json:"type,omitempty" yaml:"type,omitempty"`
+	// Type selects the backing storage. Defaults to MountTypeBlock
+	// (block-backed); set MountTypeTmpfs for a RAM-backed mount. Added
+	// in schemaVersion "2" to replace the separate top-level `tmpfs:`
+	// block.
+	Type MountType `json:"type,omitempty" yaml:"type,omitempty"`
 
 	// Size is the mount size as a byte-size string (e.g., "100m", "4g",
 	// "512m"). Optional.

--- a/spec/types.go
+++ b/spec/types.go
@@ -97,13 +97,30 @@ type Manifest struct {
 	// Security defines container security settings.
 	Security *Security `json:"security,omitempty" yaml:"security,omitempty"`
 
-	// Volumes are block-volume mounts in dash-style list form. Entries are
-	// applied by Path.
+	// Volumes are mount entries in dash-style list form. Entries are
+	// applied by Path. Each entry's Type selects the backing storage
+	// (omit or set "" for the default block-backed volume; set "tmpfs"
+	// for a RAM-backed mount).
 	Volumes []MountSpec `json:"volumes,omitempty" yaml:"volumes,omitempty"`
+}
 
-	// Tmpfs are tmpfs mounts in dash-style list form. Entries are applied
-	// by Path.
-	Tmpfs []MountSpec `json:"tmpfs,omitempty" yaml:"tmpfs,omitempty"`
+// TmpfsVolumes returns the subset of m.Volumes whose Type is "tmpfs".
+// Convenience for call-sites that previously read the separate
+// Manifest.Tmpfs field.
+func (m *Manifest) TmpfsVolumes() []MountSpec {
+	if len(m.Volumes) == 0 {
+		return nil
+	}
+	out := make([]MountSpec, 0, len(m.Volumes))
+	for _, v := range m.Volumes {
+		if v.Type == "tmpfs" {
+			out = append(out, v)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // Security defines container security settings for the sandbox.
@@ -112,13 +129,17 @@ type Security struct {
 	Privileged bool `json:"privileged,omitempty" yaml:"privileged,omitempty"`
 }
 
-// MountSpec is a single mount entry shared by Manifest.Volumes (persistent
-// block volumes) and Manifest.Tmpfs (in-memory tmpfs). The fields are
-// identical; the semantic distinction lives on the field that holds the
-// slice, not on the entry type.
+// MountSpec is a single mount entry on Manifest.Volumes. Type selects
+// the backing storage: omit or set "" for the default block-backed
+// volume; set "tmpfs" for a RAM-backed mount.
 type MountSpec struct {
 	// Path is the absolute mount path in the container.
 	Path string `json:"path" yaml:"path"`
+
+	// Type selects the backing storage. Omit (or set "") for the default
+	// block-backed volume; set "tmpfs" for a RAM-backed mount. Added in
+	// schemaVersion "2" to replace the separate top-level `tmpfs:` block.
+	Type string `json:"type,omitempty" yaml:"type,omitempty"`
 
 	// Size is the mount size as a byte-size string (e.g., "100m", "4g",
 	// "512m"). Optional.
@@ -375,13 +396,13 @@ type Artifact struct {
 // OAuthPolicy defines OAuth configuration for agents that use OAuth-based
 // authentication through the proxy.
 type OAuthPolicy struct {
-	Service             string              `json:"service" yaml:"service"`
-	TokenEndpoint       OAuthTokenEndpoint  `json:"tokenEndpoint" yaml:"tokenEndpoint"`
-	Sentinels           OAuthSentinels      `json:"sentinels" yaml:"sentinels"`
+	Service             string               `json:"service" yaml:"service"`
+	TokenEndpoint       OAuthTokenEndpoint   `json:"tokenEndpoint" yaml:"tokenEndpoint"`
+	Sentinels           OAuthSentinels       `json:"sentinels" yaml:"sentinels"`
 	CredentialFile      *OAuthCredentialFile `json:"credentialFile,omitempty" yaml:"credentialFile,omitempty"`
-	SkipIfEnv           []string            `json:"skipIfEnv,omitempty" yaml:"skipIfEnv,omitempty"`
+	SkipIfEnv           []string             `json:"skipIfEnv,omitempty" yaml:"skipIfEnv,omitempty"`
 	ResponseFields      *OAuthResponseFields `json:"responseFields,omitempty" yaml:"responseFields,omitempty"`
-	PassthroughResponse bool                `json:"passthroughResponse,omitempty" yaml:"passthroughResponse,omitempty"`
+	PassthroughResponse bool                 `json:"passthroughResponse,omitempty" yaml:"passthroughResponse,omitempty"`
 }
 
 // OAuthResponseFields maps logical OAuth token field names to the actual
@@ -449,27 +470,27 @@ func (p *OAuthPolicy) ResolvedResponseFields() OAuthResponseFields {
 
 // specFile is the on-disk YAML schema for spec.yaml.
 type specFile struct {
-	Manifest    `yaml:",inline"`
-	Extends     string             `yaml:"extends,omitempty"`
-	Locked      []string           `yaml:"locked,omitempty"`
-	Sandbox *sandboxBlock `yaml:"sandbox,omitempty"`
+	Manifest `yaml:",inline"`
+	Extends  string        `yaml:"extends,omitempty"`
+	Locked   []string      `yaml:"locked,omitempty"`
+	Sandbox  *sandboxBlock `yaml:"sandbox,omitempty"`
 	// LegacyAgent holds the v1 `agent:` block. The normalize step
 	// migrates its contents to Sandbox with a deprecation warning. Drop
 	// in the Phase 4 schema-cutover commit.
-	LegacyAgent *sandboxBlock `yaml:"agent,omitempty"`
-	Secrets     []string           `yaml:"secrets,omitempty"`
-	Egress      map[string]string  `yaml:"egress,omitempty"`
-	Network     *NetworkPolicy     `yaml:"network,omitempty"`
-	Credentials *CredentialPolicy  `yaml:"credentials,omitempty"`
-	Environment *EnvironmentPolicy `yaml:"environment,omitempty"`
-	Settings    *SettingsPolicy    `yaml:"settings,omitempty"`
-	Commands    *CommandsPolicy    `yaml:"commands,omitempty"`
-	OAuth       *OAuthPolicy       `yaml:"oauth,omitempty"`
-	AgentContext string            `yaml:"agentContext,omitempty"`
+	LegacyAgent  *sandboxBlock      `yaml:"agent,omitempty"`
+	Secrets      []string           `yaml:"secrets,omitempty"`
+	Egress       map[string]string  `yaml:"egress,omitempty"`
+	Network      *NetworkPolicy     `yaml:"network,omitempty"`
+	Credentials  *CredentialPolicy  `yaml:"credentials,omitempty"`
+	Environment  *EnvironmentPolicy `yaml:"environment,omitempty"`
+	Settings     *SettingsPolicy    `yaml:"settings,omitempty"`
+	Commands     *CommandsPolicy    `yaml:"commands,omitempty"`
+	OAuth        *OAuthPolicy       `yaml:"oauth,omitempty"`
+	AgentContext string             `yaml:"agentContext,omitempty"`
 	// LegacyMemory holds the v1 `memory:` field. The normalize step
 	// migrates it to AgentContext with a deprecation warning. Drop in
 	// the Phase 4 schema-cutover commit.
-	LegacyMemory string            `yaml:"memory,omitempty"`
+	LegacyMemory string `yaml:"memory,omitempty"`
 }
 
 // sandboxBlock groups sandbox-specific configuration (formerly the

--- a/spec/v1_compat_test.go
+++ b/spec/v1_compat_test.go
@@ -177,3 +177,55 @@ sandbox:
 		}
 	}
 }
+
+func TestVolumesType_TmpfsAccepted(t *testing.T) {
+	dir := t.TempDir()
+	specYAML := `schemaVersion: "1"
+kind: sandbox
+name: vol-tmpfs
+sandbox:
+  image: docker/sandbox-templates:shell-docker
+volumes:
+  - path: /tmp/scratch
+    type: tmpfs
+    size: 512m
+    mode: "1777"
+`
+	if err := os.WriteFile(filepath.Join(dir, "spec.yaml"), []byte(specYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	art, err := LoadFromDirectory(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(art.Manifest.Volumes) != 1 {
+		t.Fatalf("expected 1 volume, got %d", len(art.Manifest.Volumes))
+	}
+	v := art.Manifest.Volumes[0]
+	if v.Type != "tmpfs" || v.Path != "/tmp/scratch" || v.Size != "512m" || v.Mode != "1777" {
+		t.Errorf("volume mismatch: %#v", v)
+	}
+}
+
+func TestV1TmpfsBlock_StrictRejected(t *testing.T) {
+	dir := t.TempDir()
+	specYAML := `schemaVersion: "1"
+kind: sandbox
+name: legacy-tmpfs
+sandbox:
+  image: docker/sandbox-templates:shell-docker
+tmpfs:
+  - path: /tmp/scratch
+    size: 512m
+`
+	if err := os.WriteFile(filepath.Join(dir, "spec.yaml"), []byte(specYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadFromDirectory(dir)
+	if err == nil {
+		t.Fatal("expected strict-decode error for removed `tmpfs:` block, got nil")
+	}
+	if !strings.Contains(err.Error(), "tmpfs") {
+		t.Errorf("error should name the rejected field; got %v", err)
+	}
+}

--- a/spec/validate.go
+++ b/spec/validate.go
@@ -227,34 +227,27 @@ func ValidateSecurity(_ *Security) error {
 	return nil
 }
 
-// ValidateVolumes validates block-volume mount entries.
+// ValidateVolumes validates Manifest.Volumes mount entries. Each entry's
+// Type selects the backing storage (omit or "" for block-backed, "tmpfs"
+// for RAM-backed); any other value is rejected.
 func ValidateVolumes(volumes []MountSpec) error {
-	return validateMounts("volumes", volumes)
-}
-
-// ValidateTmpfs validates tmpfs mount entries.
-func ValidateTmpfs(tmpfs []MountSpec) error {
-	return validateMounts("tmpfs", tmpfs)
-}
-
-// validateMounts checks the shared MountSpec invariants: absolute Path,
-// parseable Size if set, octal Mode if set. field is used as the error
-// prefix so volume and tmpfs failures are distinguishable.
-func validateMounts(field string, mounts []MountSpec) error {
-	for i, m := range mounts {
+	for i, m := range volumes {
+		if m.Type != "" && m.Type != "tmpfs" {
+			return fmt.Errorf("manifest: volumes[%d].type %q is invalid (must be omitted or \"tmpfs\")", i, m.Type)
+		}
 		if m.Path == "" {
-			return fmt.Errorf("manifest: %s[%d].path must not be empty", field, i)
+			return fmt.Errorf("manifest: volumes[%d].path must not be empty", i)
 		}
 		if !strings.HasPrefix(m.Path, "/") {
-			return fmt.Errorf("manifest: %s[%d].path %q must be an absolute path", field, i, m.Path)
+			return fmt.Errorf("manifest: volumes[%d].path %q must be an absolute path", i, m.Path)
 		}
 		if m.Size != "" {
 			if _, err := units.RAMInBytes(m.Size); err != nil {
-				return fmt.Errorf("manifest: %s[%d].size %q is not a valid size: %w", field, i, m.Size, err)
+				return fmt.Errorf("manifest: volumes[%d].size %q is not a valid size: %w", i, m.Size, err)
 			}
 		}
 		if m.Mode != "" && !octalModePattern.MatchString(m.Mode) {
-			return fmt.Errorf("manifest: %s[%d].mode %q must be octal (e.g. \"1777\")", field, i, m.Mode)
+			return fmt.Errorf("manifest: volumes[%d].mode %q must be octal (e.g. \"1777\")", i, m.Mode)
 		}
 	}
 	return nil
@@ -269,9 +262,6 @@ func ValidateArtifact(a *Artifact) error {
 		return err
 	}
 	if err := ValidateVolumes(a.Manifest.Volumes); err != nil {
-		return err
-	}
-	if err := ValidateTmpfs(a.Manifest.Tmpfs); err != nil {
 		return err
 	}
 	if err := ValidateLocked(a.Locked); err != nil {

--- a/spec/validate.go
+++ b/spec/validate.go
@@ -228,12 +228,12 @@ func ValidateSecurity(_ *Security) error {
 }
 
 // ValidateVolumes validates Manifest.Volumes mount entries. Each entry's
-// Type selects the backing storage (omit or "" for block-backed, "tmpfs"
-// for RAM-backed); any other value is rejected.
+// Type selects the backing storage (MountTypeBlock — encoded as "" — for
+// block-backed, MountTypeTmpfs for RAM-backed); any other value is rejected.
 func ValidateVolumes(volumes []MountSpec) error {
 	for i, m := range volumes {
-		if m.Type != "" && m.Type != "tmpfs" {
-			return fmt.Errorf("manifest: volumes[%d].type %q is invalid (must be omitted or \"tmpfs\")", i, m.Type)
+		if m.Type != MountTypeBlock && m.Type != MountTypeTmpfs {
+			return fmt.Errorf("manifest: volumes[%d].type %q is invalid (must be omitted or %q)", i, m.Type, MountTypeTmpfs)
 		}
 		if m.Path == "" {
 			return fmt.Errorf("manifest: volumes[%d].path must not be empty", i)

--- a/spec/validate_test.go
+++ b/spec/validate_test.go
@@ -314,29 +314,30 @@ func TestValidateVolumes(t *testing.T) {
 	})
 }
 
-func TestValidateTmpfs(t *testing.T) {
-	t.Run("valid", func(t *testing.T) {
-		require.NoError(t, ValidateTmpfs([]MountSpec{{Path: "/tmp", Size: "1g", Mode: "1777"}}))
-	})
+func TestValidateArtifact_MountSpecType(t *testing.T) {
+	base := Manifest{
+		SchemaVersion: SchemaVersion,
+		Kind:          KindSandbox,
+		Name:          "vol-type-test",
+		Template:      "docker/sandbox-templates:shell-docker",
+	}
 
-	t.Run("path_only_is_valid", func(t *testing.T) {
-		require.NoError(t, ValidateTmpfs([]MountSpec{{Path: "/tmp"}}))
+	t.Run("empty type accepted", func(t *testing.T) {
+		m := base
+		m.Volumes = []MountSpec{{Path: "/data"}}
+		require.NoError(t, ValidateArtifact(&Artifact{Manifest: m}))
 	})
-
-	t.Run("empty_path", func(t *testing.T) {
-		require.ErrorContains(t, ValidateTmpfs([]MountSpec{{Path: ""}}), "tmpfs[0].path must not be empty")
+	t.Run("tmpfs type accepted", func(t *testing.T) {
+		m := base
+		m.Volumes = []MountSpec{{Path: "/tmp/scratch", Type: "tmpfs"}}
+		require.NoError(t, ValidateArtifact(&Artifact{Manifest: m}))
 	})
-
-	t.Run("relative_path", func(t *testing.T) {
-		require.ErrorContains(t, ValidateTmpfs([]MountSpec{{Path: "tmp"}}), "tmpfs[0].path \"tmp\" must be an absolute path")
-	})
-
-	t.Run("invalid_size", func(t *testing.T) {
-		require.ErrorContains(t, ValidateTmpfs([]MountSpec{{Path: "/tmp", Size: "huge"}}), "tmpfs[0].size \"huge\" is not a valid size")
-	})
-
-	t.Run("invalid_mode", func(t *testing.T) {
-		require.ErrorContains(t, ValidateTmpfs([]MountSpec{{Path: "/tmp", Mode: "rwx"}}), "tmpfs[0].mode \"rwx\" must be octal")
+	t.Run("invalid type rejected", func(t *testing.T) {
+		m := base
+		m.Volumes = []MountSpec{{Path: "/data", Type: "bogus"}}
+		err := ValidateArtifact(&Artifact{Manifest: m})
+		require.ErrorContains(t, err, "type")
+		require.ErrorContains(t, err, "bogus")
 	})
 }
 

--- a/tck/derive.go
+++ b/tck/derive.go
@@ -41,7 +41,7 @@ func NewSuiteFromDir(dir string, opts ...Option) (*Suite, error) {
 		Image:                  image,
 		ExpectedEnvVars:        deriveEnvVars(artifact.Environment),
 		ExpectedContainerFiles: deriveContainerFiles(artifact.Files, artifact.Commands),
-		ExpectedTmpfs:          deriveTmpfs(artifact.Manifest.Tmpfs),
+		ExpectedTmpfs:          deriveTmpfs(artifact.Manifest.TmpfsVolumes()),
 	}
 
 	// Derive network expectations
@@ -107,9 +107,10 @@ func resolveWorkdir(s string) string {
 }
 
 // deriveTmpfs builds the expected tmpfs mounts from the manifest's tmpfs
-// entries, always including /run/secrets for the secrets tmpfs. The result
-// is a path→option-string map suitable for testcontainers-go's WithTmpfs
-// (Size and Mode compose into the comma-separated value Docker expects).
+// volumes (those entries on Manifest.Volumes with Type == "tmpfs"), always
+// including /run/secrets for the secrets tmpfs. The result is a path→
+// option-string map suitable for testcontainers-go's WithTmpfs (Size and
+// Mode compose into the comma-separated value Docker expects).
 func deriveTmpfs(manifestTmpfs []spec.MountSpec) map[string]string {
 	tmpfs := map[string]string{
 		"/run/secrets": "rw,noexec,nosuid",

--- a/tck/suite.go
+++ b/tck/suite.go
@@ -280,9 +280,9 @@ func (s *Suite) RunValidationTests(t *testing.T) {
 			})
 		}
 
-		if len(m.Tmpfs) > 0 {
+		if tmpfsVolumes := m.TmpfsVolumes(); len(tmpfsVolumes) > 0 {
 			t.Run("tmpfs", func(t *testing.T) {
-				for i, mnt := range m.Tmpfs {
+				for i, mnt := range tmpfsVolumes {
 					require.True(t, strings.HasPrefix(mnt.Path, "/"),
 						"tmpfs[%d].path %q must be absolute", i, mnt.Path)
 				}


### PR DESCRIPTION
## Summary

Phase 2 of the v2 unified kit-spec migration. Single breaking change in this PR:

- Adds `MountSpec.Type` (valid values: `""` for the default block-backed mount, `"tmpfs"` for a RAM-backed mount).
- Drops `Manifest.Tmpfs`. Tmpfs entries now live in `Manifest.Volumes`, distinguished by `Type`.
- Adds `Manifest.TmpfsVolumes()` helper for callers that previously read the separate slice. The `tck` package uses it.
- `ValidateTmpfs` is gone; `ValidateVolumes` covers all entries and gains a Type-enum check.

**Breaking change.** v1 kits with a top-level `tmpfs:` block strict-decode-reject at load time with:

> `field tmpfs not found in type spec.specFile`

Kit authors migrate by moving each `tmpfs:` entry into `volumes:` with `type: tmpfs`:

```yaml
# Before (v1)
tmpfs:
  - path: /tmp/scratch
    size: 512m

# After (v2)
volumes:
  - path: /tmp/scratch
    type: tmpfs
    size: 512m
```

The sandboxes-side consumer changes (and the corresponding pseudo-version pin) ship in the matching docker/sandboxes PR, which is stacked on the in-flight Phase 1 sandboxes PR (#3177 on docker/sandboxes).

## Test plan

- [x] `go test ./spec ./tck` green
- [x] Three new spec tests: `TestVolumesType_TmpfsAccepted`, `TestV1TmpfsBlock_StrictRejected`, `TestValidateArtifact_MountSpecType`
- [x] No built-in or contrib kits used the v1 `tmpfs:` block (zero kit spec.yaml migrations needed in-tree).

## Refs

- Design doc: docker/sandboxes `docs/specs/2026-05-27-unified-kit-spec-v2.md` (Phase 2)
- Phase 2 plan: docker/sandboxes `docs/specs/2026-05-28-unified-kit-spec-v2-phase2-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)