### PR TITLE
codex-app-server: self-healing ProxyCommand + auto-Include + port cache

### DIFF
--- a/codex-app-server/README.md
+++ b/codex-app-server/README.md
@@ -32,96 +32,153 @@ A full Codex GUI experience pointed at an sbx sandbox, including:
   port on every connect, so you can stop a sandbox between sessions
   and pick up where you left off.
 
-The kit ships two host-side helpers under `bin/` —
-`sbx-codex-attach` and `sbx-codex-detach` — that handle port
-publishing and per-sandbox SSH config wiring so the GUI flow is two
-commands per sandbox.
+## Quick start
 
-## One-time host setup
+Install `jq` (`brew install jq` — `nc` ships with macOS), then drop
+this in your `~/.bashrc` / `~/.zshrc`:
 
-Symlink the helpers onto your PATH:
+```bash
+# Create-or-wake a sandbox and wire it for the Codex Mac GUI. Idempotent;
+# safe to run repeatedly. After it returns, add an SSH Connection in the
+# Codex app using the printed alias name.
+sbx_codex() {
+    local name="${1:?usage: sbx_codex <name> [path]}"
+    local path="${2:-.}"
+    local kit="git+https://github.com/docker/sbx-kits-contrib.git#dir=codex-app-server"
+
+    if ! sbx ls -q | grep -qx "$name"; then
+        sbx create --clone --kit "$kit" --name "$name" codex "$path" || return
+    else
+        sbx run -d "$name" >/dev/null || return
+    fi
+
+    # Self-heal: kit-added-post-create sandboxes don't always fire startup
+    # hooks on wake. No-op when sshd's already up.
+    sbx exec "$name" -- /home/agent/.local/bin/refresh-authorized-keys 2>/dev/null || true
+    sbx exec -u 0 "$name" -- sh -c \
+        'pgrep -x sshd >/dev/null || { mkdir -p /var/run/sshd && /usr/sbin/sshd > /tmp/sshd.log 2>&1; }' || true
+
+    # Publish sandbox port 22 (ephemeral host port) if not already.
+    sbx ports "$name" --json | jq -e '.[]|select(.sandbox_port==22 and .host_ip=="127.0.0.1")' >/dev/null \
+        || sbx ports "$name" --publish 22/tcp >/dev/null
+
+    local dir="$HOME/.sbx/ssh/codex"
+    mkdir -p "$dir"; chmod 700 "$dir"
+    local sbx_bin nc_bin jq_bin
+    sbx_bin=$(command -v sbx); nc_bin=$(command -v nc); jq_bin=$(command -v jq)
+
+    # Shared self-healing ProxyCommand: fast path reads cached port +
+    # `nc -z` probe; slow path wakes the sandbox, restarts sshd if dead,
+    # re-publishes the port, refreshes the cache.
+    cat > "$dir/proxy.sh" <<EOF
+#!/bin/sh
+NAME="\$1"; CACHE="$dir/\${NAME}.port"
+port=\$(cat "\$CACHE" 2>/dev/null)
+if [ -n "\$port" ] && ${nc_bin} -z -G 1 localhost "\$port" 2>/dev/null; then
+    exec ${nc_bin} localhost "\$port"
+fi
+${sbx_bin} exec "\$NAME" -- pgrep -x sshd >/dev/null 2>&1 || {
+    ${sbx_bin} exec "\$NAME" -- /home/agent/.local/bin/refresh-authorized-keys 2>/dev/null
+    ${sbx_bin} exec -u 0 "\$NAME" -- sh -c 'pgrep -x sshd >/dev/null || { mkdir -p /var/run/sshd && /usr/sbin/sshd > /tmp/sshd.log 2>&1; }'
+}
+${sbx_bin} ports "\$NAME" --json | ${jq_bin} -e '.[]|select(.sandbox_port==22 and .host_ip=="127.0.0.1")' >/dev/null \\
+    || ${sbx_bin} ports "\$NAME" --publish 22/tcp >/dev/null
+port=\$(${sbx_bin} ports "\$NAME" --json | ${jq_bin} -r '.[]|select(.sandbox_port==22 and .host_ip=="127.0.0.1").host_port' | head -1)
+printf '%s' "\$port" > "\$CACHE"
+exec ${nc_bin} localhost "\$port"
+EOF
+    chmod 700 "$dir/proxy.sh"
+
+    : > "$dir/$name.known_hosts"; chmod 600 "$dir/$name.known_hosts"
+    rm -f "$dir/$name.port"
+    cat > "$dir/$name.conf" <<EOF
+Host $name
+    HostName localhost
+    User agent
+    ProxyCommand $dir/proxy.sh $name
+    HostKeyAlias $name
+    UserKnownHostsFile $dir/$name.known_hosts
+    StrictHostKeyChecking accept-new
+EOF
+    chmod 600 "$dir/$name.conf"
+
+    # Ensure ~/.ssh/config picks up our include (idempotent).
+    local sc="$HOME/.ssh/config"
+    mkdir -p "$HOME/.ssh"; chmod 700 "$HOME/.ssh"
+    touch "$sc"; chmod 600 "$sc"
+    if ! grep -Fxq 'Include ~/.sbx/ssh/codex/*.conf' "$sc"; then
+        { printf '# Added by sbx_codex\nInclude ~/.sbx/ssh/codex/*.conf\n\n'; cat "$sc"; } > "$sc.tmp" && mv "$sc.tmp" "$sc"
+        chmod 600 "$sc"
+    fi
+
+    echo "ready — add SSH Connection in Codex Mac app:  Host: $name"
+}
+```
+
+Then run a sandbox:
+
+```console
+$ sbx_codex myproject ~/myproject
+ready — add SSH Connection in Codex Mac app:  Host: myproject
+```
+
+In the Codex Mac app, **Connections → Add SSH Connection**, enter
+`myproject` as the host. Auth comes from your SSH agent (1Password,
+ssh-agent, …) — no on-disk identity file needed.
+
+That's it. Subsequent invocations of `sbx_codex myproject` are
+idempotent — they wake the sandbox if it stopped, refresh sshd if
+needed, and re-resolve the host port. You can have multiple sandboxes
+attached at once; each gets its own alias.
+
+## Manual install (without modifying your shell rc)
+
+If you'd rather not paste a function into your rc, the same logic is
+shipped as standalone scripts under `bin/`:
 
 ```console
 $ ln -s $(pwd)/bin/sbx-codex-{attach,detach} ~/.local/bin/
 ```
 
-Add an `Include` to the top of `~/.ssh/config` so the helpers' per-sandbox
-config snippets get picked up (by both OpenSSH and the Codex app, which
-parses the same file):
-
-```sshconfig
-Include ~/.sbx/ssh/codex/*.conf
-```
-
-Helper dependencies: `jq` and `nc` (`brew install jq` — `nc` ships with
-macOS).
-
-## Per-sandbox workflow
-
-Create the sandbox with the kit (`sbx create` boots it without
-attaching, which is what you want for GUI-driven use):
+Then per sandbox:
 
 ```console
 $ sbx create --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=codex-app-server" --name myproject codex ~/myproject
-```
-
-Attach it for the GUI:
-
-```console
 $ sbx-codex-attach myproject
-attached: myproject
-  config:       /Users/you/.sbx/ssh/codex/myproject.conf
-  known_hosts:  /Users/you/.sbx/ssh/codex/myproject.known_hosts
-…
-```
-
-In the Codex Mac app, **Connections → Add SSH Connection**, enter
-`myproject` as the host. Auth comes from whatever's in your SSH
-agent (1Password, ssh-agent, …) — no on-disk identity file needed.
-
-When you stop and want to wake the sandbox again, use `sbx run -d`
-(detached) rather than `sbx exec`:
-
-```console
-$ sbx stop myproject
-…
-$ sbx run -d myproject       # detached; sandbox stays up after this returns
-$ sbx-codex-attach myproject # re-resolve port (helper is idempotent)
-```
-
-`sbx exec`-induced wake skips re-binding the forwarded SSH agent
-socket (see [docker/sandboxes#3190](https://github.com/docker/sandboxes/issues/3190))
-which can leave the kit's authorized_keys refresh in a stale state.
-`sbx run -d` does a full sandbox start.
-
-When you're done with the sandbox's GUI integration:
-
-```console
+# … later, when done with the GUI integration for this sandbox …
 $ sbx-codex-detach myproject
 ```
 
-(`detach` leaves the sandbox and its port publishing alone; it only
-removes the ssh-config snippet and known_hosts file. Orphans are also
-auto-pruned on the next `sbx-codex-attach` invocation.)
+The first `sbx-codex-attach` run adds the `Include ~/.sbx/ssh/codex/*.conf`
+line to `~/.ssh/config` automatically.
 
 ## What the helpers do
 
 `sbx-codex-attach <name>`:
-- Publishes sandbox port 22 to an ephemeral host port (if not already
-  published).
-- Writes `~/.sbx/ssh/codex/<name>.conf` with a `ProxyCommand` that
-  resolves the host port dynamically on each connect via
-  `sbx ports <name> --json` — so sandbox restarts that change the host
-  port still work without re-attaching.
-- Sets `HostKeyAlias <name>` and a per-sandbox
-  `UserKnownHostsFile`, so known_hosts entries survive port changes
-  and are easy to nuke per sandbox.
+- Adds `Include ~/.sbx/ssh/codex/*.conf` to `~/.ssh/config` on first run.
+- Publishes sandbox port 22 to an ephemeral host port if not already
+  published.
+- Writes `~/.sbx/ssh/codex/<name>.conf` pointing at a shared
+  self-healing `proxy.sh` wrapper:
+  - **Fast path** (steady state): reads a cached host port, probes it
+    with `nc -z`, exec's `nc` — no sbx round trips, ~50ms.
+  - **Slow path** (sandbox stopped / sshd dead / port unmapped): wakes
+    the sandbox, fires the kit's startup hooks if they didn't (works
+    around the kit-added-post-create gap), re-publishes port 22 if
+    needed, refreshes the cache, exec's `nc`. ~1s.
+- Sets `HostKeyAlias <name>` and a per-sandbox `UserKnownHostsFile`,
+  so known_hosts entries survive port changes and are easy to nuke
+  per sandbox.
+- Sweeps orphan files for sandboxes that no longer exist.
 
 `sbx-codex-detach <name>`:
-- Removes the two files under `~/.sbx/ssh/codex/`. Idempotent.
+- Removes the per-sandbox conf, known_hosts, and port cache under
+  `~/.sbx/ssh/codex/`. Leaves the shared `proxy.sh` alone (used by
+  other attached sandboxes). Idempotent.
 
 This means **parallel sandboxes work natively** — each gets its own
-ephemeral host port and its own GUI alias, no conflicts.
+ephemeral host port, its own GUI alias, and its own port cache, no
+conflicts.
 
 ## How authentication works
 

--- a/codex-app-server/bin/sbx-codex-attach
+++ b/codex-app-server/bin/sbx-codex-attach
@@ -2,14 +2,21 @@
 # sbx-codex-attach <sandbox-name>
 #
 # Wires a sandbox started with the codex-app-server kit into the Codex Mac
-# GUI: publishes sshd's port ephemerally (if not already published), writes
-# a per-sandbox ~/.sbx/ssh/codex/<name>.conf snippet, and bootstraps a
-# per-sandbox known_hosts file. After running this, the user adds an SSH
-# Connection in the Codex app using the alias `<name>`.
+# GUI. On first run it also adds the `Include ~/.sbx/ssh/codex/*.conf` line
+# to ~/.ssh/config so the generated per-sandbox aliases are picked up.
 #
-# The generated ssh config uses ProxyCommand + HostKeyAlias so the alias
-# keeps working across sandbox restarts (host port may change, host keys
-# don't).
+# Each per-sandbox conf points at a shared self-healing proxy.sh wrapper
+# that:
+#   - fast path: reads a cached host port, probes it with `nc -z`, exec's
+#     nc if it answers — no sbx round trips when the sandbox is healthy.
+#   - slow path: wakes the sandbox, fires the kit's startup hooks if they
+#     didn't (kit-added-post-create gap), re-publishes port 22 if needed
+#     (publishing doesn't survive sandbox stop), refreshes the cache, then
+#     exec's nc.
+#
+# After running this, add an SSH Connection in the Codex Mac app with the
+# sandbox name as the host. Auth comes from your host SSH agent (the kit
+# pre-populates ~/.ssh/authorized_keys in the sandbox from `ssh-add -L`).
 
 set -euo pipefail
 
@@ -23,6 +30,9 @@ sandbox="$1"
 require() {
     if ! command -v "$1" >/dev/null 2>&1; then
         echo "sbx-codex-attach: required tool '$1' not on PATH" >&2
+        case "$1" in
+            jq) echo "  install with: brew install jq" >&2 ;;
+        esac
         exit 127
     fi
     command -v "$1"
@@ -32,7 +42,7 @@ sbx="$(require sbx)"
 nc="$(require nc)"
 jq="$(require jq)"
 
-if ! "$sbx" ls 2>/dev/null | awk 'NR>1 {print $1}' | grep -qx "$sandbox"; then
+if ! "$sbx" ls -q 2>/dev/null | grep -qx "$sandbox"; then
     echo "sbx-codex-attach: sandbox '$sandbox' not found" >&2
     echo "  (sbx ls shows the sandboxes you've created)" >&2
     exit 1
@@ -49,13 +59,47 @@ dir="$HOME/.sbx/ssh/codex"
 mkdir -p "$dir"
 chmod 700 "$dir"
 
+proxy="$dir/proxy.sh"
 conf="$dir/${sandbox}.conf"
 khf="$dir/${sandbox}.known_hosts"
+cache="$dir/${sandbox}.port"
 
-# Truncate the per-sandbox known_hosts so the next connect TOFUs cleanly
+# Shared self-healing ProxyCommand. Tool paths are baked from the calling
+# shell's resolution; re-run sbx-codex-attach if any tool moves.
+cat > "$proxy" <<EOF
+#!/bin/sh
+# Auto-managed by sbx-codex-attach (shared across all attached sandboxes).
+# Usage: proxy.sh <sandbox-name>  — wired in via each <name>.conf.
+NAME="\$1"
+CACHE="$dir/\${NAME}.port"
+
+port=\$(cat "\$CACHE" 2>/dev/null)
+if [ -n "\$port" ] && ${nc} -z -G 1 localhost "\$port" 2>/dev/null; then
+    exec ${nc} localhost "\$port"
+fi
+
+${sbx} exec "\$NAME" -- pgrep -x sshd >/dev/null 2>&1 || {
+    ${sbx} exec "\$NAME" -- /home/agent/.local/bin/refresh-authorized-keys 2>/dev/null
+    ${sbx} exec -u 0 "\$NAME" -- sh -c 'pgrep -x sshd >/dev/null || { mkdir -p /var/run/sshd && /usr/sbin/sshd > /tmp/sshd.log 2>&1; }'
+}
+${sbx} ports "\$NAME" --json | ${jq} -e '.[]|select(.sandbox_port==22 and .host_ip=="127.0.0.1")' >/dev/null \\
+    || ${sbx} ports "\$NAME" --publish 22/tcp >/dev/null
+# head -1 because sbx ports --publish isn't idempotent on re-runs — repeated
+# calls can leave multiple host ports mapped to sandbox 22; we just need one.
+port=\$(${sbx} ports "\$NAME" --json | ${jq} -r '.[]|select(.sandbox_port==22 and .host_ip=="127.0.0.1").host_port' | head -1)
+printf '%s' "\$port" > "\$CACHE"
+exec ${nc} localhost "\$port"
+EOF
+chmod 700 "$proxy"
+
+# Truncate per-sandbox known_hosts so the next connect TOFUs cleanly
 # (handles sandbox recreate, which generates new host keys).
 : > "$khf"
 chmod 600 "$khf"
+
+# Clear stale cache so the first ssh after attach takes the slow path
+# and writes a fresh one.
+rm -f "$cache"
 
 cat > "$conf" <<EOF
 # Auto-managed by sbx-codex-attach for sandbox '${sandbox}'.
@@ -63,23 +107,44 @@ cat > "$conf" <<EOF
 Host ${sandbox}
     HostName localhost
     User agent
-    ProxyCommand sh -c 'exec ${nc} localhost \$(${sbx} ports ${sandbox} --json | ${jq} -r ".[]|select(.sandbox_port==22 and .host_ip==\"127.0.0.1\").host_port")'
+    ProxyCommand ${proxy} ${sandbox}
     HostKeyAlias ${sandbox}
     UserKnownHostsFile ${khf}
     StrictHostKeyChecking accept-new
 EOF
 chmod 600 "$conf"
 
+# Ensure ~/.ssh/config picks up our include. Idempotent: only adds the line
+# if absent. Wrapped in markers so a future detach-all could remove it
+# cleanly if we ever add that.
+ssh_config="$HOME/.ssh/config"
+include_line="Include ~/.sbx/ssh/codex/*.conf"
+mkdir -p "$HOME/.ssh"
+chmod 700 "$HOME/.ssh"
+touch "$ssh_config"
+chmod 600 "$ssh_config"
+if ! grep -Fxq "$include_line" "$ssh_config"; then
+    # Include directives must come BEFORE any Host blocks they apply to —
+    # prepend so existing Host * etc. inherits.
+    tmp="$(mktemp)"
+    {
+        printf '# Added by sbx-codex-attach\n%s\n\n' "$include_line"
+        cat "$ssh_config"
+    } > "$tmp"
+    mv "$tmp" "$ssh_config"
+    chmod 600 "$ssh_config"
+    echo "added to ~/.ssh/config: $include_line"
+fi
+
 # Sweep orphan attachments — files for sandboxes that no longer exist.
-# Best-effort: if `sbx ls` fails we skip pruning rather than risk
-# deleting files we can't verify are orphaned.
+# Glob on *.conf only (proxy.sh, *.known_hosts, *.port are referenced by them).
 if existing="$("$sbx" ls -q 2>/dev/null)"; then
     for orphan_conf in "$dir"/*.conf; do
         [ -e "$orphan_conf" ] || continue
         orphan_name="${orphan_conf##*/}"
         orphan_name="${orphan_name%.conf}"
         if ! printf '%s\n' "$existing" | grep -qx "$orphan_name"; then
-            rm -f -- "$orphan_conf" "$dir/${orphan_name}.known_hosts"
+            rm -f -- "$orphan_conf" "$dir/${orphan_name}.known_hosts" "$dir/${orphan_name}.port"
             echo "pruned orphan: ${orphan_name}"
         fi
     done
@@ -92,6 +157,4 @@ attached: ${sandbox}
 
 In the Codex Mac app, add an SSH Connection with:
   Host: ${sandbox}
-
-(Ensure ~/.ssh/config contains: Include ~/.sbx/ssh/codex/*.conf)
 EOF

--- a/codex-app-server/bin/sbx-codex-detach
+++ b/codex-app-server/bin/sbx-codex-detach
@@ -1,10 +1,11 @@
 #!/bin/bash
 # sbx-codex-detach <sandbox-name>
 #
-# Reverses sbx-codex-attach: removes the per-sandbox ssh config snippet and
-# known_hosts file under ~/.sbx/ssh/codex/. Does NOT unpublish the sshd
-# port or touch the sandbox itself — port publishing follows the sandbox
-# lifecycle.
+# Reverses sbx-codex-attach: removes the per-sandbox ssh config snippet,
+# known_hosts file, and port cache under ~/.sbx/ssh/codex/. Does NOT
+# unpublish the sshd port, remove the shared proxy.sh, or touch the
+# sandbox itself — port publishing follows the sandbox lifecycle, and
+# proxy.sh is shared with any other attached sandboxes.
 
 set -euo pipefail
 
@@ -17,9 +18,10 @@ sandbox="$1"
 dir="$HOME/.sbx/ssh/codex"
 conf="$dir/${sandbox}.conf"
 khf="$dir/${sandbox}.known_hosts"
+cache="$dir/${sandbox}.port"
 
 removed=0
-for f in "$conf" "$khf"; do
+for f in "$conf" "$khf" "$cache"; do
     if [ -e "$f" ]; then
         rm -- "$f"
         echo "removed: $f"


### PR DESCRIPTION
Follow-up to #57 making the codex-app-server kit easier to install and faster to use.

**Quick start, one snippet** — paste a `sbx_codex` bash function in your rc, `brew install jq` once, then `sbx_codex myproject ~/myproject`. No symlinks, no manual `~/.ssh/config` edit, no per-sandbox attach command. The standalone `bin/sbx-codex-{attach,detach}` scripts still ship for users who'd rather not modify their shell rc.

**Self-healing ProxyCommand** — per-sandbox confs now point at a shared `proxy.sh` wrapper. Fast path (~50ms) reads a cached host port + `nc -z` probes; slow path (~1s) wakes the sandbox, restarts sshd if dead (works around the kit-added-post-create gap), re-publishes port 22 (publishing doesn't survive sandbox stop), refreshes the cache. The GUI keeps working across stop/wake cycles without manual intervention — important for `--clone` sandboxes where `sbx rm` to recover isn't an option.

**Bonus polish** — first-run `~/.ssh/config` auto-includes `~/.sbx/ssh/codex/*.conf`; port cache included in detach + orphan-sweep cleanups.

Spec unchanged → no TCK update needed. Manually validated end-to-end from a clean `bash --noprofile --norc`.

Related: docker/sandboxes#3190.