### PR TITLE
feat(scripts): migrate-v1-to-v2 covers full v2 field set via spec normalizer

### DIFF
--- a/scripts/migrate-v1-to-v2.go
+++ b/scripts/migrate-v1-to-v2.go
@@ -1,29 +1,51 @@
 // Command migrate-v1-to-v2 walks a kit artifact directory, rewrites its
-// spec.yaml from schemaVersion 1 to schemaVersion 2, and writes a `.bak`
-// of the original. It is the mechanical companion to the v2 spec-package
-// breaking changes — kit authors run it once to convert their kit
-// without hand-editing every renamed field.
+// spec.yaml from the schemaVersion "1" field shapes to the canonical
+// schemaVersion "2" shapes, and writes a `.bak` of the original. It is the
+// mechanical companion to the v2 spec-package breaking changes — kit authors
+// run it once to convert their kit without hand-editing every renamed,
+// relocated, or consolidated field.
 //
 // Usage:
 //
-//	go run scripts/migrate-v1-to-v2.go <path-to-kit-directory>
+//	go run ./scripts/migrate-v1-to-v2 <path-to-kit-directory>
 //
-// The script is INCREMENTAL: it ships with the v2 migration in stages,
-// each phase adding the transforms for that phase. Today's scope is the
-// Phase 1 cosmetic renames:
+// Approach: rather than re-implement the v1 → v2 field rules as text
+// substitutions, this tool loads spec.yaml through the repository's spec
+// package — the SAME loader the sbx engine uses — which runs the full
+// normalize() pass (kind/agent/memory renames, the credentials/network/oauth
+// consolidation, caps.network promotion, publishedPorts promotion) and then
+// re-emits the normalized result as a canonical v2 spec.yaml. The spec package
+// is therefore the single source of truth: when a new v1 → v2 transform lands
+// in spec/normalize.go, this tool picks it up for free. See
+// sandboxes/docs/specs/2026-05-27-unified-kit-spec-v2.md for the migration
+// roadmap.
 //
-//	memory:    → agentContext:
-//	kind: agent → kind: sandbox
-//	agent:     → sandbox:
+// What it migrates (everything spec.normalize handles, plus the script-level
+// settings: drop below):
 //
-// Later phases will extend the transforms as their PRs land. See
-// sandboxes/docs/specs/2026-05-27-unified-kit-spec-v2.md for the
-// migration roadmap.
+//	kind: agent              → kind: sandbox
+//	agent:                   → sandbox:
+//	memory:                  → agentContext:
+//	credentials.sources      ┐
+//	network.serviceDomains   ├→ unified credentials[] (apiKey.name + .inject)
+//	network.serviceAuth      │
+//	environment.proxyManaged ┘
+//	oauth: (standalone)      → credentials[].oauth
+//	network.allowedDomains   → caps.network.allow
+//	network.deniedDomains    → caps.network.deny
+//	network.publishedPorts   → top-level publishedPorts
+//	settings:                → dropped (move agent setup to commands.initFiles)
+//	schemaVersion: "1"       → schemaVersion: "2"
 //
-// The script is intentionally STANDALONE: it has no module dependencies
-// outside the Go standard library, so kit authors can run it via
-// `go run` against any checkout without needing to pull the rest of
-// sbx-kits-contrib.
+// schemaVersion is bumped to "2" so the migrated kit is a fully-declared v2
+// spec (matching the v2 design doc's migration-strategy step 1). Note this is
+// also the opt-in to the v2 OCI artifact format at distribution time (see
+// spec.SupportedSchemaVersions): a "2" kit is rejected by engines that have not
+// yet adopted v2, so run this only when your target engines can read v2.
+//
+// Unlike the original Phase 1 version, this tool is NOT standalone: it imports
+// github.com/docker/sbx-kits-contrib/spec, so run it with `go run` from within
+// this module rather than against an arbitrary external checkout.
 package main
 
 import (
@@ -31,7 +53,9 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"regexp"
+
+	"github.com/docker/sbx-kits-contrib/spec"
+	"go.yaml.in/yaml/v3"
 )
 
 func main() {
@@ -47,9 +71,10 @@ func main() {
 
 // migrate runs the in-place migration on the spec.yaml under kitDir.
 // All progress messages are written to w; the only error condition is
-// a real I/O or contract failure (missing spec.yaml, refuse to clobber
-// an existing .bak, etc.). A migrated spec with no transforms required
-// is a successful no-op.
+// a real I/O or contract failure (missing spec.yaml, undecodable spec,
+// refuse to clobber an existing .bak, etc.). A spec that already uses only
+// canonical v2 fields is a successful no-op: nothing is rewritten and no
+// .bak is created.
 func migrate(kitDir string, w io.Writer) error {
 	specPath, err := findSpec(kitDir)
 	if err != nil {
@@ -61,7 +86,10 @@ func migrate(kitDir string, w io.Writer) error {
 		return fmt.Errorf("read %s: %w", specPath, err)
 	}
 
-	migrated, changes := applyPhase1Transforms(string(original))
+	migrated, changes, err := migrateSpec(original)
+	if err != nil {
+		return fmt.Errorf("%s: %w", specPath, err)
+	}
 
 	if len(changes) == 0 {
 		fmt.Fprintf(w, "no changes needed in %s\n", specPath)
@@ -75,7 +103,7 @@ func migrate(kitDir string, w io.Writer) error {
 	if err := os.WriteFile(bakPath, original, 0o644); err != nil {
 		return fmt.Errorf("write %s: %w", bakPath, err)
 	}
-	if err := os.WriteFile(specPath, []byte(migrated), 0o644); err != nil {
+	if err := os.WriteFile(specPath, migrated, 0o644); err != nil {
 		return fmt.Errorf("write %s: %w", specPath, err)
 	}
 
@@ -98,35 +126,181 @@ func findSpec(kitDir string) (string, error) {
 	return "", fmt.Errorf("no spec.yaml or spec.yml found in %s", kitDir)
 }
 
-// Phase 1 transforms: rename three top-level YAML keys/values. Anchored
-// to the start of a line so nested keys with the same name (unlikely but
-// possible) are left alone. Each transform reports the change in
-// human-readable form for the migration summary.
-
-var (
-	kindAgentRE  = regexp.MustCompile(`(?m)^kind:\s*agent\s*$`)
-	agentBlockRE = regexp.MustCompile(`(?m)^agent:`)
-	memoryFieldRE = regexp.MustCompile(`(?m)^memory:`)
-)
-
-// applyPhase1Transforms runs the Phase 1 v1 → v2 renames on src. Returns
-// the rewritten YAML and a list of human-readable change descriptions
-// (empty when no transforms applied).
-func applyPhase1Transforms(src string) (string, []string) {
-	var changes []string
-
-	if kindAgentRE.MatchString(src) {
-		src = kindAgentRE.ReplaceAllString(src, "kind: sandbox")
-		changes = append(changes, "kind: agent → kind: sandbox")
-	}
-	if agentBlockRE.MatchString(src) {
-		src = agentBlockRE.ReplaceAllString(src, "sandbox:")
-		changes = append(changes, "agent: block → sandbox: block")
-	}
-	if memoryFieldRE.MatchString(src) {
-		src = memoryFieldRE.ReplaceAllString(src, "agentContext:")
-		changes = append(changes, "memory: → agentContext:")
+// migrateSpec loads v1 (or already-v2) spec.yaml bytes through the spec
+// package's normalize pass and re-emits a canonical v2 spec.yaml. It returns
+// the rewritten YAML and a list of human-readable change descriptions (the
+// spec package's own deprecation warnings, plus any script-level drops such
+// as settings:). changes is empty when the input already uses only canonical
+// v2 fields, in which case the returned bytes should be ignored (no rewrite).
+func migrateSpec(data []byte) ([]byte, []string, error) {
+	a, err := spec.LoadFromBytes(data)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	return src, changes
+	// The spec loader flattens the sandbox entrypoint (run/args/ttyArgs/
+	// pipeMode) into Manifest.Binary/RunOptions and drops ttyArgs/pipeMode, so
+	// it cannot faithfully reconstruct the entrypoint block. Re-read the raw
+	// entrypoint directly from the source YAML (the v1 `agent:` and v2
+	// `sandbox:` blocks share an identical entrypoint shape) and carry it
+	// verbatim into the v2 sandbox: block.
+	var raw rawSpec
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, nil, fmt.Errorf("re-read entrypoint: %w", err)
+	}
+	srcSandbox := raw.Sandbox
+	if srcSandbox == nil {
+		srcSandbox = raw.Agent
+	}
+
+	out := buildV2(a, srcSandbox)
+
+	changes := append([]string(nil), a.Warnings...)
+	// normalize() carries settings: onto Artifact.Settings but never warns:
+	// settings is removed in v2 and we drop it from the emitted spec. Surface
+	// that as a change so the author knows to re-home the behavior.
+	if a.Settings != nil {
+		changes = append(changes, `deprecated field "settings": removed in v2; move agent-specific setup to commands.initFiles (kit-spec v2)`)
+	}
+
+	if len(changes) == 0 {
+		return data, nil, nil
+	}
+
+	emitted, err := yaml.Marshal(out)
+	if err != nil {
+		return nil, nil, fmt.Errorf("emit v2 spec: %w", err)
+	}
+
+	// Safety net: the rewritten spec must parse cleanly through the same
+	// loader. A decode error here means we produced a malformed spec.yaml —
+	// fail loudly rather than overwrite the author's file with garbage.
+	if _, err := spec.LoadFromBytes(emitted); err != nil {
+		return nil, nil, fmt.Errorf("migrated spec failed to re-parse: %w", err)
+	}
+
+	return emitted, changes, nil
+}
+
+// buildV2 assembles the canonical v2 output spec from a normalized Artifact.
+// The credentials/caps/publishedPorts/agentContext/kind values come from the
+// normalized Artifact (where the v1 → v2 consolidation already happened); the
+// sandbox entrypoint comes from srcSandbox (the raw source block) to preserve
+// the run/args/ttyArgs/pipeMode distinctions the Artifact flattens away.
+func buildV2(a *spec.Artifact, srcSandbox *rawSandbox) *outSpec {
+	out := &outSpec{
+		// Always emit the v2 schema version: a migrated kit is a fully-declared
+		// v2 spec. This is reached only when there were v1 constructs to migrate
+		// (callers gate on a non-empty change list), so a clean v2 spec is never
+		// rewritten just to touch this field.
+		SchemaVersion:  "2",
+		Kind:           a.Manifest.Kind,
+		Name:           a.Manifest.Name,
+		Version:        a.Manifest.Version,
+		DisplayName:    a.Manifest.DisplayName,
+		Description:    a.Manifest.Description,
+		SourceURL:      a.Manifest.SourceURL,
+		Extends:        a.Extends,
+		Locked:         a.Locked,
+		Volumes:        a.Manifest.Volumes,
+		Security:       a.Manifest.Security,
+		PublishedPorts: a.PublishedPorts,
+		Caps:           a.Caps,
+		Credentials:    a.Credentials,
+		Commands:       a.Commands,
+		AgentContext:   a.AgentContext,
+	}
+
+	hasEntrypoint := srcSandbox != nil && srcSandbox.Entrypoint != nil
+	if a.Manifest.Template != "" || a.Manifest.AIFilename != "" || a.Manifest.Resources != nil || hasEntrypoint {
+		sb := &outSandbox{
+			Image:      a.Manifest.Template,
+			AIFilename: a.Manifest.AIFilename,
+			Resources:  a.Manifest.Resources,
+		}
+		if hasEntrypoint {
+			sb.Entrypoint = &outEntrypoint{
+				Run:      srcSandbox.Entrypoint.Run,
+				Args:     srcSandbox.Entrypoint.Args,
+				TtyArgs:  srcSandbox.Entrypoint.TtyArgs,
+				PipeMode: srcSandbox.Entrypoint.PipeMode,
+			}
+		}
+		out.Sandbox = sb
+	}
+
+	if a.Environment != nil && len(a.Environment.Variables) > 0 {
+		out.Environment = &outEnv{Variables: a.Environment.Variables}
+	}
+
+	return out
+}
+
+// outSpec is the canonical v2 spec.yaml emit shape. Field order here is the
+// emit order; yaml.Marshal writes struct fields in declaration order. Folded
+// and removed v1 blocks (network:, oauth:, settings:, credentials.sources,
+// environment.proxyManaged) deliberately have no field here, so they never
+// appear in the output.
+type outSpec struct {
+	SchemaVersion  string               `yaml:"schemaVersion"`
+	Kind           string               `yaml:"kind"`
+	Name           string               `yaml:"name"`
+	Version        string               `yaml:"version,omitempty"`
+	DisplayName    string               `yaml:"displayName,omitempty"`
+	Description    string               `yaml:"description,omitempty"`
+	SourceURL      string               `yaml:"sourceURL,omitempty"`
+	Extends        string               `yaml:"extends,omitempty"`
+	Locked         []string             `yaml:"locked,omitempty"`
+	Sandbox        *outSandbox          `yaml:"sandbox,omitempty"`
+	Volumes        []spec.MountSpec     `yaml:"volumes,omitempty"`
+	Security       *spec.Security       `yaml:"security,omitempty"`
+	PublishedPorts []spec.PublishedPort `yaml:"publishedPorts,omitempty"`
+	Caps           *spec.Caps           `yaml:"caps,omitempty"`
+	Credentials    []spec.Credential    `yaml:"credentials,omitempty"`
+	Environment    *outEnv              `yaml:"environment,omitempty"`
+	Commands       *spec.CommandsPolicy `yaml:"commands,omitempty"`
+	AgentContext   string               `yaml:"agentContext,omitempty"`
+}
+
+// outSandbox is the v2 sandbox: block emit shape.
+type outSandbox struct {
+	Image      string          `yaml:"image,omitempty"`
+	AIFilename string          `yaml:"aiFilename,omitempty"`
+	Entrypoint *outEntrypoint  `yaml:"entrypoint,omitempty"`
+	Resources  *spec.Resources `yaml:"resources,omitempty"`
+}
+
+// outEntrypoint is the sandbox.entrypoint emit shape.
+type outEntrypoint struct {
+	Run      []string `yaml:"run,omitempty"`
+	Args     []string `yaml:"args,omitempty"`
+	TtyArgs  []string `yaml:"ttyArgs,omitempty"`
+	PipeMode string   `yaml:"pipeMode,omitempty"`
+}
+
+// outEnv is the environment: block emit shape, restricted to the canonical v2
+// variables: map (the removed proxyManaged list has no field and so is never
+// emitted).
+type outEnv struct {
+	Variables map[string]string `yaml:"variables,omitempty"`
+}
+
+// rawSpec / rawSandbox / rawEntrypoint capture only the entrypoint block from
+// the source spec.yaml, accepting both the v1 `agent:` and v2 `sandbox:`
+// spellings. They exist solely to preserve run/args/ttyArgs/pipeMode through
+// the migration, since the normalized Artifact discards that structure.
+type rawSpec struct {
+	Sandbox *rawSandbox `yaml:"sandbox,omitempty"`
+	Agent   *rawSandbox `yaml:"agent,omitempty"`
+}
+
+type rawSandbox struct {
+	Entrypoint *rawEntrypoint `yaml:"entrypoint,omitempty"`
+}
+
+type rawEntrypoint struct {
+	Run      []string `yaml:"run,omitempty"`
+	Args     []string `yaml:"args,omitempty"`
+	TtyArgs  []string `yaml:"ttyArgs,omitempty"`
+	PipeMode string   `yaml:"pipeMode,omitempty"`
 }

--- a/scripts/migrate_v1_to_v2_test.go
+++ b/scripts/migrate_v1_to_v2_test.go
@@ -8,11 +8,10 @@ import (
 	"testing"
 )
 
-// TestApplyPhase1Transforms_FullShape exercises a v1 spec.yaml that uses
-// every Phase 1 renamed field at once and confirms the output matches
-// the v2-expected golden file byte-for-byte. Comments, blank lines, and
-// block-scalar formatting must survive.
-func TestApplyPhase1Transforms_FullShape(t *testing.T) {
+// TestMigrateSpec_FullShape exercises a v1 spec.yaml that uses every v1 → v2
+// transform at once and confirms the output matches the v2-expected golden
+// file byte-for-byte, and that every expected deprecation change is reported.
+func TestMigrateSpec_FullShape(t *testing.T) {
 	input, err := os.ReadFile(filepath.Join("testdata", "v1-full", "spec.yaml"))
 	if err != nil {
 		t.Fatalf("read input: %v", err)
@@ -22,41 +21,59 @@ func TestApplyPhase1Transforms_FullShape(t *testing.T) {
 		t.Fatalf("read expected: %v", err)
 	}
 
-	got, changes := applyPhase1Transforms(string(input))
+	got, changes, err := migrateSpec(input)
+	if err != nil {
+		t.Fatalf("migrateSpec: %v", err)
+	}
 
-	if got != string(expected) {
+	if string(got) != string(expected) {
 		t.Errorf("output mismatch.\nGOT:\n%s\n\nEXPECTED:\n%s", got, expected)
 	}
 
-	wantChanges := []string{
-		"kind: agent → kind: sandbox",
-		"agent: block → sandbox: block",
-		"memory: → agentContext:",
+	// Each v1 surface in the fixture must surface a change line. We assert on
+	// substrings (the canonical field name) rather than exact warning strings
+	// so wording tweaks in spec/normalize.go don't brittly break this test.
+	wantSubstrings := []string{
+		"kind: agent",
+		"agent:",
+		"credentials.sources",
+		"network.serviceAuth",
+		"network.serviceDomains",
+		"environment.proxyManaged",
+		"oauth: (standalone block)",
+		"network.allowedDomains",
+		"network.deniedDomains",
+		"network.publishedPorts",
+		"memory",
+		"settings",
 	}
-	if len(changes) != len(wantChanges) {
-		t.Fatalf("changes len = %d; want %d (got %v)", len(changes), len(wantChanges), changes)
-	}
-	for i, w := range wantChanges {
-		if changes[i] != w {
-			t.Errorf("changes[%d] = %q; want %q", i, changes[i], w)
+	for _, want := range wantSubstrings {
+		found := false
+		for _, c := range changes {
+			if strings.Contains(c, want) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected a change mentioning %q; got %v", want, changes)
 		}
 	}
 }
 
-// TestApplyPhase1Transforms_AlreadyV2 confirms running the migration on
-// a clean v2 spec is a no-op: no transforms applied, no changes
-// reported, file content unchanged.
-func TestApplyPhase1Transforms_AlreadyV2(t *testing.T) {
+// TestMigrateSpec_AlreadyV2 confirms running the migration on a clean v2 spec
+// is a no-op: no changes reported.
+func TestMigrateSpec_AlreadyV2(t *testing.T) {
 	input, err := os.ReadFile(filepath.Join("testdata", "v2-clean", "spec.yaml"))
 	if err != nil {
 		t.Fatalf("read input: %v", err)
 	}
 
-	got, changes := applyPhase1Transforms(string(input))
-
-	if got != string(input) {
-		t.Errorf("clean v2 spec should be unchanged.\nGOT:\n%s\n\nORIGINAL:\n%s", got, input)
+	_, changes, err := migrateSpec(input)
+	if err != nil {
+		t.Fatalf("migrateSpec: %v", err)
 	}
+
 	if len(changes) != 0 {
 		t.Errorf("expected no changes on clean v2 spec, got %v", changes)
 	}
@@ -103,8 +120,8 @@ func TestMigrate_EndToEnd_FullShape(t *testing.T) {
 		t.Errorf(".bak should hold the original; got differing content")
 	}
 
-	// Summary output mentions each transform.
-	for _, want := range []string{"kind: agent", "agent: block", "memory:"} {
+	// Summary output mentions a representative sample of the transforms.
+	for _, want := range []string{"kind: agent", "agent:", "credentials.sources", "memory", "settings"} {
 		if !strings.Contains(out.String(), want) {
 			t.Errorf("summary output missing %q; got: %s", want, out.String())
 		}
@@ -187,5 +204,23 @@ func TestMigrate_RefusesToClobberBackup(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), ".bak") {
 		t.Errorf("error should mention .bak; got: %v", err)
+	}
+}
+
+// TestMigrate_Idempotent confirms that migrating an already-migrated spec is a
+// no-op: feeding the v2-expected golden back through migrateSpec yields no
+// changes. This guards against the migrator churning canonical v2 output.
+func TestMigrate_Idempotent(t *testing.T) {
+	expected, err := os.ReadFile(filepath.Join("testdata", "v2-expected", "spec.yaml"))
+	if err != nil {
+		t.Fatalf("read expected: %v", err)
+	}
+
+	_, changes, err := migrateSpec(expected)
+	if err != nil {
+		t.Fatalf("migrateSpec on v2-expected: %v", err)
+	}
+	if len(changes) != 0 {
+		t.Errorf("re-migrating canonical v2 output should be a no-op; got changes %v", changes)
 	}
 }

--- a/scripts/testdata/v1-full/spec.yaml
+++ b/scripts/testdata/v1-full/spec.yaml
@@ -2,7 +2,7 @@ schemaVersion: "1"
 kind: agent
 name: legacy-kit
 displayName: Legacy Kit
-description: exercises every Phase 1 renamed field at once
+description: exercises every v1 → v2 transform at once
 
 agent:
   image: "example/test:latest"
@@ -10,6 +10,64 @@ agent:
   entrypoint:
     run: ["test-bin"]
     args: ["--flag"]
+    ttyArgs: ["--interactive"]
+    pipeMode: append
+
+network:
+  serviceDomains:
+    api.anthropic.com: anthropic
+    console.anthropic.com: anthropic
+  serviceAuth:
+    anthropic:
+      headerName: x-api-key
+      valueFormat: "%s"
+  allowedDomains:
+    - "api.anthropic.com:443"
+    - "registry.npmjs.org"
+  deniedDomains:
+    - "malware.example.com"
+  publishedPorts:
+    - container: 8080
+      protocol: tcp
+      name: web
+
+credentials:
+  sources:
+    anthropic:
+      env:
+        - ANTHROPIC_API_KEY
+
+environment:
+  variables:
+    IS_SANDBOX: "1"
+  proxyManaged:
+    - ANTHROPIC_API_KEY
+
+settings:
+  containerSettings:
+    claude: true
+
+commands:
+  install:
+    - command: "echo install"
+      user: "0"
+      description: Install step
+
+oauth:
+  service: anthropic
+  tokenEndpoint:
+    host: platform.claude.com
+    path: /v1/oauth/token
+  sentinels:
+    accessToken: sk-ant-oat01-proxy-managed
+    refreshToken: sk-ant-ort01-proxy-managed
+  credentialFile:
+    path: "~/.claude/.credentials.json"
+    structure:
+      claudeAiOauth:
+        accessToken: "{{.AccessToken}}"
+        refreshToken: "{{.RefreshToken}}"
+        expiresAt: "{{.ExpiresAt}}"
 
 memory: |
   Some legacy memory content.

--- a/scripts/testdata/v2-expected/spec.yaml
+++ b/scripts/testdata/v2-expected/spec.yaml
@@ -1,16 +1,63 @@
-schemaVersion: "1"
+schemaVersion: "2"
 kind: sandbox
 name: legacy-kit
 displayName: Legacy Kit
-description: exercises every Phase 1 renamed field at once
-
+description: exercises every v1 → v2 transform at once
 sandbox:
-  image: "example/test:latest"
-  aiFilename: TEST.md
-  entrypoint:
-    run: ["test-bin"]
-    args: ["--flag"]
-
+    image: example/test:latest
+    aiFilename: TEST.md
+    entrypoint:
+        run:
+            - test-bin
+        args:
+            - --flag
+        ttyArgs:
+            - --interactive
+        pipeMode: append
+publishedPorts:
+    - container: 8080
+      protocol: tcp
+      name: web
+caps:
+    network:
+        allow:
+            - api.anthropic.com:443
+            - registry.npmjs.org
+        deny:
+            - malware.example.com
+credentials:
+    - service: anthropic
+      apiKey:
+        name: ANTHROPIC_API_KEY
+        inject:
+            - domain: api.anthropic.com
+              header: x-api-key
+              format: '%s'
+            - domain: console.anthropic.com
+              header: x-api-key
+              format: '%s'
+      oauth:
+        tokenEndpoint:
+            host: platform.claude.com
+            path: /v1/oauth/token
+        sentinels:
+            accessToken: sk-ant-oat01-proxy-managed
+            refreshToken: sk-ant-ort01-proxy-managed
+        credentialFile:
+            path: ~/.claude/.credentials.json
+            structure:
+                claudeAiOauth:
+                    accessToken: '{{.AccessToken}}'
+                    expiresAt: '{{.ExpiresAt}}'
+                    refreshToken: '{{.RefreshToken}}'
+environment:
+    variables:
+        IS_SANDBOX: "1"
+commands:
+    install:
+        - command: echo install
+          user: "0"
+          description: Install step
 agentContext: |
-  Some legacy memory content.
-  Should be carried over verbatim under agentContext after migration.
+    Some legacy memory content.
+    Should be carried over verbatim under agentContext after migration.


### PR DESCRIPTION
## What

Rewrites `scripts/migrate-v1-to-v2.go` from the Phase-1-only regex renames to a normalizer-backed migration. The script now loads `spec.yaml` through the **`spec` package's `normalize()` pass** (the same loader the sbx engine uses) and re-emits canonical v2 YAML. The spec package becomes the single source of truth, so every v1 → v2 transform that landed since the script was written is applied — and future `normalize.go` transforms are picked up for free.

### Transforms now covered
- `credentials.sources` + `network.serviceDomains`/`serviceAuth` + `environment.proxyManaged` + standalone `oauth:` → unified **`credentials[]`** (`apiKey.name`/`.inject` + `oauth`)
- `network.allowedDomains`/`deniedDomains` → **`caps.network.allow`/`deny`**
- `network.publishedPorts` → top-level **`publishedPorts`**
- `settings:` → **dropped**, with a change note to re-home setup in `commands.initFiles`
- `memory:` → `agentContext:`, `kind: agent` → `sandbox`, `agent:` → `sandbox:`
- **`schemaVersion: "1"` → `"2"`**

The sandbox entrypoint (`run`/`args`/`ttyArgs`/`pipeMode`) is re-read from the raw source YAML because `normalize()` flattens it onto the Manifest.

## ⚠️ `schemaVersion` is now bumped to `"2"` — implications

This is a **behavioral choice with distribution consequences**, called out explicitly:

- Per `spec.SupportedSchemaVersions`, `schemaVersion: "2"` is **also the opt-in to the v2 OCI artifact format** at distribution time — it is *not* purely a field-shape marker (the v2 field shapes themselves decode under both `"1"` and `"2"`).
- Per the spec's forward-compat rule, **engines that have not yet adopted v2 will reject a `"2"` kit.** The repo deliberately keeps `SchemaVersion = "1"` as the scaffolding default *"while sbx releases v2-capable engines into the field."*
- **Therefore: run this migration only when your target engines can read v2.** A migrated kit is no longer loadable by a v1-only engine.
- This aligns the tool with the v2 design doc's migration-strategy step 1 ("bump `schemaVersion` from `\"1\"` to `\"2\"`"). The alternative (preserving `"1"`) was considered and rejected in favor of producing a fully-declared v2 spec.

## Not standalone anymore
The script now imports `github.com/docker/sbx-kits-contrib/spec`, so it must run from within this module: `go run ./scripts/migrate-v1-to-v2 <kit-dir>` (the old version was stdlib-only).

## Testing
- Expanded `testdata/v1-full` to exercise every transform; regenerated the `v2-expected` golden.
- Rewrote unit tests + added an idempotency test (re-migrating v2 output is a no-op).
- Validated against all 18 in-repo kits: each migrates and round-trips back through the loader with **zero remaining v1 deprecation warnings**.
- `go build ./...`, `go vet`, `gofmt`, `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)