### PR TITLE
Phase 3: credentials[] + caps.network + bindings file format + parsers

### DIFF
--- a/bindings/bindings_test.go
+++ b/bindings/bindings_test.go
@@ -1,0 +1,134 @@
+package bindings
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoad_ParsesExampleFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "credentials.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+bindings:
+  anthropic:
+    discovery:
+      - env: [ANTHROPIC_API_KEY]
+    allowedDomains: [api.anthropic.com]
+
+  github:
+    discovery:
+      - env: [GH_TOKEN, GITHUB_TOKEN]
+      - file:
+          path: ~/.config/gh/token
+    allowedDomains: [api.github.com, github.com]
+`), 0o600))
+
+	b, err := Load(path)
+	require.NoError(t, err)
+	require.NotNil(t, b)
+	require.Contains(t, b.Bindings, "anthropic")
+	require.Len(t, b.Bindings["anthropic"].Discovery, 1)
+	require.Equal(t, []string{"ANTHROPIC_API_KEY"}, b.Bindings["anthropic"].Discovery[0].Env)
+	require.Equal(t, []string{"api.anthropic.com"}, b.Bindings["anthropic"].AllowedDomains)
+
+	require.Contains(t, b.Bindings, "github")
+	require.Len(t, b.Bindings["github"].Discovery, 2)
+	require.Equal(t, []string{"GH_TOKEN", "GITHUB_TOKEN"}, b.Bindings["github"].Discovery[0].Env)
+	require.NotNil(t, b.Bindings["github"].Discovery[1].File)
+	require.Equal(t, "~/.config/gh/token", b.Bindings["github"].Discovery[1].File.Path)
+}
+
+func TestLoad_MissingFileIsError(t *testing.T) {
+	_, err := Load("/nonexistent/credentials.yaml")
+	require.Error(t, err)
+}
+
+func TestLoad_EmptyPathIsError(t *testing.T) {
+	_, err := Load("")
+	require.Error(t, err)
+}
+
+func TestLoad_MalformedYAMLRejected(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "credentials.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("bindings:\n  : oops\n  - unbalanced"), 0o600))
+	_, err := Load(path)
+	require.ErrorContains(t, err, "parse")
+}
+
+func TestLoad_DiscoveryWithBothEnvAndFileRejected(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "credentials.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+bindings:
+  bad:
+    discovery:
+      - env: [FOO]
+        file:
+          path: ~/foo
+    allowedDomains: [foo.example.com]
+`), 0o600))
+	_, err := Load(path)
+	require.ErrorContains(t, err, "exactly one of env or file")
+}
+
+func TestLoad_EmptyDiscoveryRejected(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "credentials.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+bindings:
+  bad:
+    discovery: []
+    allowedDomains: [foo.example.com]
+`), 0o600))
+	_, err := Load(path)
+	require.ErrorContains(t, err, "discovery list cannot be empty")
+}
+
+func TestLoad_FilePathRequired(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "credentials.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+bindings:
+  bad:
+    discovery:
+      - file: {}
+    allowedDomains: [foo.example.com]
+`), 0o600))
+	_, err := Load(path)
+	require.ErrorContains(t, err, "file.path is required")
+}
+
+func TestDefaultPath_ResolvesXDGConfigHome(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("XDG_CONFIG_HOME is a non-Windows convention")
+	}
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	path := DefaultPath()
+	require.True(t, strings.HasPrefix(path, dir),
+		"DefaultPath should resolve under XDG_CONFIG_HOME (%q), got %q", dir, path)
+	require.True(t, strings.HasSuffix(path, "sbx/credentials.yaml"),
+		"DefaultPath should end with sbx/credentials.yaml, got %q", path)
+}
+
+func TestDefaultPath_FallsBackToHomeDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("home-dir convention is non-Windows")
+	}
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	path := DefaultPath()
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(path, home),
+		"DefaultPath should fall back under $HOME (%q), got %q", home, path)
+	require.True(t, strings.HasSuffix(path, ".config/sbx/credentials.yaml"),
+		"DefaultPath should end with .config/sbx/credentials.yaml on non-Windows, got %q", path)
+}

--- a/bindings/bindings_test.go
+++ b/bindings/bindings_test.go
@@ -77,17 +77,24 @@ bindings:
 	require.ErrorContains(t, err, "exactly one of env or file")
 }
 
-func TestLoad_EmptyDiscoveryRejected(t *testing.T) {
+func TestLoad_EmptyDiscoveryAccepted(t *testing.T) {
+	// Discovery is optional — a binding with only allowedDomains is the
+	// canonical way to express "the value lives in the secret store, I'm
+	// just declaring the trust scope here." The resolver consults the
+	// store before any user-declared discovery entries so an empty
+	// discovery list is well-formed.
 	dir := t.TempDir()
 	path := filepath.Join(dir, "credentials.yaml")
 	require.NoError(t, os.WriteFile(path, []byte(`
 bindings:
-  bad:
+  store-only:
     discovery: []
     allowedDomains: [foo.example.com]
 `), 0o600))
-	_, err := Load(path)
-	require.ErrorContains(t, err, "discovery list cannot be empty")
+	b, err := Load(path)
+	require.NoError(t, err)
+	require.Equal(t, []string{"foo.example.com"}, b.Bindings["store-only"].AllowedDomains)
+	require.Empty(t, b.Bindings["store-only"].Discovery)
 }
 
 func TestLoad_FilePathRequired(t *testing.T) {

--- a/bindings/load.go
+++ b/bindings/load.go
@@ -1,0 +1,74 @@
+package bindings
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"go.yaml.in/yaml/v3"
+)
+
+// configDirName is the per-user sbx config directory under the
+// platform-conventional config root. Joined with credentialsFileName
+// for the absolute path.
+const (
+	configDirName       = "sbx"
+	credentialsFileName = "credentials.yaml"
+)
+
+// DefaultPath returns the platform-conventional path to the user
+// credentials.yaml file:
+//
+//   - Linux/macOS: $XDG_CONFIG_HOME/sbx/credentials.yaml if XDG_CONFIG_HOME
+//     is set; otherwise $HOME/.config/sbx/credentials.yaml.
+//   - Windows:     %APPDATA%\sbx\credentials.yaml.
+//
+// Returns an empty string when none of the expected env vars / home
+// directory can be resolved; callers should treat that as "no bindings
+// file available" and surface an actionable error.
+func DefaultPath() string {
+	if runtime.GOOS == "windows" {
+		if appdata := os.Getenv("APPDATA"); appdata != "" {
+			return filepath.Join(appdata, configDirName, credentialsFileName)
+		}
+		return ""
+	}
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		return filepath.Join(xdg, configDirName, credentialsFileName)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".config", configDirName, credentialsFileName)
+}
+
+// Load reads and parses the bindings file at path. Returns an error
+// when the file is missing, malformed, or fails validation — by design,
+// a missing file is NOT silently treated as "no bindings declared,"
+// because that would conflate two distinct user states (haven't set up
+// bindings yet vs. deliberately have no service-binding-needing kits).
+// The resolver's hard-fail error message points the user at the
+// expected path so first-time setup is discoverable.
+func Load(path string) (*UserBindings, error) {
+	if path == "" {
+		return nil, fmt.Errorf("bindings: file path is empty (no XDG_CONFIG_HOME/HOME/APPDATA?)")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("bindings: read %s: %w", path, err)
+	}
+
+	var b UserBindings
+	if err := yaml.Unmarshal(data, &b); err != nil {
+		return nil, fmt.Errorf("bindings: parse %s: %w", path, err)
+	}
+
+	if err := Validate(&b); err != nil {
+		return nil, fmt.Errorf("bindings: validate %s: %w", path, err)
+	}
+
+	return &b, nil
+}

--- a/bindings/parser.go
+++ b/bindings/parser.go
@@ -1,0 +1,77 @@
+package bindings
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrParserMalformed indicates the parser spec itself is invalid (unknown
+// prefix, empty path after `json:`). It is distinct from a parser that runs
+// successfully but finds nothing — see ErrParserMiss for that.
+var ErrParserMalformed = errors.New("bindings: parser spec malformed")
+
+// ErrParserMiss indicates the parser ran cleanly against the file content
+// but the requested key was not present (or the structure didn't match).
+// Resolvers treat this as "no value here" — equivalent to an unset env var
+// in priority terms — rather than as a hard error.
+var ErrParserMiss = errors.New("bindings: parser found no value")
+
+// ParseValue extracts a credential value from raw file bytes according to
+// the parser spec from DiscoveryFile.Parser. The supported parsers come
+// directly from the RFC §Discovery Sources table:
+//
+//   - "" or "raw": return the file content trimmed of trailing whitespace.
+//     Trailing-only trim is intentional — credentials that legitimately
+//     begin with whitespace are extraordinarily rare, while files written
+//     by tools like `echo "$TOKEN" > token` reliably end with a newline.
+//
+//   - "json:a.b.c": treat the file as JSON, walk the dotted path, and
+//     return the value at the leaf as a string. Dots inside a key are not
+//     escapable in this commit — the RFC leaves keys-with-dots open and a
+//     follow-up can introduce a quoting form if real configs need it.
+//     Non-string leaves (numbers, bools) are rejected with ErrParserMiss
+//     because credentials are always strings in this codebase.
+func ParseValue(content []byte, parser string) (string, error) {
+	switch {
+	case parser == "" || parser == "raw":
+		return strings.TrimRight(string(content), " \t\r\n"), nil
+
+	case strings.HasPrefix(parser, "json:"):
+		path := strings.TrimPrefix(parser, "json:")
+		if path == "" {
+			return "", fmt.Errorf("%w: %q has empty json path", ErrParserMalformed, parser)
+		}
+		return parseJSONPath(content, path)
+
+	default:
+		return "", fmt.Errorf("%w: unknown parser %q", ErrParserMalformed, parser)
+	}
+}
+
+func parseJSONPath(content []byte, path string) (string, error) {
+	var root any
+	if err := json.Unmarshal(content, &root); err != nil {
+		return "", fmt.Errorf("%w: invalid JSON: %v", ErrParserMiss, err)
+	}
+
+	cur := root
+	for _, segment := range strings.Split(path, ".") {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return "", fmt.Errorf("%w: %q: parent of %q is not an object", ErrParserMiss, path, segment)
+		}
+		next, present := m[segment]
+		if !present {
+			return "", fmt.Errorf("%w: %q: key %q not present", ErrParserMiss, path, segment)
+		}
+		cur = next
+	}
+
+	s, ok := cur.(string)
+	if !ok {
+		return "", fmt.Errorf("%w: %q: leaf is %T, not string", ErrParserMiss, path, cur)
+	}
+	return s, nil
+}

--- a/bindings/parser_test.go
+++ b/bindings/parser_test.go
@@ -1,0 +1,105 @@
+package bindings
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestParseValue_RawAndEmpty(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		parser  string
+		want    string
+	}{
+		{"empty parser is raw", "sk-ant-abc\n", "", "sk-ant-abc"},
+		{"explicit raw", "sk-ant-abc\n", "raw", "sk-ant-abc"},
+		{"raw preserves leading whitespace", " sk-ant-abc\n", "raw", " sk-ant-abc"},
+		{"raw strips multiple trailing newlines", "tok\n\n\n", "raw", "tok"},
+		{"raw strips trailing CRLF", "tok\r\n", "raw", "tok"},
+		{"raw on multi-line content keeps internal newlines", "line1\nline2\n", "raw", "line1\nline2"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseValue([]byte(tc.content), tc.parser)
+			if err != nil {
+				t.Fatalf("ParseValue: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseValue_JSONPath(t *testing.T) {
+	doc := []byte(`{"apiKey":"sk-top","credentials":{"token":"sk-nested","meta":{"version":"v1"}}}`)
+	cases := []struct {
+		name   string
+		parser string
+		want   string
+	}{
+		{"top-level key", "json:apiKey", "sk-top"},
+		{"nested two-segment", "json:credentials.token", "sk-nested"},
+		{"nested three-segment", "json:credentials.meta.version", "v1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseValue(doc, tc.parser)
+			if err != nil {
+				t.Fatalf("ParseValue(%s): %v", tc.parser, err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseValue_JSONPath_Misses(t *testing.T) {
+	doc := []byte(`{"apiKey":"sk-top","count":42,"flag":true,"nested":{"key":"v"}}`)
+	cases := []struct {
+		name   string
+		parser string
+	}{
+		{"missing top-level key", "json:missing"},
+		{"missing nested key", "json:nested.missing"},
+		{"walks through non-object", "json:apiKey.further"},
+		{"leaf is number", "json:count"},
+		{"leaf is bool", "json:flag"},
+		{"leaf is object", "json:nested"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseValue(doc, tc.parser)
+			if !errors.Is(err, ErrParserMiss) {
+				t.Errorf("got err=%v, want ErrParserMiss", err)
+			}
+		})
+	}
+}
+
+func TestParseValue_JSONPath_InvalidJSON(t *testing.T) {
+	_, err := ParseValue([]byte(`{not json`), "json:foo")
+	if !errors.Is(err, ErrParserMiss) {
+		t.Errorf("got err=%v, want ErrParserMiss", err)
+	}
+}
+
+func TestParseValue_MalformedParserSpec(t *testing.T) {
+	cases := []struct {
+		name   string
+		parser string
+	}{
+		{"unknown parser", "yaml:foo"},
+		{"json with empty path", "json:"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseValue([]byte(`{"k":"v"}`), tc.parser)
+			if !errors.Is(err, ErrParserMalformed) {
+				t.Errorf("got err=%v, want ErrParserMalformed", err)
+			}
+		})
+	}
+}

--- a/bindings/types.go
+++ b/bindings/types.go
@@ -1,0 +1,72 @@
+// Package bindings defines the user-side credential bindings file format
+// (`~/.config/sbx/credentials.yaml` on Linux/macOS, `%APPDATA%\sbx\
+// credentials.yaml` on Windows). The file declares, per service, where
+// the user wants their credentials to come from and which domains the
+// engine may inject the resolved value into.
+//
+// Why this exists: pre-Phase-3 kits declared credential discovery in
+// their own spec.yaml (`credentials.sources[svc].env`,
+// `network.allowedDomains`). Phase 3 moved the kit-side declaration to
+// "what the kit needs" (service identity, inject domains/headers); the
+// "where the credential lives" half of the contract moves out of the
+// kit and into this user-controlled file. The split lets a kit ship a
+// minimal description and lets the user point sbx at whatever
+// credential storage they actually use.
+//
+// Commit 10 ships the file format, the loader, and basic validation.
+// The resolver runtime integration (commit 11) walks these bindings as
+// one of several candidate buckets and enforces inject-domain ∈
+// allowedDomains intersection at injection time.
+package bindings
+
+// UserBindings is the on-disk credentials.yaml shape. Decoded directly
+// from YAML by Load.
+type UserBindings struct {
+	// Bindings maps a service identifier to its discovery + allow-list
+	// declaration. The service identifier matches the kit's
+	// credentials[].service from the v2 spec.
+	Bindings map[string]Binding `yaml:"bindings"`
+}
+
+// Binding is the per-service declaration: how to find the credential
+// on the host (Discovery) and which domains the engine may inject the
+// resolved value into (AllowedDomains).
+type Binding struct {
+	// Discovery is a non-empty list of places to look for this
+	// credential on the host. Entries are tried in order; the first
+	// entry that yields a value wins.
+	Discovery []DiscoverySpec `yaml:"discovery"`
+
+	// AllowedDomains is the explicit list of domains the engine may
+	// inject this credential into. Cross-checked against the kit's
+	// credentials[].apiKey.inject[].domain at sandbox-create time;
+	// inject domains not in AllowedDomains are silently dropped from
+	// the injection set with a one-line warning in interactive
+	// contexts.
+	AllowedDomains []string `yaml:"allowedDomains"`
+}
+
+// DiscoverySpec is one place to look for a credential. Exactly one of
+// Env or File should be non-nil per entry; an entry with both is
+// rejected at validate time.
+type DiscoverySpec struct {
+	// Env lists environment variable names to check on the host, in
+	// priority order (first set wins within an Env entry).
+	Env []string `yaml:"env,omitempty"`
+
+	// File describes a file-backed credential location.
+	File *DiscoveryFile `yaml:"file,omitempty"`
+}
+
+// DiscoveryFile is the file-backed variant of a discovery entry.
+type DiscoveryFile struct {
+	// Path is the file path on the host (~ is expanded to the user's
+	// home directory before reading).
+	Path string `yaml:"path"`
+
+	// Parser describes how to extract the credential value from the
+	// file. Empty means "the entire file content trimmed of trailing
+	// whitespace." Supported parsers ship in commit 11; for the
+	// file-format commit the field is just decoded.
+	Parser string `yaml:"parser,omitempty"`
+}

--- a/bindings/validate.go
+++ b/bindings/validate.go
@@ -1,0 +1,38 @@
+package bindings
+
+import "fmt"
+
+// Validate checks the bindings file for structural well-formedness:
+// every binding has at least one discovery entry, and every discovery
+// entry has exactly one of Env or File set. Content-level rules
+// (service-name pattern, allowedDomains entry format, env-var name
+// patterns) are intentionally NOT enforced here — they belong to a
+// future RFC, tracked alongside the Phase 3 deferred validation rules
+// in docs/specs/2026-05-29-unified-kit-spec-v2-deferred-ideas.md.
+func Validate(b *UserBindings) error {
+	if b == nil {
+		return nil
+	}
+	for service, binding := range b.Bindings {
+		if service == "" {
+			return fmt.Errorf("bindings: service name cannot be empty")
+		}
+		if len(binding.Discovery) == 0 {
+			return fmt.Errorf("bindings[%q]: discovery list cannot be empty", service)
+		}
+		for i, d := range binding.Discovery {
+			envSet := len(d.Env) > 0
+			fileSet := d.File != nil
+			switch {
+			case envSet && fileSet:
+				return fmt.Errorf("bindings[%q].discovery[%d]: exactly one of env or file must be set, got both", service, i)
+			case !envSet && !fileSet:
+				return fmt.Errorf("bindings[%q].discovery[%d]: exactly one of env or file must be set, got neither", service, i)
+			}
+			if fileSet && d.File.Path == "" {
+				return fmt.Errorf("bindings[%q].discovery[%d].file.path is required", service, i)
+			}
+		}
+	}
+	return nil
+}

--- a/bindings/validate.go
+++ b/bindings/validate.go
@@ -3,12 +3,20 @@ package bindings
 import "fmt"
 
 // Validate checks the bindings file for structural well-formedness:
-// every binding has at least one discovery entry, and every discovery
-// entry has exactly one of Env or File set. Content-level rules
-// (service-name pattern, allowedDomains entry format, env-var name
-// patterns) are intentionally NOT enforced here — they belong to a
-// future RFC, tracked alongside the Phase 3 deferred validation rules
-// in docs/specs/2026-05-29-unified-kit-spec-v2-deferred-ideas.md.
+// every discovery entry (when present) has exactly one of Env or File
+// set, and File entries have a non-empty path. Discovery itself is
+// optional — a binding with only allowedDomains is legitimate when the
+// user has stored the credential in the secret store under the
+// service's canonical name (the resolver consults the store before
+// any user-declared discovery entries, so leaving discovery empty is
+// the right way to express "trust these domains; the value lives
+// where sbx secret set put it").
+//
+// Content-level rules (service-name pattern, allowedDomains entry
+// format, env-var name patterns) are intentionally NOT enforced here
+// — they belong to a future RFC, tracked alongside the Phase 3
+// deferred validation rules in
+// docs/specs/2026-05-29-unified-kit-spec-v2-deferred-ideas.md.
 func Validate(b *UserBindings) error {
 	if b == nil {
 		return nil
@@ -16,9 +24,6 @@ func Validate(b *UserBindings) error {
 	for service, binding := range b.Bindings {
 		if service == "" {
 			return fmt.Errorf("bindings: service name cannot be empty")
-		}
-		if len(binding.Discovery) == 0 {
-			return fmt.Errorf("bindings[%q]: discovery list cannot be empty", service)
 		}
 		for i, d := range binding.Discovery {
 			envSet := len(d.Env) > 0

--- a/spec/artifact.go
+++ b/spec/artifact.go
@@ -125,19 +125,15 @@ func parseArtifactBytes(data []byte) (*Artifact, error) {
 		return nil, fmt.Errorf("artifact: %w", err)
 	}
 
-	// Build the canonical Artifact.Network from LegacyNetwork's canonical
-	// fields (AllowedDomains, DeniedDomains, PublishedPorts). The
-	// serviceDomains/serviceAuth fields are deliberately not copied —
-	// normalizeLegacyCredentials already folded them into Credentials.
+	// Build the canonical Artifact.Network from LegacyNetwork's
+	// PublishedPorts (the only NetworkPolicy field that survives as a
+	// canonical concern post-Phase-3 commit 7). AllowedDomains and
+	// DeniedDomains moved to Caps.Network; ServiceDomains and
+	// ServiceAuth moved to Credentials[].ApiKey.Inject.
 	var network *NetworkPolicy
-	if spec.LegacyNetwork != nil {
-		ln := spec.LegacyNetwork
-		if len(ln.AllowedDomains) > 0 || len(ln.DeniedDomains) > 0 || len(ln.PublishedPorts) > 0 {
-			network = &NetworkPolicy{
-				AllowedDomains: ln.AllowedDomains,
-				DeniedDomains:  ln.DeniedDomains,
-				PublishedPorts: ln.PublishedPorts,
-			}
+	if spec.LegacyNetwork != nil && len(spec.LegacyNetwork.PublishedPorts) > 0 {
+		network = &NetworkPolicy{
+			PublishedPorts: spec.LegacyNetwork.PublishedPorts,
 		}
 	}
 

--- a/spec/artifact.go
+++ b/spec/artifact.go
@@ -125,16 +125,32 @@ func parseArtifactBytes(data []byte) (*Artifact, error) {
 		return nil, fmt.Errorf("artifact: %w", err)
 	}
 
+	// Build the canonical Artifact.Network from LegacyNetwork's canonical
+	// fields (AllowedDomains, DeniedDomains, PublishedPorts). The
+	// serviceDomains/serviceAuth fields are deliberately not copied —
+	// normalizeLegacyCredentials already folded them into Credentials.
+	var network *NetworkPolicy
+	if spec.LegacyNetwork != nil {
+		ln := spec.LegacyNetwork
+		if len(ln.AllowedDomains) > 0 || len(ln.DeniedDomains) > 0 || len(ln.PublishedPorts) > 0 {
+			network = &NetworkPolicy{
+				AllowedDomains: ln.AllowedDomains,
+				DeniedDomains:  ln.DeniedDomains,
+				PublishedPorts: ln.PublishedPorts,
+			}
+		}
+	}
+
 	return &Artifact{
 		Manifest:     spec.Manifest,
 		Extends:      spec.Extends,
 		Locked:       spec.Locked,
-		Network:      spec.Network,
-		Credentials:  spec.Credentials,
+		Network:      network,
+		Caps:         spec.Caps,
+		Credentials:  spec.Credentials.List,
 		Environment:  spec.Environment,
 		Settings:     spec.Settings,
 		Commands:     spec.Commands,
-		OAuth:        spec.OAuth,
 		AgentContext: spec.AgentContext,
 		Warnings:     w.messages,
 	}, nil

--- a/spec/artifact.go
+++ b/spec/artifact.go
@@ -125,30 +125,23 @@ func parseArtifactBytes(data []byte) (*Artifact, error) {
 		return nil, fmt.Errorf("artifact: %w", err)
 	}
 
-	// Build the canonical Artifact.Network from LegacyNetwork's
-	// PublishedPorts (the only NetworkPolicy field that survives as a
-	// canonical concern post-Phase-3 commit 7). AllowedDomains and
-	// DeniedDomains moved to Caps.Network; ServiceDomains and
-	// ServiceAuth moved to Credentials[].ApiKey.Inject.
-	var network *NetworkPolicy
-	if spec.LegacyNetwork != nil && len(spec.LegacyNetwork.PublishedPorts) > 0 {
-		network = &NetworkPolicy{
-			PublishedPorts: spec.LegacyNetwork.PublishedPorts,
-		}
-	}
-
+	// PublishedPorts is canonical at the top level in v2. normalize has
+	// already promoted any v1 LegacyNetwork.PublishedPorts into
+	// spec.PublishedPorts (with a deprecation warning), so this is a
+	// straight copy. AllowedDomains/DeniedDomains moved to Caps.Network;
+	// ServiceDomains/ServiceAuth moved to Credentials[].ApiKey.Inject.
 	return &Artifact{
-		Manifest:     spec.Manifest,
-		Extends:      spec.Extends,
-		Locked:       spec.Locked,
-		Network:      network,
-		Caps:         spec.Caps,
-		Credentials:  spec.Credentials.List,
-		Environment:  spec.Environment,
-		Settings:     spec.Settings,
-		Commands:     spec.Commands,
-		AgentContext: spec.AgentContext,
-		Warnings:     w.messages,
+		Manifest:       spec.Manifest,
+		Extends:        spec.Extends,
+		Locked:         spec.Locked,
+		PublishedPorts: spec.PublishedPorts,
+		Caps:           spec.Caps,
+		Credentials:    spec.Credentials.List,
+		Environment:    spec.Environment,
+		Settings:       spec.Settings,
+		Commands:       spec.Commands,
+		AgentContext:   spec.AgentContext,
+		Warnings:       w.messages,
 	}, nil
 }
 

--- a/spec/artifact_test.go
+++ b/spec/artifact_test.go
@@ -3,6 +3,7 @@ package spec
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"testing/fstest"
 
@@ -19,7 +20,7 @@ func TestLoadFromDirectory(t *testing.T) {
 		require.Equal(t, "1.0.0", a.Manifest.Version)
 		require.Equal(t, "https://example.com/sample-mixin", a.Manifest.SourceURL)
 		require.Empty(t, a.Manifest.Template, "mixins have no template")
-		require.NotNil(t, a.Network)
+		require.NotEmpty(t, a.PublishedPorts)
 		require.NotNil(t, a.Credentials)
 		require.NotNil(t, a.Environment)
 		require.NotNil(t, a.Settings)
@@ -102,47 +103,84 @@ description: "loaded from spec.yml"
 	require.Equal(t, "yml-kit", a.Manifest.Name)
 }
 
-func TestLoadFromFS_NetworkPublishedPorts(t *testing.T) {
-	// YAML round-trip for the new network.publishedPorts field: the
-	// minimal form (just container) and the full form (container +
-	// protocol + name) must both parse, defaulting protocol at use-site
-	// rather than at decode-time (the spec keeps zero values).
+func TestLoadFromFS_PublishedPorts_V2TopLevel(t *testing.T) {
+	// v2 canonical form: top-level `publishedPorts:`. The minimal form
+	// (just container) and the full form (container + protocol + name) must
+	// both parse, defaulting protocol at use-site rather than at decode-time
+	// (the spec keeps zero values). No deprecation warning.
 	fsys := fstest.MapFS{
 		"port-kit/spec.yaml": &fstest.MapFile{
-			Data: []byte(`schemaVersion: "1"
+			Data: []byte(`schemaVersion: "2"
 kind: mixin
 name: port-kit
 displayName: Port Kit
-description: "exercises network.publishedPorts"
-network:
-  publishedPorts:
-    - container: 9418
-    - container: 8080
-      protocol: tcp
-      name: web
-    - container: 53
-      protocol: udp
-      name: dns
+description: "exercises top-level publishedPorts"
+publishedPorts:
+  - container: 9418
+  - container: 8080
+    protocol: tcp
+    name: web
+  - container: 53
+    protocol: udp
+    name: dns
 `),
 		},
 	}
 
 	a, err := LoadFromFS(fsys, "port-kit")
 	require.NoError(t, err)
-	require.NotNil(t, a.Network)
-	require.Len(t, a.Network.PublishedPorts, 3)
+	require.Len(t, a.PublishedPorts, 3)
 
-	require.Equal(t, 9418, a.Network.PublishedPorts[0].Container)
-	require.Empty(t, a.Network.PublishedPorts[0].Protocol, "minimal form leaves protocol empty; consumers default it")
-	require.Empty(t, a.Network.PublishedPorts[0].Name)
+	require.Equal(t, 9418, a.PublishedPorts[0].Container)
+	require.Empty(t, a.PublishedPorts[0].Protocol, "minimal form leaves protocol empty; consumers default it")
+	require.Empty(t, a.PublishedPorts[0].Name)
 
-	require.Equal(t, 8080, a.Network.PublishedPorts[1].Container)
-	require.Equal(t, "tcp", a.Network.PublishedPorts[1].Protocol)
-	require.Equal(t, "web", a.Network.PublishedPorts[1].Name)
+	require.Equal(t, 8080, a.PublishedPorts[1].Container)
+	require.Equal(t, "tcp", a.PublishedPorts[1].Protocol)
+	require.Equal(t, "web", a.PublishedPorts[1].Name)
 
-	require.Equal(t, 53, a.Network.PublishedPorts[2].Container)
-	require.Equal(t, "udp", a.Network.PublishedPorts[2].Protocol)
-	require.Equal(t, "dns", a.Network.PublishedPorts[2].Name)
+	require.Equal(t, 53, a.PublishedPorts[2].Container)
+	require.Equal(t, "udp", a.PublishedPorts[2].Protocol)
+	require.Equal(t, "dns", a.PublishedPorts[2].Name)
+
+	for _, w := range a.Warnings {
+		require.NotContains(t, w, "publishedPorts", "canonical v2 form must not warn")
+	}
+}
+
+func TestLoadFromFS_PublishedPorts_V1NetworkDeprecated(t *testing.T) {
+	// v1 compat: `network.publishedPorts` is promoted to the canonical
+	// top-level Artifact.PublishedPorts with a deprecation warning, matching
+	// how the other v1 network.* fields migrate.
+	fsys := fstest.MapFS{
+		"port-kit/spec.yaml": &fstest.MapFile{
+			Data: []byte(`schemaVersion: "1"
+kind: mixin
+name: port-kit
+displayName: Port Kit
+description: "exercises v1 network.publishedPorts"
+network:
+  publishedPorts:
+    - container: 8080
+      protocol: tcp
+      name: web
+`),
+		},
+	}
+
+	a, err := LoadFromFS(fsys, "port-kit")
+	require.NoError(t, err)
+	require.Len(t, a.PublishedPorts, 1)
+	require.Equal(t, 8080, a.PublishedPorts[0].Container)
+	require.Equal(t, "web", a.PublishedPorts[0].Name)
+
+	var found bool
+	for _, w := range a.Warnings {
+		if strings.Contains(w, "network.publishedPorts") {
+			found = true
+		}
+	}
+	require.True(t, found, "v1 network.publishedPorts must emit a deprecation warning; got %v", a.Warnings)
 }
 
 func TestParseArtifact_NoSpecFile(t *testing.T) {

--- a/spec/artifact_test.go
+++ b/spec/artifact_test.go
@@ -41,6 +41,61 @@ func TestLoadFromDirectory(t *testing.T) {
 		require.Equal(t, []string{"--verbose", "--task-mode"}, a.Manifest.RunOptions)
 		require.Equal(t, "SAMPLE.md", a.Manifest.AIFilename)
 		require.NotEmpty(t, a.AgentContext)
+
+		// v1 network.publishedPorts is promoted to the canonical top-level
+		// PublishedPorts with a deprecation warning steering authors to the
+		// v2 spelling (sample-agent-v2 shows the canonical form).
+		require.Equal(t, []PublishedPort{{Container: 8080, Protocol: "tcp", Name: "web"}}, a.PublishedPorts)
+		var sawPortWarning bool
+		for _, w := range a.Warnings {
+			if strings.Contains(w, "network.publishedPorts") {
+				sawPortWarning = true
+			}
+		}
+		require.True(t, sawPortWarning, "v1 network.publishedPorts must warn; got %v", a.Warnings)
+	})
+
+	t.Run("sample-agent-v2", func(t *testing.T) {
+		// Canonical schemaVersion 2 reference kit: exercises the full v2
+		// surface and must load with ZERO deprecation warnings.
+		a, err := LoadFromDirectory("testdata/sample-agent-v2")
+		require.NoError(t, err)
+		require.Empty(t, a.Warnings, "canonical v2 kit must not emit deprecation warnings")
+
+		require.Equal(t, "sample-agent-v2", a.Manifest.Name)
+		require.Equal(t, KindSandbox, a.Manifest.Kind)
+		require.Equal(t, "2.0.0", a.Manifest.Version)
+		require.Equal(t, "https://example.com/sample-agent-v2", a.Manifest.SourceURL)
+		require.Equal(t, "docker/sandbox-templates:shell-docker", a.Manifest.Template)
+		require.Equal(t, []string{"sandbox.image"}, a.Locked)
+
+		// Top-level publishedPorts (the v2 home): minimal, full-tcp, and udp forms.
+		require.Equal(t, []PublishedPort{
+			{Container: 9418},
+			{Container: 8080, Protocol: "tcp", Name: "web"},
+			{Container: 53, Protocol: "udp", Name: "dns"},
+		}, a.PublishedPorts)
+
+		// Egress under caps.network (not the removed network block).
+		require.NotNil(t, a.Caps)
+		require.NotNil(t, a.Caps.Network)
+		require.ElementsMatch(t, []string{"api.anthropic.com", "api.openai.com:443", "*.example.com"}, a.Caps.Network.Allow)
+		require.ElementsMatch(t, []string{"telemetry.example.com"}, a.Caps.Network.Deny)
+
+		// Unified credentials[].
+		require.Len(t, a.Credentials, 3)
+		var services []string
+		for _, c := range a.Credentials {
+			services = append(services, c.Service)
+		}
+		require.ElementsMatch(t, []string{"anthropic", "github", "workos"}, services)
+
+		require.Len(t, a.Manifest.Volumes, 2)
+		require.NotNil(t, a.Commands)
+		require.NotEmpty(t, a.Commands.Startup)
+		require.NotEmpty(t, a.Commands.InitFiles)
+		require.NotEmpty(t, a.AgentContext)
+		require.NotEmpty(t, a.Files, "v2 reference kit ships static files")
 	})
 
 	t.Run("missing_directory", func(t *testing.T) {
@@ -101,86 +156,6 @@ description: "loaded from spec.yml"
 	a, err := LoadFromDirectory(dir)
 	require.NoError(t, err)
 	require.Equal(t, "yml-kit", a.Manifest.Name)
-}
-
-func TestLoadFromFS_PublishedPorts_V2TopLevel(t *testing.T) {
-	// v2 canonical form: top-level `publishedPorts:`. The minimal form
-	// (just container) and the full form (container + protocol + name) must
-	// both parse, defaulting protocol at use-site rather than at decode-time
-	// (the spec keeps zero values). No deprecation warning.
-	fsys := fstest.MapFS{
-		"port-kit/spec.yaml": &fstest.MapFile{
-			Data: []byte(`schemaVersion: "2"
-kind: mixin
-name: port-kit
-displayName: Port Kit
-description: "exercises top-level publishedPorts"
-publishedPorts:
-  - container: 9418
-  - container: 8080
-    protocol: tcp
-    name: web
-  - container: 53
-    protocol: udp
-    name: dns
-`),
-		},
-	}
-
-	a, err := LoadFromFS(fsys, "port-kit")
-	require.NoError(t, err)
-	require.Len(t, a.PublishedPorts, 3)
-
-	require.Equal(t, 9418, a.PublishedPorts[0].Container)
-	require.Empty(t, a.PublishedPorts[0].Protocol, "minimal form leaves protocol empty; consumers default it")
-	require.Empty(t, a.PublishedPorts[0].Name)
-
-	require.Equal(t, 8080, a.PublishedPorts[1].Container)
-	require.Equal(t, "tcp", a.PublishedPorts[1].Protocol)
-	require.Equal(t, "web", a.PublishedPorts[1].Name)
-
-	require.Equal(t, 53, a.PublishedPorts[2].Container)
-	require.Equal(t, "udp", a.PublishedPorts[2].Protocol)
-	require.Equal(t, "dns", a.PublishedPorts[2].Name)
-
-	for _, w := range a.Warnings {
-		require.NotContains(t, w, "publishedPorts", "canonical v2 form must not warn")
-	}
-}
-
-func TestLoadFromFS_PublishedPorts_V1NetworkDeprecated(t *testing.T) {
-	// v1 compat: `network.publishedPorts` is promoted to the canonical
-	// top-level Artifact.PublishedPorts with a deprecation warning, matching
-	// how the other v1 network.* fields migrate.
-	fsys := fstest.MapFS{
-		"port-kit/spec.yaml": &fstest.MapFile{
-			Data: []byte(`schemaVersion: "1"
-kind: mixin
-name: port-kit
-displayName: Port Kit
-description: "exercises v1 network.publishedPorts"
-network:
-  publishedPorts:
-    - container: 8080
-      protocol: tcp
-      name: web
-`),
-		},
-	}
-
-	a, err := LoadFromFS(fsys, "port-kit")
-	require.NoError(t, err)
-	require.Len(t, a.PublishedPorts, 1)
-	require.Equal(t, 8080, a.PublishedPorts[0].Container)
-	require.Equal(t, "web", a.PublishedPorts[0].Name)
-
-	var found bool
-	for _, w := range a.Warnings {
-		if strings.Contains(w, "network.publishedPorts") {
-			found = true
-		}
-	}
-	require.True(t, found, "v1 network.publishedPorts must emit a deprecation warning; got %v", a.Warnings)
 }
 
 func TestParseArtifact_NoSpecFile(t *testing.T) {

--- a/spec/normalize.go
+++ b/spec/normalize.go
@@ -19,6 +19,15 @@ func (s *specFile) normalize(w *warnings) error {
 	if err := s.normalizeEgress(); err != nil {
 		return err
 	}
+	if err := s.normalizeLegacyCredentials(w); err != nil {
+		return err
+	}
+	if err := s.normalizeLegacyOAuthBlock(w); err != nil {
+		return err
+	}
+	if err := s.normalizeCapsNetwork(w); err != nil {
+		return err
+	}
 	s.normalizeAgentContext(w)
 	return nil
 }
@@ -97,25 +106,24 @@ func (s *specFile) normalizeSandbox(w *warnings) error {
 	return nil
 }
 
-// normalizeSecrets converts the flat secrets: [NAME] list into credential sources.
+// normalizeSecrets converts the flat secrets: [NAME] list into v1-shape
+// credential sources stashed on Credentials.LegacySources. The later
+// normalizeLegacyCredentials pass folds them into Credentials.List.
 func (s *specFile) normalizeSecrets() error {
 	if len(s.Secrets) == 0 {
 		return nil
 	}
 
-	if s.Credentials == nil {
-		s.Credentials = &CredentialPolicy{Sources: make(map[string]CredentialSource)}
-	}
-	if s.Credentials.Sources == nil {
-		s.Credentials.Sources = make(map[string]CredentialSource)
+	if s.Credentials.LegacySources == nil {
+		s.Credentials.LegacySources = make(map[string]CredentialSource)
 	}
 
 	for _, name := range s.Secrets {
 		svc := deriveServiceKey(name)
-		if _, exists := s.Credentials.Sources[svc]; exists {
+		if _, exists := s.Credentials.LegacySources[svc]; exists {
 			return fmt.Errorf("secret %q conflicts with existing credential source %q", name, svc)
 		}
-		s.Credentials.Sources[svc] = CredentialSource{
+		s.Credentials.LegacySources[svc] = CredentialSource{
 			Env:      []string{name},
 			Required: true,
 		}
@@ -144,39 +152,274 @@ func deriveServiceKey(envVar string) string {
 	return name
 }
 
-// normalizeEgress converts the egress: {domain: hook} map into network policy.
+// normalizeEgress converts the egress: {domain: hook} map into v1-shape
+// network policy entries stashed on LegacyNetwork. The later
+// normalizeLegacyCredentials pass folds them into Credentials.List.
 func (s *specFile) normalizeEgress() error {
 	if len(s.Egress) == 0 {
 		return nil
 	}
 
-	if s.Network == nil {
-		s.Network = &NetworkPolicy{
+	if s.LegacyNetwork == nil {
+		s.LegacyNetwork = &NetworkPolicy{
 			ServiceDomains: make(map[string]string),
 			ServiceAuth:    make(map[string]ServiceAuth),
 		}
 	}
-	if s.Network.ServiceDomains == nil {
-		s.Network.ServiceDomains = make(map[string]string)
+	if s.LegacyNetwork.ServiceDomains == nil {
+		s.LegacyNetwork.ServiceDomains = make(map[string]string)
 	}
-	if s.Network.ServiceAuth == nil {
-		s.Network.ServiceAuth = make(map[string]ServiceAuth)
+	if s.LegacyNetwork.ServiceAuth == nil {
+		s.LegacyNetwork.ServiceAuth = make(map[string]ServiceAuth)
 	}
 
 	for domain, hookName := range s.Egress {
-		if existing, ok := s.Network.ServiceDomains[domain]; ok {
+		if existing, ok := s.LegacyNetwork.ServiceDomains[domain]; ok {
 			return fmt.Errorf("egress domain %q conflicts with existing serviceDomain (mapped to %q)", domain, existing)
 		}
-		s.Network.ServiceDomains[domain] = hookName
+		s.LegacyNetwork.ServiceDomains[domain] = hookName
 
-		if _, exists := s.Network.ServiceAuth[hookName]; !exists {
+		if _, exists := s.LegacyNetwork.ServiceAuth[hookName]; !exists {
 			if auth, ok := wellKnownAuth[hookName]; ok {
-				s.Network.ServiceAuth[hookName] = auth
+				s.LegacyNetwork.ServiceAuth[hookName] = auth
 			}
 		}
 	}
 
 	return nil
+}
+
+// normalizeLegacyCredentials folds the four v1 credential surfaces
+// (Credentials.LegacySources, LegacyNetwork.ServiceAuth,
+// LegacyNetwork.ServiceDomains, Environment.LegacyProxyManaged) into a
+// single canonical Credentials.List per service. Emits one deprecation
+// warning per legacy surface touched. v2 entries already present in
+// Credentials.List take precedence — a v2 entry for a given service
+// suppresses the v1 fold for that service entirely.
+//
+// After this pass, Credentials.List is the source of truth and the
+// Legacy* fields are left intact only so artifact.go can still see
+// they were present (for any diagnostic surface that wants to report
+// "kit used v1 spelling X").
+func (s *specFile) normalizeLegacyCredentials(w *warnings) error {
+	// Track which services already have v2 entries.
+	v2Services := make(map[string]bool, len(s.Credentials.List))
+	for _, c := range s.Credentials.List {
+		v2Services[c.Service] = true
+	}
+
+	// Track which legacy surfaces we actually consume, so we emit one
+	// warning per kind rather than per service.
+	var sawSources, sawServiceAuth, sawServiceDomains, sawProxyManaged bool
+
+	// Build "service -> partial Credential" from the legacy surfaces.
+	// We accumulate inject entries first (from serviceDomains+serviceAuth),
+	// then attach apiKey.Name from LegacySources, then attach Required from
+	// LegacySources.required, then fold proxyManaged as the apiKey.Name
+	// fallback if LegacySources didn't supply one.
+	type pending struct {
+		required bool
+		envName  string // becomes ApiKey.Name
+		inject   []ApiKeyInject
+	}
+	byService := make(map[string]*pending)
+
+	get := func(svc string) *pending {
+		p, ok := byService[svc]
+		if !ok {
+			p = &pending{}
+			byService[svc] = p
+		}
+		return p
+	}
+
+	// Fold v1 credentials.sources entries.
+	for svc, src := range s.Credentials.LegacySources {
+		if v2Services[svc] {
+			continue
+		}
+		sawSources = true
+		p := get(svc)
+		if src.Required {
+			p.required = true
+		}
+		if len(src.Env) > 0 {
+			p.envName = src.Env[0]
+		}
+	}
+
+	// Fold v1 network.serviceDomains + network.serviceAuth into inject entries.
+	if s.LegacyNetwork != nil {
+		// Domain -> service map; for each, emit one inject entry with header
+		// from serviceAuth if present.
+		for domain, svc := range s.LegacyNetwork.ServiceDomains {
+			if v2Services[svc] {
+				continue
+			}
+			sawServiceDomains = true
+			p := get(svc)
+			inj := ApiKeyInject{Domain: domain, Format: "%s"}
+			if auth, ok := s.LegacyNetwork.ServiceAuth[svc]; ok {
+				sawServiceAuth = true
+				inj.Header = auth.HeaderName
+				if auth.ValueFormat != "" {
+					inj.Format = auth.ValueFormat
+				}
+			}
+			p.inject = append(p.inject, inj)
+		}
+		// serviceAuth entries that have no serviceDomain partner still
+		// count as touched (and surface the warning) but contribute no
+		// inject rows by themselves.
+		if !sawServiceAuth && len(s.LegacyNetwork.ServiceAuth) > 0 {
+			sawServiceAuth = true
+		}
+	}
+
+	// Fold v1 environment.proxyManaged: each entry is an env-var name the
+	// proxy populates inside the container. Map it onto the matching
+	// pending.envName by lookup against LegacySources (if a kit lists
+	// proxyManaged: [ANTHROPIC_API_KEY], the matching service is whatever
+	// LegacySources or serviceAuth maps that env-var to). If we can't
+	// derive the service from existing data, fall back to deriveServiceKey.
+	if s.Environment != nil && len(s.Environment.LegacyProxyManaged) > 0 {
+		sawProxyManaged = true
+		// Build env-var -> service lookup from LegacySources first.
+		envToService := make(map[string]string)
+		for svc, src := range s.Credentials.LegacySources {
+			for _, e := range src.Env {
+				envToService[e] = svc
+			}
+		}
+		for _, envName := range s.Environment.LegacyProxyManaged {
+			svc, ok := envToService[envName]
+			if !ok {
+				svc = deriveServiceKey(envName)
+			}
+			if v2Services[svc] {
+				continue
+			}
+			p := get(svc)
+			if p.envName == "" {
+				p.envName = envName
+			}
+		}
+	}
+
+	// Materialize Credential entries in a stable order (sorted by service
+	// name) so the resulting Credentials.List is deterministic.
+	services := make([]string, 0, len(byService))
+	for svc := range byService {
+		services = append(services, svc)
+	}
+	sortStrings(services)
+
+	for _, svc := range services {
+		p := byService[svc]
+		c := Credential{Service: svc, Required: p.required}
+		if p.envName != "" || len(p.inject) > 0 {
+			c.ApiKey = &ApiKey{Name: p.envName, Inject: p.inject}
+		}
+		s.Credentials.List = append(s.Credentials.List, c)
+	}
+
+	if sawSources {
+		w.deprecate("credentials.sources", "use the top-level credentials: list with apiKey: sub-blocks (kit-spec v2)")
+	}
+	if sawServiceAuth {
+		w.deprecate("network.serviceAuth", "use credentials[].apiKey.inject[].header/format (kit-spec v2)")
+	}
+	if sawServiceDomains {
+		w.deprecate("network.serviceDomains", "use credentials[].apiKey.inject[].domain (kit-spec v2)")
+	}
+	if sawProxyManaged {
+		w.deprecate("environment.proxyManaged", "use credentials[].apiKey.name (kit-spec v2)")
+	}
+
+	return nil
+}
+
+// normalizeLegacyOAuthBlock folds the v1 standalone top-level `oauth:`
+// block (specFile.LegacyOAuth) into Credentials.List. If a Credential
+// entry for LegacyOAuth.Service already exists, the OAuth shape is
+// attached to it; otherwise a fresh Credential entry is synthesized.
+// Emits a deprecation warning.
+func (s *specFile) normalizeLegacyOAuthBlock(w *warnings) error {
+	if s.LegacyOAuth == nil {
+		return nil
+	}
+	o := s.LegacyOAuth
+	if o.Service == "" {
+		return fmt.Errorf("oauth: standalone block requires a service field")
+	}
+
+	v2 := &OAuth{
+		TokenEndpoint:  o.TokenEndpoint,
+		Sentinels:      o.Sentinels,
+		CredentialFile: o.CredentialFile,
+		SkipIfEnv:      o.SkipIfEnv,
+		ResponseFields: o.ResponseFields,
+		// v1 PassthroughResponse maps directly to v2 Passthrough (renamed;
+		// same semantics).
+		Passthrough: o.PassthroughResponse,
+	}
+
+	// Attach to existing Credential if present.
+	for i, c := range s.Credentials.List {
+		if c.Service == o.Service {
+			if c.OAuth == nil {
+				s.Credentials.List[i].OAuth = v2
+			}
+			w.deprecate("oauth: (standalone block)", "use credentials[].oauth (kit-spec v2)")
+			return nil
+		}
+	}
+
+	// Otherwise synthesize a new entry.
+	s.Credentials.List = append(s.Credentials.List, Credential{
+		Service: o.Service,
+		OAuth:   v2,
+	})
+	w.deprecate("oauth: (standalone block)", "use credentials[].oauth (kit-spec v2)")
+	return nil
+}
+
+// normalizeCapsNetwork promotes v1 network.allowedDomains/deniedDomains
+// (LegacyNetwork) into the canonical Caps.Network.Allow/Deny lists.
+// Emits one deprecation warning per legacy field touched.
+func (s *specFile) normalizeCapsNetwork(w *warnings) error {
+	hasV1Allow := s.LegacyNetwork != nil && len(s.LegacyNetwork.AllowedDomains) > 0
+	hasV1Deny := s.LegacyNetwork != nil && len(s.LegacyNetwork.DeniedDomains) > 0
+	if !hasV1Allow && !hasV1Deny {
+		return nil
+	}
+
+	if s.Caps == nil {
+		s.Caps = &Caps{}
+	}
+	if s.Caps.Network == nil {
+		s.Caps.Network = &CapsNetwork{}
+	}
+
+	if hasV1Allow {
+		s.Caps.Network.Allow = append(s.Caps.Network.Allow, s.LegacyNetwork.AllowedDomains...)
+		w.deprecate("network.allowedDomains", "use 'caps.network.allow' instead (kit-spec v2)")
+	}
+	if hasV1Deny {
+		s.Caps.Network.Deny = append(s.Caps.Network.Deny, s.LegacyNetwork.DeniedDomains...)
+		w.deprecate("network.deniedDomains", "use 'caps.network.deny' instead (kit-spec v2)")
+	}
+
+	return nil
+}
+
+// sortStrings is a small helper to keep the slice sort import local.
+func sortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j-1] > s[j]; j-- {
+			s[j-1], s[j] = s[j], s[j-1]
+		}
+	}
 }
 
 // wellKnownAuth maps well-known service hook names to their default auth configuration.

--- a/spec/normalize.go
+++ b/spec/normalize.go
@@ -29,8 +29,22 @@ func (s *specFile) normalize(w *warnings) error {
 	if err := s.normalizeCapsNetwork(w); err != nil {
 		return err
 	}
+	s.normalizePublishedPorts(w)
 	s.normalizeAgentContext(w)
 	return nil
+}
+
+// normalizePublishedPorts promotes the v1 `network.publishedPorts`
+// (LegacyNetwork) into the canonical top-level PublishedPorts list, emitting
+// a deprecation warning. v2 entries already decoded into PublishedPorts are
+// kept; the legacy entries are appended after them.
+func (s *specFile) normalizePublishedPorts(w *warnings) {
+	if s.LegacyNetwork == nil || len(s.LegacyNetwork.PublishedPorts) == 0 {
+		return
+	}
+	s.PublishedPorts = append(s.PublishedPorts, s.LegacyNetwork.PublishedPorts...)
+	s.LegacyNetwork.PublishedPorts = nil
+	w.deprecate("network.publishedPorts", "use the top-level 'publishedPorts' field instead (kit-spec v2)")
 }
 
 // normalizeKind maps the v1 `kind: agent` value to `sandbox`. The v2 value

--- a/spec/normalize.go
+++ b/spec/normalize.go
@@ -2,6 +2,7 @@ package spec
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -251,8 +252,17 @@ func (s *specFile) normalizeLegacyCredentials(w *warnings) error {
 	// Fold v1 network.serviceDomains + network.serviceAuth into inject entries.
 	if s.LegacyNetwork != nil {
 		// Domain -> service map; for each, emit one inject entry with header
-		// from serviceAuth if present.
-		for domain, svc := range s.LegacyNetwork.ServiceDomains {
+		// from serviceAuth if present. Iterate in sorted domain order so the
+		// resulting Credentials[].ApiKey.Inject list is deterministic — Go map
+		// iteration order is randomised, so otherwise byte-identical specs
+		// would produce different normalized artifacts across loads.
+		domains := make([]string, 0, len(s.LegacyNetwork.ServiceDomains))
+		for d := range s.LegacyNetwork.ServiceDomains {
+			domains = append(domains, d)
+		}
+		sort.Strings(domains)
+		for _, domain := range domains {
+			svc := s.LegacyNetwork.ServiceDomains[domain]
 			if v2Services[svc] {
 				continue
 			}

--- a/spec/normalize_test.go
+++ b/spec/normalize_test.go
@@ -61,18 +61,25 @@ func TestNormalizeSecrets(t *testing.T) {
 			Secrets:  []string{"ANTHROPIC_API_KEY", "GH_TOKEN"},
 		}
 		require.NoError(t, s.normalize(&warnings{}))
-		require.NotNil(t, s.Credentials)
-		require.Contains(t, s.Credentials.Sources, "anthropic")
-		require.Contains(t, s.Credentials.Sources, "github")
-		require.True(t, s.Credentials.Sources["anthropic"].Required)
+		// After normalize, the v1 LegacySources have been folded into
+		// Credentials.List as v2 Credential entries.
+		services := map[string]Credential{}
+		for _, c := range s.Credentials.List {
+			services[c.Service] = c
+		}
+		require.Contains(t, services, "anthropic")
+		require.Contains(t, services, "github")
+		require.True(t, services["anthropic"].Required)
+		require.NotNil(t, services["anthropic"].ApiKey)
+		require.Equal(t, "ANTHROPIC_API_KEY", services["anthropic"].ApiKey.Name)
 	})
 
 	t.Run("conflict_with_existing_source", func(t *testing.T) {
 		s := specFile{
 			Manifest: Manifest{Kind: KindMixin, SchemaVersion: SchemaVersion, Name: "m"},
 			Secrets:  []string{"ANTHROPIC_API_KEY"},
-			Credentials: &CredentialPolicy{
-				Sources: map[string]CredentialSource{
+			Credentials: credentialsField{
+				LegacySources: map[string]CredentialSource{
 					"anthropic": {Env: []string{"EXISTING"}},
 				},
 			},
@@ -88,9 +95,16 @@ func TestNormalizeEgress(t *testing.T) {
 			Egress:   map[string]string{"api.anthropic.com": "anthropic"},
 		}
 		require.NoError(t, s.normalize(&warnings{}))
-		require.NotNil(t, s.Network)
-		require.Equal(t, "anthropic", s.Network.ServiceDomains["api.anthropic.com"])
-		require.Equal(t, "x-api-key", s.Network.ServiceAuth["anthropic"].HeaderName)
+		// Egress folds into LegacyNetwork.ServiceDomains+ServiceAuth (v1
+		// intermediate); normalizeLegacyCredentials then folds that into
+		// Credentials.List. Assert against the final canonical shape.
+		require.Len(t, s.Credentials.List, 1)
+		c := s.Credentials.List[0]
+		require.Equal(t, "anthropic", c.Service)
+		require.NotNil(t, c.ApiKey)
+		require.Len(t, c.ApiKey.Inject, 1)
+		require.Equal(t, "api.anthropic.com", c.ApiKey.Inject[0].Domain)
+		require.Equal(t, "x-api-key", c.ApiKey.Inject[0].Header)
 	})
 
 	t.Run("unknown_service_gets_no_default_auth", func(t *testing.T) {
@@ -99,8 +113,15 @@ func TestNormalizeEgress(t *testing.T) {
 			Egress:   map[string]string{"custom.example.com": "custom"},
 		}
 		require.NoError(t, s.normalize(&warnings{}))
-		_, hasAuth := s.Network.ServiceAuth["custom"]
-		require.False(t, hasAuth, "unknown services should not get default auth")
+		// Service "custom" has no wellKnownAuth entry, so its inject
+		// entry has no header. The Credential exists with apiKey.Inject
+		// but no Header value.
+		require.Len(t, s.Credentials.List, 1)
+		c := s.Credentials.List[0]
+		require.Equal(t, "custom", c.Service)
+		require.NotNil(t, c.ApiKey)
+		require.Len(t, c.ApiKey.Inject, 1)
+		require.Empty(t, c.ApiKey.Inject[0].Header)
 	})
 }
 

--- a/spec/testdata/sample-agent-v2/files/home/.sample-agent-v2/config.json
+++ b/spec/testdata/sample-agent-v2/files/home/.sample-agent-v2/config.json
@@ -1,0 +1,4 @@
+{
+  "sample": true,
+  "reference": "v2"
+}

--- a/spec/testdata/sample-agent-v2/files/workspace/.sample/rules.md
+++ b/spec/testdata/sample-agent-v2/files/workspace/.sample/rules.md
@@ -1,0 +1,3 @@
+# Sample workspace rules
+
+Reference workspace file for the v2 sample kit.

--- a/spec/testdata/sample-agent-v2/spec.yaml
+++ b/spec/testdata/sample-agent-v2/spec.yaml
@@ -1,0 +1,110 @@
+schemaVersion: "2"
+kind: sandbox
+name: sample-agent-v2
+version: "2.0.0"
+displayName: Sample Agent (v2)
+description: "Canonical schemaVersion 2 reference kit — exercises the full v2 surface; doubles as a load/round-trip test fixture."
+sourceURL: https://example.com/sample-agent-v2
+locked:
+  - sandbox.image
+
+sandbox:
+  image: "docker/sandbox-templates:shell-docker"
+  aiFilename: SAMPLE.md
+  entrypoint:
+    run: ["sample-bin", "--verbose"]
+    args: ["--task-mode"]
+    ttyArgs: ["--interactive"]
+  resources:
+    cpu: 2.0
+    memoryMB: 4096
+    gpu: "1"
+
+# Outbound egress policy lives under caps.network (replaces the v1
+# network.allowedDomains/deniedDomains).
+caps:
+  network:
+    allow:
+      - api.anthropic.com
+      - api.openai.com:443
+      - "*.example.com"
+    deny:
+      - telemetry.example.com
+
+# Credentials declare WHAT the kit needs and how to inject it — never where
+# it lives (that's the user-side bindings file). One apiKey credential, one
+# with multiple inject targets, and one OAuth-only credential.
+credentials:
+  - service: anthropic
+    description: "Anthropic API credentials"
+    required: true
+    apiKey:
+      name: ANTHROPIC_API_KEY
+      inject:
+        - domain: api.anthropic.com
+          header: x-api-key
+          format: "%s"
+  - service: github
+    description: "GitHub credential for git + API access"
+    apiKey:
+      name: GITHUB_TOKEN
+      inject:
+        - domain: api.github.com
+          header: Authorization
+          format: "Bearer %s"
+        - domain: github.com
+          header: Authorization
+          format: "%s"
+          username: x-access-token
+  - service: workos
+    description: "OAuth-only example credential"
+    oauth:
+      tokenEndpoint:
+        host: api.workos.com
+        path: /oauth/token
+      sentinels: {}
+      passthrough: true
+
+# Inbound service exposure — top-level in v2 (moved out of the network
+# block). Covers the minimal (container only), full (tcp + name), and udp
+# forms.
+publishedPorts:
+  - container: 9418
+  - container: 8080
+    protocol: tcp
+    name: web
+  - container: 53
+    protocol: udp
+    name: dns
+
+environment:
+  variables:
+    SAMPLE_AGENT_HOME: /home/agent/.sample-agent-v2
+
+volumes:
+  - path: /home/agent/.cache/sample
+    size: 1g
+  - path: /tmp/scratch
+    type: tmpfs
+    size: 512m
+    mode: "1777"
+
+commands:
+  install:
+    - command: "echo agent-installed"
+      user: "0"
+      description: Sample agent install
+  startup:
+    - command: ["echo", "agent-started"]
+      user: "1000"
+      background: true
+      description: Sample agent startup
+  initFiles:
+    - path: /home/agent/.sample-agent-v2/init.json
+      content: '{"initialized": true}'
+      mode: "0644"
+      onlyIfMissing: true
+      description: Seed the agent config
+
+agentContext: |
+  This is sample-agent-v2 reference content for v2 spec coverage.

--- a/spec/types.go
+++ b/spec/types.go
@@ -7,6 +7,12 @@
 // based) and the internal sandboxes engine.
 package spec
 
+import (
+	"fmt"
+
+	"go.yaml.in/yaml/v3"
+)
+
 // SchemaVersion is the default schemaVersion used when a tool scaffolds
 // a new kit. Stays at "1" while sbx releases v2-capable engines into
 // the field; flip to "2" once enough consumers can read v2 artifacts to
@@ -239,10 +245,74 @@ type ServiceAuth struct {
 	ValueFormat string `json:"valueFormat" yaml:"valueFormat"`
 }
 
-// CredentialPolicy defines how the agent discovers and uses credentials from the host.
+// CredentialPolicy is the v1 `credentials:` block shape (mapping with
+// `sources:` inside). Kept as a deserialization target for the
+// credentialsField polymorphic wrapper on specFile; normalize folds its
+// contents into the canonical Artifact.Credentials []Credential list with
+// a deprecation warning. Removed in the Phase 6 schema cutover.
 type CredentialPolicy struct {
 	// Sources maps service identifiers to credential source definitions.
 	Sources map[string]CredentialSource `json:"sources,omitempty" yaml:"sources,omitempty"`
+}
+
+// Credential is one credential the kit declares it needs. The kit
+// describes WHAT it needs (service identity, where to inject the
+// resolved value); the user-side bindings file
+// (~/.config/sbx/credentials.yaml) is the sole source for WHERE the
+// credential lives.
+type Credential struct {
+	// Service is the canonical service identifier (e.g., "anthropic",
+	// "openai", "github"). Must match the lowercase-kebab pattern.
+	Service string `json:"service" yaml:"service"`
+
+	// Description is a free-text label surfaced in interactive prompts
+	// when the resolver needs to ask the user which binding to create.
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	// Required marks the credential as essential for the agent to function.
+	// The resolver fails fast (rather than continuing with the credential
+	// unset) when a required entry has no binding and no host fallback.
+	Required bool `json:"required,omitempty" yaml:"required,omitempty"`
+
+	// Provider is a forward-compat stub for the future provider registry
+	// (`provider: anthropic` -> standard injection config). Setting this
+	// field emits a deprecation-style warning at load time and has no
+	// runtime effect in this release. See the v2 design doc's deferred
+	// list for the registry roadmap.
+	Provider string `json:"provider,omitempty" yaml:"provider,omitempty"`
+
+	// ApiKey describes the api-key-shaped half of this credential, if any.
+	ApiKey *ApiKey `json:"apiKey,omitempty" yaml:"apiKey,omitempty"`
+
+	// OAuth describes the OAuth-shaped half of this credential, if any.
+	// A credential can declare both ApiKey and OAuth; the resolver's
+	// precedence rule (OAuth wins when both have host material) picks one.
+	OAuth *OAuth `json:"oauth,omitempty" yaml:"oauth,omitempty"`
+}
+
+// ApiKey describes an api-key-shaped credential. Inject is the fan-out
+// of which domains/headers the proxy injects the resolved value into;
+// Name is the env-var name the proxy populates inside the container
+// (set to the literal "proxy-managed" by the engine when this credential
+// is wired up).
+type ApiKey struct {
+	Name   string         `json:"name" yaml:"name"`
+	Inject []ApiKeyInject `json:"inject,omitempty" yaml:"inject,omitempty"`
+}
+
+// ApiKeyInject describes one (domain, header) injection rule for an
+// api-key credential. Format must contain exactly one %s where the
+// resolved credential value is substituted.
+type ApiKeyInject struct {
+	Domain string `json:"domain" yaml:"domain"`
+	Header string `json:"header" yaml:"header"`
+	Format string `json:"format" yaml:"format"`
+
+	// Username is set when the injection is HTTP Basic Auth — the proxy
+	// uses this string as the username and the resolved credential value
+	// as the password. Used by the github kit for git HTTPS clone
+	// (`x-access-token` as the literal username).
+	Username string `json:"username,omitempty" yaml:"username,omitempty"`
 }
 
 // CredentialSource defines how to discover a credential for a specific service.
@@ -269,13 +339,40 @@ type FileCredentialSource struct {
 	Parser string `json:"parser,omitempty" yaml:"parser,omitempty"`
 }
 
+// Caps is the v2 top-level capability block. Phase 3 commit 6 introduces
+// caps.network as the canonical home for the egress allow/deny lists
+// (previously network.allowedDomains / network.deniedDomains). Future
+// caps surfaces (caps.filesystem and so on, RFC §82x) attach here.
+type Caps struct {
+	Network *CapsNetwork `json:"network,omitempty" yaml:"network,omitempty"`
+}
+
+// CapsNetwork declares which external domains the sandbox is allowed to
+// reach (Allow) and which are denied (Deny). Deny takes precedence over
+// Allow at policy evaluation time. P2 entry formats (this release):
+//
+//   - exact:                 api.example.com
+//   - exact:port:            api.example.com:443
+//   - single-label wildcard: *.example.com
+//
+// P3 entry formats (deferred): double wildcards (**.example.com), CIDR
+// (10.0.0.0/8), port ranges (api.example.com:8000-9000).
+type CapsNetwork struct {
+	Allow []string `json:"allow,omitempty" yaml:"allow,omitempty"`
+	Deny  []string `json:"deny,omitempty" yaml:"deny,omitempty"`
+}
+
 // EnvironmentPolicy defines environment variables to set in the container.
 type EnvironmentPolicy struct {
 	// Variables are static environment variables to set in the container.
 	Variables map[string]string `json:"variables,omitempty" yaml:"variables,omitempty"`
 
-	// ProxyManaged lists environment variable names managed by the proxy.
-	ProxyManaged []string `json:"proxyManaged,omitempty" yaml:"proxyManaged,omitempty"`
+	// LegacyProxyManaged absorbs the v1 `environment.proxyManaged` list.
+	// The normalize step folds each entry into the matching
+	// Credentials[].ApiKey.Name (by service lookup against
+	// LegacyNetwork.ServiceAuth) and emits a deprecation warning.
+	// Removed in the Phase 6 schema cutover.
+	LegacyProxyManaged []string `json:"-" yaml:"proxyManaged,omitempty"`
 }
 
 // SettingsPolicy defines container settings that control agent-specific
@@ -376,11 +473,23 @@ type Artifact struct {
 	// in the consumer that performs the merge.
 	Locked []string `json:"locked,omitempty"`
 
-	// Network is the optional network policy.
+	// Network is the optional network policy. Post-Phase-3 commit 6 only
+	// PublishedPorts remains canonical here; AllowedDomains/DeniedDomains
+	// move to Caps.Network.Allow/Deny. Commit 7 drops the parent struct.
 	Network *NetworkPolicy `json:"network,omitempty"`
 
-	// Credentials is the optional credential policy.
-	Credentials *CredentialPolicy `json:"credentials,omitempty"`
+	// Caps is the v2 capabilities block. caps.network is the canonical
+	// home for egress allow/deny lists; future caps.* surfaces attach
+	// here.
+	Caps *Caps `json:"caps,omitempty"`
+
+	// Credentials is the unified credential list (one entry per service)
+	// populated by normalize. v2 spec.yaml decodes directly into this
+	// slice; v1 spec.yaml has its credentials.sources / network.serviceAuth /
+	// network.serviceDomains / environment.proxyManaged / standalone oauth:
+	// shapes folded together into one Credential per service with a
+	// deprecation warning per legacy block touched.
+	Credentials []Credential `json:"credentials,omitempty"`
 
 	// Environment is the optional environment policy.
 	Environment *EnvironmentPolicy `json:"environment,omitempty"`
@@ -390,9 +499,6 @@ type Artifact struct {
 
 	// Commands is the optional startup commands and init files.
 	Commands *CommandsPolicy `json:"commands,omitempty"`
-
-	// OAuth is the optional OAuth configuration.
-	OAuth *OAuthPolicy `json:"oauth,omitempty"`
 
 	// Files are static files from the files/ directory to copy into the container.
 	Files []ArtifactFile `json:"files,omitempty"`
@@ -409,8 +515,10 @@ type Artifact struct {
 	Warnings []string `json:"warnings,omitempty"`
 }
 
-// OAuthPolicy defines OAuth configuration for agents that use OAuth-based
-// authentication through the proxy.
+// OAuthPolicy is the v1 standalone top-level `oauth:` block shape. Kept
+// as a deserialization target for specFile.LegacyOAuth; normalize folds
+// it into Credentials[].OAuth with a deprecation warning. Removed in the
+// Phase 6 schema cutover.
 type OAuthPolicy struct {
 	Service             string               `json:"service" yaml:"service"`
 	TokenEndpoint       OAuthTokenEndpoint   `json:"tokenEndpoint" yaml:"tokenEndpoint"`
@@ -419,6 +527,26 @@ type OAuthPolicy struct {
 	SkipIfEnv           []string             `json:"skipIfEnv,omitempty" yaml:"skipIfEnv,omitempty"`
 	ResponseFields      *OAuthResponseFields `json:"responseFields,omitempty" yaml:"responseFields,omitempty"`
 	PassthroughResponse bool                 `json:"passthroughResponse,omitempty" yaml:"passthroughResponse,omitempty"`
+}
+
+// OAuth is the v2 per-credential OAuth sub-shape. Same fields as OAuthPolicy
+// minus Service (the service identifier comes from the parent Credential),
+// and with Passthrough replacing PassthroughResponse (renamed; same
+// semantics — Passthrough = true opts out of sentinel masking, a security
+// downgrade flagged with a warning at load time).
+//
+// A `passthroughReason: ...` field is deliberately NOT included in this
+// release. Whether passthrough should require a documented justification is
+// a design question we want to revisit later; if added in a future schema
+// version, existing kits using only `passthrough: true` would have to add
+// the reason.
+type OAuth struct {
+	TokenEndpoint  OAuthTokenEndpoint   `json:"tokenEndpoint" yaml:"tokenEndpoint"`
+	Sentinels      OAuthSentinels       `json:"sentinels" yaml:"sentinels"`
+	CredentialFile *OAuthCredentialFile `json:"credentialFile,omitempty" yaml:"credentialFile,omitempty"`
+	SkipIfEnv      []string             `json:"skipIfEnv,omitempty" yaml:"skipIfEnv,omitempty"`
+	ResponseFields *OAuthResponseFields `json:"responseFields,omitempty" yaml:"responseFields,omitempty"`
+	Passthrough    bool                 `json:"passthrough,omitempty" yaml:"passthrough,omitempty"`
 }
 
 // OAuthResponseFields maps logical OAuth token field names to the actual
@@ -445,9 +573,22 @@ type OAuthSentinels struct {
 
 // OAuthCredentialFile defines how to render and inject an OAuth credential
 // file into the container at startup.
+//
+// Two render shapes are supported:
+//   - Template (v1): a Go text/template string rendered with OAuthTemplateData.
+//     Free-form string output; prone to injection attacks when token values
+//     contain quotes/braces. Kept for back-compat; deprecated.
+//   - Structure (v2): a declarative JSON shape with `{{.AccessToken}}`-style
+//     placeholders that the engine substitutes at runtime. Output is
+//     guaranteed to be well-formed JSON because the shape is encoded as a
+//     Go map before placeholder substitution. Preferred for new kits.
+//
+// When both are set, Structure wins and Template is ignored with a
+// deprecation warning. Phase 6 removes Template.
 type OAuthCredentialFile struct {
-	Path     string `json:"path" yaml:"path"`
-	Template string `json:"template" yaml:"template"`
+	Path      string                 `json:"path" yaml:"path"`
+	Template  string                 `json:"template,omitempty" yaml:"template,omitempty"`
+	Structure map[string]interface{} `json:"structure,omitempty" yaml:"structure,omitempty"`
 }
 
 // OAuthTemplateData is the data passed to OAuthCredentialFile.Template.
@@ -492,21 +633,80 @@ type specFile struct {
 	Sandbox  *sandboxBlock `yaml:"sandbox,omitempty"`
 	// LegacyAgent holds the v1 `agent:` block. The normalize step
 	// migrates its contents to Sandbox with a deprecation warning. Drop
-	// in the Phase 4 schema-cutover commit.
-	LegacyAgent  *sandboxBlock      `yaml:"agent,omitempty"`
-	Secrets      []string           `yaml:"secrets,omitempty"`
-	Egress       map[string]string  `yaml:"egress,omitempty"`
-	Network      *NetworkPolicy     `yaml:"network,omitempty"`
-	Credentials  *CredentialPolicy  `yaml:"credentials,omitempty"`
-	Environment  *EnvironmentPolicy `yaml:"environment,omitempty"`
-	Settings     *SettingsPolicy    `yaml:"settings,omitempty"`
-	Commands     *CommandsPolicy    `yaml:"commands,omitempty"`
-	OAuth        *OAuthPolicy       `yaml:"oauth,omitempty"`
-	AgentContext string             `yaml:"agentContext,omitempty"`
+	// in the Phase 6 schema-cutover commit.
+	LegacyAgent *sandboxBlock     `yaml:"agent,omitempty"`
+	Secrets     []string          `yaml:"secrets,omitempty"`
+	Egress      map[string]string `yaml:"egress,omitempty"`
+	// Credentials is the polymorphic-decode wrapper handling both v1
+	// (mapping with sources:) and v2 (sequence of Credential) shapes.
+	// normalizeLegacyCredentials folds the v1 surface plus the
+	// LegacyNetwork / LegacyOAuth / Environment.LegacyProxyManaged
+	// shims into Artifact.Credentials.
+	Credentials credentialsField `yaml:"credentials,omitempty"`
+	// LegacyNetwork absorbs the v1 top-level `network:` block. normalize
+	// folds its serviceDomains/serviceAuth fields into Credentials and
+	// copies its allowedDomains/deniedDomains/publishedPorts to
+	// Artifact.Network. Removed in the Phase 6 schema cutover.
+	LegacyNetwork *NetworkPolicy     `yaml:"network,omitempty"`
+	Environment   *EnvironmentPolicy `yaml:"environment,omitempty"`
+	Settings      *SettingsPolicy    `yaml:"settings,omitempty"`
+	Commands      *CommandsPolicy    `yaml:"commands,omitempty"`
+	// Caps is the v2 capabilities block (caps.network and any future
+	// caps.* surfaces). Decoded directly from YAML; the normalize step
+	// also populates Caps.Network from the v1 network.allowedDomains/
+	// deniedDomains shim (LegacyNetwork) when those are present.
+	Caps *Caps `yaml:"caps,omitempty"`
+	// LegacyOAuth absorbs the v1 standalone top-level `oauth:` block.
+	// normalize folds it into Credentials[].OAuth (matched by service)
+	// or synthesizes a new Credential entry if no entry exists for its
+	// service yet. Removed in the Phase 6 schema cutover.
+	LegacyOAuth  *OAuthPolicy `yaml:"oauth,omitempty"`
+	AgentContext string       `yaml:"agentContext,omitempty"`
 	// LegacyMemory holds the v1 `memory:` field. The normalize step
 	// migrates it to AgentContext with a deprecation warning. Drop in
-	// the Phase 4 schema-cutover commit.
+	// the Phase 6 schema-cutover commit.
 	LegacyMemory string `yaml:"memory,omitempty"`
+}
+
+// credentialsField is the specFile-level polymorphic wrapper for the
+// `credentials:` YAML key. It handles both v1 (mapping with sources:
+// inside) and v2 (sequence of Credential) shapes. The normalize step
+// reads LegacySources (if present) plus the Legacy fields under network:
+// and environment:, constructs []Credential, and stores into
+// Artifact.Credentials.
+//
+// Phase 1's two-yaml-tag pattern (used for memory/agentContext and
+// agent/sandbox) doesn't apply here because v1 and v2 share the same
+// `credentials:` YAML tag with different value kinds — only a custom
+// UnmarshalYAML can disambiguate.
+type credentialsField struct {
+	// List is populated when credentials: is a sequence (v2 spelling).
+	List []Credential
+
+	// LegacySources is populated when credentials: is a mapping with
+	// sources: under it (v1 spelling). Each entry carries the env/file
+	// discovery hints the v1 shape used.
+	LegacySources map[string]CredentialSource
+}
+
+func (c *credentialsField) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.SequenceNode:
+		return node.Decode(&c.List)
+	case yaml.MappingNode:
+		var v1 struct {
+			Sources map[string]CredentialSource `yaml:"sources"`
+		}
+		if err := node.Decode(&v1); err != nil {
+			return err
+		}
+		c.LegacySources = v1.Sources
+		return nil
+	case 0:
+		return nil
+	default:
+		return fmt.Errorf("credentials: must be a list (v2) or a mapping with sources: (v1)")
+	}
 }
 
 // sandboxBlock groups sandbox-specific configuration (formerly the

--- a/spec/types.go
+++ b/spec/types.go
@@ -204,16 +204,14 @@ type NetworkPolicy struct {
 	// other allow lists contributed by composed kits.
 	DeniedDomains []string `json:"deniedDomains,omitempty" yaml:"deniedDomains,omitempty"`
 
-	// PublishedPorts is a list of in-container ports the kit wants the
-	// sandbox runtime to expose on the host so external tooling can reach
-	// services the kit runs inside the sandbox (a git-daemon, code-server,
-	// a Jupyter kernel, …). Each entry is published to an ephemeral host
-	// port on 127.0.0.1 when the sandbox starts; the binding is released
-	// automatically when the sandbox is deleted.
+	// PublishedPorts is the v1 location for declared ports
+	// (`network.publishedPorts`). In v2 this moved to the top-level
+	// `publishedPorts:` field; normalize promotes this shim there with a
+	// deprecation warning. Retained only so v1 spec.yaml still decodes
+	// under strict (KnownFields) decoding. Removed in the Phase 6 cutover.
 	//
-	// Users who want a fixed host port keep using `sbx ports --publish`
-	// on top of the kit's declaration — this field is for the
-	// "publish-on-start" UX, not for pinning a specific host port.
+	// See PublishedPort and Artifact.PublishedPorts for the semantics
+	// (ephemeral host port on 127.0.0.1; `sbx ports --publish` for pinning).
 	PublishedPorts []PublishedPort `json:"publishedPorts,omitempty" yaml:"publishedPorts,omitempty"`
 }
 
@@ -473,10 +471,13 @@ type Artifact struct {
 	// in the consumer that performs the merge.
 	Locked []string `json:"locked,omitempty"`
 
-	// Network is the optional network policy. Post-Phase-3 commit 6 only
-	// PublishedPorts remains canonical here; AllowedDomains/DeniedDomains
-	// move to Caps.Network.Allow/Deny. Commit 7 drops the parent struct.
-	Network *NetworkPolicy `json:"network,omitempty"`
+	// PublishedPorts lists in-container ports the kit wants the runtime to
+	// publish on the host when the sandbox starts. It is a top-level
+	// canonical field in v2 — port publishing is inbound service exposure,
+	// a separate concern from the outbound egress policy under Caps.Network.
+	// The v1 `network.publishedPorts` location is promoted here by normalize
+	// with a deprecation warning.
+	PublishedPorts []PublishedPort `json:"publishedPorts,omitempty"`
 
 	// Caps is the v2 capabilities block. caps.network is the canonical
 	// home for egress allow/deny lists; future caps.* surfaces attach
@@ -643,10 +644,14 @@ type specFile struct {
 	// LegacyNetwork / LegacyOAuth / Environment.LegacyProxyManaged
 	// shims into Artifact.Credentials.
 	Credentials credentialsField `yaml:"credentials,omitempty"`
+	// PublishedPorts is the v2 canonical top-level `publishedPorts:` list.
+	// Decoded directly from YAML; normalize also promotes the v1
+	// LegacyNetwork.PublishedPorts shim into this slice.
+	PublishedPorts []PublishedPort `yaml:"publishedPorts,omitempty"`
 	// LegacyNetwork absorbs the v1 top-level `network:` block. normalize
-	// folds its serviceDomains/serviceAuth fields into Credentials and
-	// copies its allowedDomains/deniedDomains/publishedPorts to
-	// Artifact.Network. Removed in the Phase 6 schema cutover.
+	// folds its serviceDomains/serviceAuth fields into Credentials, its
+	// allowedDomains/deniedDomains into Caps.Network, and its publishedPorts
+	// into the top-level PublishedPorts. Removed in the Phase 6 schema cutover.
 	LegacyNetwork *NetworkPolicy     `yaml:"network,omitempty"`
 	Environment   *EnvironmentPolicy `yaml:"environment,omitempty"`
 	Settings      *SettingsPolicy    `yaml:"settings,omitempty"`

--- a/spec/v1_compat_test.go
+++ b/spec/v1_compat_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestV1Memory_MapsToAgentContext(t *testing.T) {
@@ -228,4 +230,300 @@ tmpfs:
 	if !strings.Contains(err.Error(), "tmpfs") {
 		t.Errorf("error should name the rejected field; got %v", err)
 	}
+}
+
+// TestV2Credentials_ListShape exercises the minimal shape — one credential
+// with apiKey only. Catches "did the new types decode?" regressions
+// without obscuring them under a wall of fields.
+func TestV2Credentials_ListShape(t *testing.T) {
+	dir := t.TempDir()
+	specYAML := `schemaVersion: "2"
+kind: sandbox
+name: creds-minimal
+sandbox:
+  image: docker/sandbox-templates:shell-docker
+credentials:
+  - service: anthropic
+    description: "Anthropic API"
+    required: true
+    apiKey:
+      name: ANTHROPIC_API_KEY
+      inject:
+        - domain: api.anthropic.com
+          header: x-api-key
+          format: "%s"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "spec.yaml"), []byte(specYAML), 0o644))
+	art, err := LoadFromDirectory(dir)
+	require.NoError(t, err)
+	require.Len(t, art.Credentials, 1)
+	c := art.Credentials[0]
+	require.Equal(t, "anthropic", c.Service)
+	require.True(t, c.Required)
+	require.NotNil(t, c.ApiKey)
+	require.Equal(t, "ANTHROPIC_API_KEY", c.ApiKey.Name)
+	require.Len(t, c.ApiKey.Inject, 1)
+	require.Equal(t, "api.anthropic.com", c.ApiKey.Inject[0].Domain)
+}
+
+// TestV2Credentials_FullShape exercises every field documented in the
+// RFC: apiKey with username (HTTP basic auth for git HTTPS), full oauth
+// shape (credentialFile.structure, responseFields, skipIfEnv,
+// passthrough+passthroughReason). Schema regressions surface here first.
+func TestV2Credentials_FullShape(t *testing.T) {
+	dir := t.TempDir()
+	specYAML := `schemaVersion: "2"
+kind: sandbox
+name: creds-full
+sandbox:
+  image: docker/sandbox-templates:shell-docker
+credentials:
+  - service: anthropic
+    description: "Anthropic API credentials"
+    required: true
+    apiKey:
+      name: ANTHROPIC_API_KEY
+      inject:
+        - domain: api.anthropic.com
+          header: x-api-key
+          format: "%s"
+    oauth:
+      tokenEndpoint:
+        host: platform.claude.com
+        path: /v1/oauth/token
+      sentinels:
+        accessToken: sk-ant-oat01-proxy-managed
+        refreshToken: sk-ant-ort01-proxy-managed
+      credentialFile:
+        path: "~/.claude/.credentials.json"
+        structure:
+          claudeAiOauth:
+            accessToken: "{{.AccessToken}}"
+            refreshToken: "{{.RefreshToken}}"
+            expiresAt: "{{.ExpiresAt}}"
+      responseFields:
+        accessToken: access_token
+        refreshToken: refresh_token
+        expiresIn: expires_in
+        scope: scope
+      skipIfEnv: [ANTHROPIC_API_KEY]
+
+  - service: github
+    description: "GitHub credential for git+API access"
+    apiKey:
+      name: GITHUB_TOKEN
+      inject:
+        - domain: api.github.com
+          header: Authorization
+          format: "Bearer %s"
+        - domain: github.com
+          header: Authorization
+          format: "%s"
+          username: x-access-token
+
+  - service: workos
+    oauth:
+      tokenEndpoint:
+        host: api.workos.com
+        path: /oauth/token
+      sentinels: {}
+      passthrough: true
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "spec.yaml"), []byte(specYAML), 0o644))
+	art, err := LoadFromDirectory(dir)
+	require.NoError(t, err)
+	require.Len(t, art.Credentials, 3)
+
+	// anthropic — apiKey + full oauth.
+	a := art.Credentials[0]
+	require.Equal(t, "anthropic", a.Service)
+	require.Equal(t, "Anthropic API credentials", a.Description)
+	require.True(t, a.Required)
+	require.NotNil(t, a.ApiKey)
+	require.Equal(t, "ANTHROPIC_API_KEY", a.ApiKey.Name)
+	require.NotNil(t, a.OAuth)
+	require.Equal(t, "platform.claude.com", a.OAuth.TokenEndpoint.Host)
+	require.Equal(t, "/v1/oauth/token", a.OAuth.TokenEndpoint.Path)
+	require.Equal(t, "sk-ant-oat01-proxy-managed", a.OAuth.Sentinels.AccessToken)
+	require.Equal(t, "sk-ant-ort01-proxy-managed", a.OAuth.Sentinels.RefreshToken)
+	require.NotNil(t, a.OAuth.CredentialFile)
+	require.Equal(t, "~/.claude/.credentials.json", a.OAuth.CredentialFile.Path)
+	require.NotNil(t, a.OAuth.CredentialFile.Structure)
+	require.NotNil(t, a.OAuth.ResponseFields)
+	require.Equal(t, "access_token", a.OAuth.ResponseFields.AccessToken)
+	require.Equal(t, []string{"ANTHROPIC_API_KEY"}, a.OAuth.SkipIfEnv)
+	require.False(t, a.OAuth.Passthrough)
+
+	// github — basic auth with username for git HTTPS.
+	g := art.Credentials[1]
+	require.Equal(t, "github", g.Service)
+	require.Len(t, g.ApiKey.Inject, 2)
+	require.Equal(t, "x-access-token", g.ApiKey.Inject[1].Username)
+
+	// workos — passthrough OAuth (passthroughReason is deliberately
+	// deferred to a later release; this assertion will gain a reason
+	// check if/when that field lands).
+	w := art.Credentials[2]
+	require.True(t, w.OAuth.Passthrough)
+}
+
+// TestV1Credentials_FullShape_RoundTripsToList exercises the parallel-load
+// contract for the credentials redesign: a realistic v1 spec.yaml using
+// credentials.sources + network.serviceAuth + network.serviceDomains +
+// environment.proxyManaged loads cleanly, normalizes to a single v2
+// credentials[] entry per service, and produces one deprecation warning
+// per legacy block touched.
+func TestV1Credentials_FullShape_RoundTripsToList(t *testing.T) {
+	dir := t.TempDir()
+	specYAML := `schemaVersion: "1"
+kind: sandbox
+name: creds-v1
+sandbox:
+  image: docker/sandbox-templates:shell-docker
+credentials:
+  sources:
+    anthropic:
+      env: [ANTHROPIC_API_KEY]
+      required: true
+network:
+  serviceDomains:
+    api.anthropic.com: anthropic
+  serviceAuth:
+    anthropic:
+      headerName: x-api-key
+      valueFormat: "%s"
+environment:
+  proxyManaged: [ANTHROPIC_API_KEY]
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "spec.yaml"), []byte(specYAML), 0o644))
+	art, err := LoadFromDirectory(dir)
+	require.NoError(t, err)
+
+	// The four v1 surfaces fold into one v2 credentials[] entry.
+	require.Len(t, art.Credentials, 1)
+	c := art.Credentials[0]
+	require.Equal(t, "anthropic", c.Service)
+	require.True(t, c.Required)
+	require.NotNil(t, c.ApiKey)
+	require.Equal(t, "ANTHROPIC_API_KEY", c.ApiKey.Name)
+	require.Len(t, c.ApiKey.Inject, 1)
+	require.Equal(t, "api.anthropic.com", c.ApiKey.Inject[0].Domain)
+	require.Equal(t, "x-api-key", c.ApiKey.Inject[0].Header)
+	require.Equal(t, "%s", c.ApiKey.Inject[0].Format)
+
+	// One deprecation warning per legacy block.
+	var sourcesWarn, serviceAuthWarn, serviceDomainsWarn, proxyManagedWarn bool
+	for _, w := range art.Warnings {
+		switch {
+		case strings.Contains(w, "credentials.sources"):
+			sourcesWarn = true
+		case strings.Contains(w, "network.serviceAuth"):
+			serviceAuthWarn = true
+		case strings.Contains(w, "network.serviceDomains"):
+			serviceDomainsWarn = true
+		case strings.Contains(w, "environment.proxyManaged"):
+			proxyManagedWarn = true
+		}
+	}
+	require.True(t, sourcesWarn, "expected credentials.sources warning, got %v", art.Warnings)
+	require.True(t, serviceAuthWarn, "expected network.serviceAuth warning, got %v", art.Warnings)
+	require.True(t, serviceDomainsWarn, "expected network.serviceDomains warning, got %v", art.Warnings)
+	require.True(t, proxyManagedWarn, "expected environment.proxyManaged warning, got %v", art.Warnings)
+}
+
+// TestV1OAuth_StandaloneBlock_RoundTripsToCredentials exercises the
+// parallel-load contract for the standalone top-level oauth: block →
+// credentials[].oauth migration.
+func TestV1OAuth_StandaloneBlock_RoundTripsToCredentials(t *testing.T) {
+	dir := t.TempDir()
+	specYAML := `schemaVersion: "1"
+kind: sandbox
+name: oauth-v1
+sandbox:
+  image: docker/sandbox-templates:shell-docker
+oauth:
+  service: openai
+  tokenEndpoint: {host: auth.openai.com, path: /oauth/token}
+  sentinels: {accessToken: oai-oat01-proxy-managed, refreshToken: oai-ort01-proxy-managed}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "spec.yaml"), []byte(specYAML), 0o644))
+	art, err := LoadFromDirectory(dir)
+	require.NoError(t, err)
+
+	require.Len(t, art.Credentials, 1)
+	c := art.Credentials[0]
+	require.Equal(t, "openai", c.Service)
+	require.NotNil(t, c.OAuth)
+	require.Equal(t, "auth.openai.com", c.OAuth.TokenEndpoint.Host)
+	require.Equal(t, "/oauth/token", c.OAuth.TokenEndpoint.Path)
+
+	var oauthWarn bool
+	for _, w := range art.Warnings {
+		if strings.Contains(w, "oauth:") && strings.Contains(w, "standalone") {
+			oauthWarn = true
+		}
+	}
+	require.True(t, oauthWarn, "expected standalone oauth: deprecation warning, got %v", art.Warnings)
+}
+
+// TestV2CapsNetwork_Accepted exercises the v2 caps.network block —
+// allow + deny lists with the three P2 formats (exact, exact:port,
+// single-label wildcard).
+func TestV2CapsNetwork_Accepted(t *testing.T) {
+	dir := t.TempDir()
+	specYAML := `schemaVersion: "2"
+kind: sandbox
+name: caps-test
+sandbox:
+  image: docker/sandbox-templates:shell-docker
+caps:
+  network:
+    allow: [api.anthropic.com, api.openai.com:443, "*.github.com"]
+    deny: [malware.example.com]
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "spec.yaml"), []byte(specYAML), 0o644))
+	art, err := LoadFromDirectory(dir)
+	require.NoError(t, err)
+	require.NotNil(t, art.Caps)
+	require.NotNil(t, art.Caps.Network)
+	require.ElementsMatch(t, []string{"api.anthropic.com", "api.openai.com:443", "*.github.com"}, art.Caps.Network.Allow)
+	require.ElementsMatch(t, []string{"malware.example.com"}, art.Caps.Network.Deny)
+}
+
+// TestV1NetworkAllowedDomains_RoundTripsToCapsNetwork exercises the
+// parallel-load contract for the network -> caps.network rename: a v1
+// spec with network.allowedDomains / network.deniedDomains loads
+// cleanly, normalizes to caps.network.allow / .deny, and produces one
+// deprecation warning per legacy field.
+func TestV1NetworkAllowedDomains_RoundTripsToCapsNetwork(t *testing.T) {
+	dir := t.TempDir()
+	specYAML := `schemaVersion: "1"
+kind: sandbox
+name: net-v1
+sandbox:
+  image: docker/sandbox-templates:shell-docker
+network:
+  allowedDomains: [api.anthropic.com]
+  deniedDomains: [malware.example.com]
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "spec.yaml"), []byte(specYAML), 0o644))
+	art, err := LoadFromDirectory(dir)
+	require.NoError(t, err)
+
+	require.NotNil(t, art.Caps)
+	require.NotNil(t, art.Caps.Network)
+	require.Contains(t, art.Caps.Network.Allow, "api.anthropic.com")
+	require.ElementsMatch(t, []string{"malware.example.com"}, art.Caps.Network.Deny)
+
+	var allowWarn, denyWarn bool
+	for _, w := range art.Warnings {
+		switch {
+		case strings.Contains(w, "network.allowedDomains"):
+			allowWarn = true
+		case strings.Contains(w, "network.deniedDomains"):
+			denyWarn = true
+		}
+	}
+	require.True(t, allowWarn, "expected network.allowedDomains warning, got %v", art.Warnings)
+	require.True(t, denyWarn, "expected network.deniedDomains warning, got %v", art.Warnings)
 }

--- a/spec/validate.go
+++ b/spec/validate.go
@@ -165,7 +165,7 @@ func ValidateEnvironmentPolicy(e *EnvironmentPolicy) error {
 		}
 	}
 
-	for _, key := range e.ProxyManaged {
+	for _, key := range e.LegacyProxyManaged {
 		if key == "" {
 			return fmt.Errorf("environment: proxyManaged entry cannot be empty")
 		}
@@ -270,16 +270,10 @@ func ValidateArtifact(a *Artifact) error {
 	if err := ValidateNetworkPolicy(a.Network); err != nil {
 		return err
 	}
-	if err := ValidateCredentialPolicy(a.Credentials); err != nil {
-		return err
-	}
 	if err := ValidateEnvironmentPolicy(a.Environment); err != nil {
 		return err
 	}
 	if err := ValidateCommandsPolicy(a.Commands); err != nil {
-		return err
-	}
-	if err := ValidateOAuthPolicy(a.OAuth); err != nil {
 		return err
 	}
 

--- a/spec/validate.go
+++ b/spec/validate.go
@@ -110,15 +110,22 @@ func ValidateNetworkPolicy(n *NetworkPolicy) error {
 		}
 	}
 
-	for i, p := range n.PublishedPorts {
+	return nil
+}
+
+// ValidatePublishedPorts validates the canonical top-level publishedPorts
+// list: each entry's container port must be in 1..65535 and its protocol must
+// be empty (defaulted to "tcp" at consumption time), "tcp", or "udp".
+func ValidatePublishedPorts(ports []PublishedPort) error {
+	for i, p := range ports {
 		if p.Container < 1 || p.Container > 65535 {
-			return fmt.Errorf("network: publishedPorts[%d].container must be in 1..65535 (got %d)", i, p.Container)
+			return fmt.Errorf("publishedPorts[%d].container must be in 1..65535 (got %d)", i, p.Container)
 		}
 		switch p.Protocol {
 		case "", "tcp", "udp":
 			// "" is accepted and defaults to "tcp" at consumption time.
 		default:
-			return fmt.Errorf("network: publishedPorts[%d].protocol must be empty, \"tcp\" or \"udp\" (got %q)", i, p.Protocol)
+			return fmt.Errorf("publishedPorts[%d].protocol must be empty, \"tcp\" or \"udp\" (got %q)", i, p.Protocol)
 		}
 	}
 
@@ -267,7 +274,7 @@ func ValidateArtifact(a *Artifact) error {
 	if err := ValidateLocked(a.Locked); err != nil {
 		return err
 	}
-	if err := ValidateNetworkPolicy(a.Network); err != nil {
+	if err := ValidatePublishedPorts(a.PublishedPorts); err != nil {
 		return err
 	}
 	if err := ValidateEnvironmentPolicy(a.Environment); err != nil {

--- a/spec/validate_test.go
+++ b/spec/validate_test.go
@@ -159,40 +159,38 @@ func TestValidateNetworkPolicy(t *testing.T) {
 		require.ErrorContains(t, ValidateNetworkPolicy(n), "in both allowedDomains and deniedDomains")
 	})
 
-	t.Run("publishedPorts_minimal", func(t *testing.T) {
+}
+
+func TestValidatePublishedPorts(t *testing.T) {
+	t.Run("nil_is_valid", func(t *testing.T) {
+		require.NoError(t, ValidatePublishedPorts(nil))
+	})
+
+	t.Run("minimal", func(t *testing.T) {
 		// Only Container is required; empty Protocol is accepted (consumers
 		// default it to "tcp" at use-site to keep this struct ergonomic).
-		n := &NetworkPolicy{
-			PublishedPorts: []PublishedPort{{Container: 8080}},
-		}
-		require.NoError(t, ValidateNetworkPolicy(n))
+		require.NoError(t, ValidatePublishedPorts([]PublishedPort{{Container: 8080}}))
 	})
 
-	t.Run("publishedPorts_full", func(t *testing.T) {
-		n := &NetworkPolicy{
-			PublishedPorts: []PublishedPort{
-				{Container: 9418, Protocol: "tcp", Name: "git-daemon"},
-				{Container: 8080, Protocol: "tcp", Name: "code-server"},
-				{Container: 53, Protocol: "udp", Name: "dns"},
-			},
-		}
-		require.NoError(t, ValidateNetworkPolicy(n))
+	t.Run("full", func(t *testing.T) {
+		require.NoError(t, ValidatePublishedPorts([]PublishedPort{
+			{Container: 9418, Protocol: "tcp", Name: "git-daemon"},
+			{Container: 8080, Protocol: "tcp", Name: "code-server"},
+			{Container: 53, Protocol: "udp", Name: "dns"},
+		}))
 	})
 
-	t.Run("publishedPorts_container_out_of_range", func(t *testing.T) {
+	t.Run("container_out_of_range", func(t *testing.T) {
 		for _, p := range []int{0, -1, 65536, 70000} {
-			n := &NetworkPolicy{PublishedPorts: []PublishedPort{{Container: p}}}
-			require.ErrorContains(t, ValidateNetworkPolicy(n),
+			require.ErrorContains(t, ValidatePublishedPorts([]PublishedPort{{Container: p}}),
 				"publishedPorts[0].container must be in 1..65535",
 				"container=%d", p)
 		}
 	})
 
-	t.Run("publishedPorts_invalid_protocol", func(t *testing.T) {
-		n := &NetworkPolicy{
-			PublishedPorts: []PublishedPort{{Container: 8080, Protocol: "sctp"}},
-		}
-		require.ErrorContains(t, ValidateNetworkPolicy(n),
+	t.Run("invalid_protocol", func(t *testing.T) {
+		require.ErrorContains(t,
+			ValidatePublishedPorts([]PublishedPort{{Container: 8080, Protocol: "sctp"}}),
 			"publishedPorts[0].protocol must be empty, \"tcp\" or \"udp\"")
 	})
 }

--- a/spec/validate_test.go
+++ b/spec/validate_test.go
@@ -231,7 +231,7 @@ func TestValidateEnvironmentPolicy(t *testing.T) {
 
 	t.Run("invalid_proxy_managed", func(t *testing.T) {
 		e := &EnvironmentPolicy{
-			ProxyManaged: []string{"bad-name"},
+			LegacyProxyManaged: []string{"bad-name"},
 		}
 		require.ErrorContains(t, ValidateEnvironmentPolicy(e), "not a valid shell identifier")
 	})

--- a/tck/derive.go
+++ b/tck/derive.go
@@ -44,12 +44,39 @@ func NewSuiteFromDir(dir string, opts ...Option) (*Suite, error) {
 		ExpectedTmpfs:          deriveTmpfs(artifact.Manifest.TmpfsVolumes()),
 	}
 
-	// Derive network expectations
-	if artifact.Network != nil {
-		suite.ExpectedAllowedDomains = artifact.Network.AllowedDomains
-		suite.ExpectedDeniedDomains = artifact.Network.DeniedDomains
-		suite.ExpectedServiceDomains = artifact.Network.ServiceDomains
-		suite.ExpectedServiceAuth = artifact.Network.ServiceAuth
+	// Derive network expectations. Post-Phase-3 commit 7: allow/deny
+	// derive from Caps.Network; serviceDomains/serviceAuth derive from
+	// Credentials[].ApiKey.Inject. The Suite's expected-field names are
+	// preserved for backward compatibility with existing TCK tests.
+	if artifact.Caps != nil && artifact.Caps.Network != nil {
+		suite.ExpectedAllowedDomains = artifact.Caps.Network.Allow
+		suite.ExpectedDeniedDomains = artifact.Caps.Network.Deny
+	}
+	if len(artifact.Credentials) > 0 {
+		domains := map[string]string{}
+		auth := map[string]spec.ServiceAuth{}
+		for _, c := range artifact.Credentials {
+			if c.ApiKey == nil {
+				continue
+			}
+			for _, inj := range c.ApiKey.Inject {
+				if inj.Domain != "" {
+					domains[inj.Domain] = c.Service
+				}
+			}
+			if len(c.ApiKey.Inject) > 0 {
+				if _, exists := auth[c.Service]; !exists {
+					inj := c.ApiKey.Inject[0]
+					auth[c.Service] = spec.ServiceAuth{HeaderName: inj.Header, ValueFormat: inj.Format}
+				}
+			}
+		}
+		if len(domains) > 0 {
+			suite.ExpectedServiceDomains = domains
+		}
+		if len(auth) > 0 {
+			suite.ExpectedServiceAuth = auth
+		}
 	}
 
 	// Apply functional options (e.g., WithImage)

--- a/tck/suite.go
+++ b/tck/suite.go
@@ -421,7 +421,14 @@ func (s *Suite) RunCredentialPolicyTests(t *testing.T) {
 				require.True(t, c.ApiKey != nil || c.OAuth != nil,
 					"credential entry for %q must have at least one of apiKey or oauth", c.Service)
 
-				if c.ApiKey != nil {
+				if c.ApiKey != nil && c.ApiKey.Name != "" {
+					// "Routing-only" credentials (ApiKey.Name empty, Inject
+					// non-empty) are valid under the parallel-load normalize
+					// path: v1 kits that declared services in network.serviceAuth
+					// + network.serviceDomains without a matching
+					// credentials.sources entry produce these entries (e.g.,
+					// amp, github routing in docker-agent). Skip the name
+					// shape check when the credential is routing-only.
 					require.True(t, shellIdentifierPattern.MatchString(c.ApiKey.Name),
 						"credential apiKey.name %q for service %q is not a valid shell identifier", c.ApiKey.Name, c.Service)
 				}

--- a/tck/suite.go
+++ b/tck/suite.go
@@ -392,24 +392,14 @@ func (s *Suite) RunCredentialPolicyTests(t *testing.T) {
 	}
 
 	t.Run("credential_policy", func(t *testing.T) {
-		for service, source := range s.Artifact.Credentials.Sources {
-			t.Run(service, func(t *testing.T) {
-				require.True(t, len(source.Env) > 0 || source.File != nil,
-					"credential source for %q must have at least one of env or file", service)
+		for _, c := range s.Artifact.Credentials {
+			t.Run(c.Service, func(t *testing.T) {
+				require.True(t, c.ApiKey != nil || c.OAuth != nil,
+					"credential entry for %q must have at least one of apiKey or oauth", c.Service)
 
-				for i, envVar := range source.Env {
-					require.True(t, shellIdentifierPattern.MatchString(envVar),
-						"credential env[%d] %q for service %q is not a valid shell identifier", i, envVar, service)
-				}
-
-				if source.File != nil {
-					require.NotEmpty(t, source.File.Path,
-						"credential file path for %q must not be empty", service)
-				}
-
-				if source.Priority != "" {
-					require.Contains(t, []string{"env-first", "file-first"}, source.Priority,
-						"invalid priority %q for service %q", source.Priority, service)
+				if c.ApiKey != nil {
+					require.True(t, shellIdentifierPattern.MatchString(c.ApiKey.Name),
+						"credential apiKey.name %q for service %q is not a valid shell identifier", c.ApiKey.Name, c.Service)
 				}
 			})
 		}
@@ -434,14 +424,11 @@ func (s *Suite) RunEnvironmentPolicyTests(t *testing.T) {
 			})
 		}
 
-		if len(env.ProxyManaged) > 0 {
-			t.Run("proxy_managed", func(t *testing.T) {
-				for _, key := range env.ProxyManaged {
-					require.True(t, shellIdentifierPattern.MatchString(key),
-						"proxyManaged entry %q is not a valid shell identifier", key)
-				}
-			})
-		}
+		// Note: post-Phase-3 commit 5, environment.proxyManaged is the
+		// v1-only LegacyProxyManaged shim. The canonical place to enumerate
+		// proxy-managed env-var names is Credentials[].ApiKey.Name, which
+		// is validated by RunCredentialPolicyTests above. The shim is
+		// validated by ValidateEnvironmentPolicy at load time.
 	})
 }
 
@@ -486,34 +473,39 @@ func (s *Suite) RunSettingsPolicyTests(t *testing.T) {
 	})
 }
 
-// RunOAuthPolicyTests verifies the OAuth policy is well-formed.
+// RunOAuthPolicyTests verifies the OAuth policy is well-formed for every
+// credential that declares an oauth: sub-block. Post-Phase-3 commit 5,
+// OAuth lives under Credential.OAuth (per-credential); the standalone
+// top-level oauth: block is the v1 LegacyOAuth shim handled at load time.
 func (s *Suite) RunOAuthPolicyTests(t *testing.T) {
-	if s.Artifact.OAuth == nil {
-		return
-	}
-
-	t.Run("oauth_policy", func(t *testing.T) {
-		oauth := s.Artifact.OAuth
-
-		require.NotEmpty(t, oauth.Service, "oauth.service is required")
-
-		t.Run("token_endpoint", func(t *testing.T) {
-			require.NotEmpty(t, oauth.TokenEndpoint.Host, "oauth.tokenEndpoint.host is required")
-			require.NotEmpty(t, oauth.TokenEndpoint.Path, "oauth.tokenEndpoint.path is required")
-		})
-
-		t.Run("sentinels", func(t *testing.T) {
-			require.NotEmpty(t, oauth.Sentinels.AccessToken, "oauth.sentinels.accessToken is required")
-			require.NotEmpty(t, oauth.Sentinels.RefreshToken, "oauth.sentinels.refreshToken is required")
-		})
-
-		if oauth.CredentialFile != nil {
-			t.Run("credential_file", func(t *testing.T) {
-				require.NotEmpty(t, oauth.CredentialFile.Path, "oauth.credentialFile.path is required")
-				require.NotEmpty(t, oauth.CredentialFile.Template, "oauth.credentialFile.template is required")
-			})
+	for _, c := range s.Artifact.Credentials {
+		if c.OAuth == nil {
+			continue
 		}
-	})
+		t.Run("oauth_policy/"+c.Service, func(t *testing.T) {
+			oauth := c.OAuth
+
+			t.Run("token_endpoint", func(t *testing.T) {
+				require.NotEmpty(t, oauth.TokenEndpoint.Host, "oauth.tokenEndpoint.host is required")
+				require.NotEmpty(t, oauth.TokenEndpoint.Path, "oauth.tokenEndpoint.path is required")
+			})
+
+			t.Run("sentinels", func(t *testing.T) {
+				require.NotEmpty(t, oauth.Sentinels.AccessToken, "oauth.sentinels.accessToken is required")
+				require.NotEmpty(t, oauth.Sentinels.RefreshToken, "oauth.sentinels.refreshToken is required")
+			})
+
+			if oauth.CredentialFile != nil {
+				t.Run("credential_file", func(t *testing.T) {
+					require.NotEmpty(t, oauth.CredentialFile.Path, "oauth.credentialFile.path is required")
+					// v2 prefers Structure; v1 Template is still accepted.
+					require.True(t,
+						oauth.CredentialFile.Template != "" || oauth.CredentialFile.Structure != nil,
+						"oauth.credentialFile must have either template (v1) or structure (v2)")
+				})
+			}
+		})
+	}
 }
 
 // startContainer creates and starts a container from the suite's image using testcontainers-go.

--- a/tck/suite.go
+++ b/tck/suite.go
@@ -340,39 +340,63 @@ func (s *Suite) RunValidationTests(t *testing.T) {
 }
 
 // RunNetworkPolicyTests verifies the artifact's network policy is consistent.
+//
+// Post-Phase-3 commit 7: allow/deny come from Caps.Network; service
+// domains/auth come from Credentials[].ApiKey.Inject. The Suite's
+// Expected* field names are preserved.
 func (s *Suite) RunNetworkPolicyTests(t *testing.T) {
-	if s.Artifact.Network == nil && len(s.ExpectedAllowedDomains) == 0 && len(s.ExpectedDeniedDomains) == 0 && len(s.ExpectedServiceDomains) == 0 {
+	caps := s.Artifact.Caps
+	creds := s.Artifact.Credentials
+	if caps == nil && len(creds) == 0 && len(s.ExpectedAllowedDomains) == 0 && len(s.ExpectedDeniedDomains) == 0 && len(s.ExpectedServiceDomains) == 0 {
 		return
 	}
 
+	// Build the actual service-domains / service-auth maps from
+	// Credentials[].ApiKey.Inject.
+	actualDomains := map[string]string{}
+	actualAuth := map[string]spec.ServiceAuth{}
+	for _, c := range creds {
+		if c.ApiKey == nil {
+			continue
+		}
+		for _, inj := range c.ApiKey.Inject {
+			if inj.Domain != "" {
+				actualDomains[inj.Domain] = c.Service
+			}
+		}
+		if len(c.ApiKey.Inject) > 0 {
+			if _, exists := actualAuth[c.Service]; !exists {
+				inj := c.ApiKey.Inject[0]
+				actualAuth[c.Service] = spec.ServiceAuth{HeaderName: inj.Header, ValueFormat: inj.Format}
+			}
+		}
+	}
+
 	t.Run("network_policy", func(t *testing.T) {
-		net := s.Artifact.Network
-		if net == nil {
-			require.Empty(t, s.ExpectedAllowedDomains, "expected allowed domains but network policy is nil")
-			require.Empty(t, s.ExpectedDeniedDomains, "expected denied domains but network policy is nil")
-			require.Empty(t, s.ExpectedServiceDomains, "expected service domains but network policy is nil")
-			return
+		var actualAllow, actualDeny []string
+		if caps != nil && caps.Network != nil {
+			actualAllow = caps.Network.Allow
+			actualDeny = caps.Network.Deny
 		}
 
 		if len(s.ExpectedAllowedDomains) > 0 {
-			require.ElementsMatch(t, s.ExpectedAllowedDomains, net.AllowedDomains,
+			require.ElementsMatch(t, s.ExpectedAllowedDomains, actualAllow,
 				"allowed domains should match")
 		}
 
 		if len(s.ExpectedDeniedDomains) > 0 {
-			require.ElementsMatch(t, s.ExpectedDeniedDomains, net.DeniedDomains,
+			require.ElementsMatch(t, s.ExpectedDeniedDomains, actualDeny,
 				"denied domains should match")
 		}
 
 		if len(s.ExpectedServiceDomains) > 0 {
-			require.Equal(t, s.ExpectedServiceDomains, net.ServiceDomains,
+			require.Equal(t, s.ExpectedServiceDomains, actualDomains,
 				"service domains should match")
 		}
 
 		if len(s.ExpectedServiceAuth) > 0 {
-			require.NotNil(t, net.ServiceAuth)
 			for service, expected := range s.ExpectedServiceAuth {
-				actual, ok := net.ServiceAuth[service]
+				actual, ok := actualAuth[service]
 				require.True(t, ok, "service auth for %q not found", service)
 				require.Equal(t, expected.HeaderName, actual.HeaderName,
 					"headerName mismatch for service %q", service)

--- a/tck/tck_test.go
+++ b/tck/tck_test.go
@@ -222,7 +222,7 @@ func TestRunOAuthPolicyTests(t *testing.T) {
 	require.NoError(t, err)
 	suite.RunOAuthPolicyTests(t)
 
-	// Test with an artifact that has OAuth
+	// Test with an artifact that has OAuth under a v2 credentials[] entry.
 	suite2 := &Suite{
 		Artifact: &spec.Artifact{
 			Manifest: spec.Manifest{
@@ -230,11 +230,13 @@ func TestRunOAuthPolicyTests(t *testing.T) {
 				Kind:          spec.KindMixin,
 				Name:          "oauth-test",
 			},
-			OAuth: &spec.OAuthPolicy{
-				Service:       "test-svc",
-				TokenEndpoint: spec.OAuthTokenEndpoint{Host: "auth.example.com", Path: "/token"},
-				Sentinels:     spec.OAuthSentinels{AccessToken: "at", RefreshToken: "rt"},
-			},
+			Credentials: []spec.Credential{{
+				Service: "test-svc",
+				OAuth: &spec.OAuth{
+					TokenEndpoint: spec.OAuthTokenEndpoint{Host: "auth.example.com", Path: "/token"},
+					Sentinels:     spec.OAuthSentinels{AccessToken: "at", RefreshToken: "rt"},
+				},
+			}},
 		},
 	}
 	suite2.RunOAuthPolicyTests(t)


### PR DESCRIPTION

## Summary

Phase 3 of the unified kit-spec v2 migration restructures four overlapping v1 surfaces (`credentials.sources` map, `network.serviceAuth`, `network.serviceDomains`, `environment.proxyManaged`, standalone `oauth:` block, `network.allowedDomains`/`deniedDomains`) into:

- A unified `credentials[]` list per service (apiKey + oauth sub-blocks; inject domains/headers)
- A `caps.network.allow/deny` block for the egress allow/deny lists
- A separate user-side bindings file (`~/.config/sbx/credentials.yaml`) declaring where credentials live on the host

v1 spec.yaml files continue to load unchanged via `LegacyXxx` shims on `specFile` and a polymorphic `credentialsField` decoder that handles both v1 (mapping with `sources:`) and v2 (sequence) shapes for the same `credentials:` YAML tag. A normalize pass folds v1 surfaces into the canonical fields with one deprecation warning per legacy block touched. Phase 6's schema cutover (later) removes the shims.

## Commits

- `d296aa1` feat(spec): Phase 3 — credentials[] + caps.network types (format migration only)
- `3f9d46c` chore(spec,tck): drop redundant Network canonical fields
- `17c3ad4` feat(bindings): add user credential bindings file format + loader (commit 10)
- `0a7ffff` fix(tck): allow routing-only credentials (empty `ApiKey.Name` when `Inject` non-empty)
- `48adfd7` fix(spec): sort legacy `serviceDomains` during normalize for determinism. Go map iteration order is randomized; without this, byte-identical specs produced different `Credentials[].ApiKey.Inject` orderings across loads and the sandboxes-side round-trip test flagged it as a regression.
- `ffc2e34` feat(bindings): `ParseValue` for raw + json-path discovery file parsers (commit 11a). Implements the parser dispatch declared by `DiscoveryFile.Parser`: `""` / `"raw"` returns content with trailing whitespace trimmed; `"json:a.b.c"` walks a dotted JSON path. Misses (key not present, non-string leaf) yield `ErrParserMiss` so the resolver can treat them as "no value here"; malformed parser specs yield `ErrParserMalformed` for the resolver to surface as a logged warning.
- `7e8eade` feat(bindings): allow binding entries with empty discovery list. Scenario 1c from the Phase 3 design discussion — value already in the sandboxes secret store, no separate discovery declaration needed — required the validator to accept bindings with just `allowedDomains`. The resolver consults the secret store before any discovery entries anyway, so making `discovery` optional is the clean expression of "trust these domains; the value is wherever `sbx secret set` put it."

## Scope discipline (important context for review)

Phase 3 is a **format migration only**. Pre-Phase-3 sandboxes passed credential field values through as opaque strings; semantic enforcement (format checks, security policy) happened at the runtime matcher / proxy / governance layer. This PR preserves that posture.

Several validation rules the original plan called for were removed during execution because they were **policy additions wearing a migration's clothes**:

- `apiKey.name` reserved-prefix rule (DASH_/SBX_/DOCKER_)
- `apiKey.inject[].format` must contain exactly one `%s`
- `oauth.passthrough = true` security-downgrade warning
- `provider` field deprecation-style warning
- `Credential.Service` lowercase-kebab pattern
- `apiKey.name` shell-identifier pattern
- `caps.network.allow/deny` entry format validation (P2 vs P3)
- Cross-block rule: `credentials[].apiKey.inject[].domain` must appear in `caps.network.allow` (RFC §818)

Each is tracked in `docs/specs/2026-05-29-unified-kit-spec-v2-deferred-ideas.md` on the sandboxes side, with the rule, why it has merit, why it was deferred, and how to add it later. Reopening any of them is fine — just under its own RFC, not under this migration.

`OAuthCredentialFile.Structure` (declarative JSON shape, security-motivated replacement for the existing free-form `Template` string) and `Credential.Provider` (forward-compat stub for the future provider registry) **do** ship in this PR — the first because removing an attack vector is the new format we want, the second because we want the full v2 spec shape in place.

## Test plan

- [x] `go test ./spec ./tck ./bindings -count=1` passes
- [x] `go vet ./...` clean
- [x] `gofmt -l ...` empty
- [x] v1 round-trip tests for credentials and caps.network shapes pass with deprecation warnings collected
- [x] New tests: `ParseValue` covers raw + json paths, misses, malformed specs (5 cases). Empty-discovery binding round-trips through `Load` + `Validate`.
- [x] Sandboxes-side wire baseline (`TestPhase3Baseline_KitCredentialResolution` in [docker/sandboxes#3267](https://github.com/docker/sandboxes/pull/3267)) stays byte-identical across all 7 sampled built-in kits — validates the wire-format-stability posture end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)