### PR TITLE
feat(kits): declare publishedPorts for code-server and codex-app-server

### DIFF
--- a/code-server/README.md
+++ b/code-server/README.md
@@ -3,9 +3,12 @@
 A mixin that installs [code-server](https://github.com/coder/code-server)
 and runs it as a background service on port 8080, with the
 [Claude Code VS Code extension](https://code.claude.com/docs/en/vscode)
-pre-installed. Combined with `sbx ports --publish`, you get a web-based
-VS Code pointed at the sandbox workspace with a native Claude panel that
-shares credentials and conversation history with the `claude` CLI agent.
+pre-installed. The kit declares port 8080 in `network.publishedPorts`,
+so the sandbox runtime publishes it on an ephemeral host port at start
+time — no separate `sbx ports --publish` step is needed. You get a
+web-based VS Code pointed at the sandbox workspace with a native Claude
+panel that shares credentials and conversation history with the `claude`
+CLI agent.
 
 ## Usage
 
@@ -15,16 +18,20 @@ Pair it with the built-in `claude` agent:
 $ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=code-server" ~/my-project
 ```
 
-Publish the port from your host:
+Once the sandbox is up, find the assigned host port:
 
 ```console
-$ sbx ports <sandbox-name> --publish 8080:8080/tcp
+$ sbx ports <sandbox-name>
 ```
 
-Open `http://localhost:8080/` in a browser. code-server opens the
-sandbox workspace on launch — no **File → Open Folder…** needed.
+Open `http://localhost:<host-port>/` in a browser. code-server opens
+the sandbox workspace on launch — no **File → Open Folder…** needed.
 Click the **Spark** icon in the editor toolbar (top-right) to open the
 Claude Code panel; it picks up the same auth the CLI uses.
+
+If you'd rather pin the host port to a fixed value, the classic
+`sbx ports <sandbox-name> --publish 8080:8080/tcp` still works
+alongside the declared ephemeral binding.
 
 If the page doesn't load, check the startup log inside the sandbox:
 
@@ -50,9 +57,10 @@ hardcoded in a static file or a shell-string command.
 ## About authentication
 
 The startup command passes `--auth none`. code-server is only reachable
-through `sbx ports`, which publishes to `localhost` on your host by
-default, so you're already behind the sandbox boundary. If you want a
-password anyway, override the startup command in a forked kit.
+through the runtime's published-port binding, which lands on `localhost`
+on your host by default, so you're already behind the sandbox boundary.
+If you want a password anyway, override the startup command in a forked
+kit.
 
 ### Claude Code extension auth
 

--- a/code-server/spec.yaml
+++ b/code-server/spec.yaml
@@ -6,6 +6,10 @@ displayName: code-server (web VS Code) with Claude Code
 description: Runs code-server on port 8080, opened on the sandbox workspace, with the Claude Code VS Code extension preinstalled. Pair with the built-in claude agent so the extension inherits the sandbox's Anthropic credentials.
 
 network:
+  publishedPorts:
+    - container: 8080
+      protocol: tcp
+      name: code-server
   allowedDomains:
     # `https://code-server.dev/install.sh` is a Cloudflare 302 redirect to
     # `https://raw.githubusercontent.com/cdr/code-server/main/install.sh` —

--- a/codex-app-server/README.md
+++ b/codex-app-server/README.md
@@ -58,7 +58,9 @@ sbx_codex() {
     sbx exec -u 0 "$name" -- sh -c \
         'pgrep -x sshd >/dev/null || { mkdir -p /var/run/sshd && /usr/sbin/sshd > /tmp/sshd.log 2>&1; }' || true
 
-    # Publish sandbox port 22 (ephemeral host port) if not already.
+    # The kit declares port 22 in `publishedPorts`, so the runtime publishes
+    # it on sandbox start. Fallback-publish here for sandboxes created
+    # before the kit grew that declaration.
     sbx ports "$name" --json | jq -e '.[]|select(.sandbox_port==22 and .host_ip=="127.0.0.1")' >/dev/null \
         || sbx ports "$name" --publish 22/tcp >/dev/null
 
@@ -156,8 +158,10 @@ line to `~/.ssh/config` automatically.
 
 `sbx-codex-attach <name>`:
 - Adds `Include ~/.sbx/ssh/codex/*.conf` to `~/.ssh/config` on first run.
-- Publishes sandbox port 22 to an ephemeral host port if not already
-  published.
+- Confirms sandbox port 22 is published to an ephemeral host port (the
+  kit declares it in `publishedPorts`, so the runtime publishes it on
+  every sandbox start; the helper re-publishes only as a fallback for
+  sandboxes created before that declaration landed).
 - Writes `~/.sbx/ssh/codex/<name>.conf` pointing at a shared
   self-healing `proxy.sh` wrapper:
   - **Fast path** (steady state): reads a cached host port, probes it

--- a/codex-app-server/bin/sbx-codex-attach
+++ b/codex-app-server/bin/sbx-codex-attach
@@ -10,9 +10,10 @@
 #   - fast path: reads a cached host port, probes it with `nc -z`, exec's
 #     nc if it answers — no sbx round trips when the sandbox is healthy.
 #   - slow path: wakes the sandbox, fires the kit's startup hooks if they
-#     didn't (kit-added-post-create gap), re-publishes port 22 if needed
-#     (publishing doesn't survive sandbox stop), refreshes the cache, then
-#     exec's nc.
+#     didn't (kit-added-post-create gap), re-publishes port 22 as a
+#     defensive fallback (the kit declares it in `publishedPorts`, so the
+#     runtime publishes it automatically on start), refreshes the cache,
+#     then exec's nc.
 #
 # After running this, add an SSH Connection in the Codex Mac app with the
 # sandbox name as the host. Auth comes from your host SSH agent (the kit
@@ -48,8 +49,9 @@ if ! "$sbx" ls -q 2>/dev/null | grep -qx "$sandbox"; then
     exit 1
 fi
 
-# Publish sandbox port 22 ephemerally if not already published. Idempotent
-# on re-runs because we check first.
+# The kit declares port 22 in `publishedPorts`, so the runtime publishes
+# it on sandbox start. Re-publish here as a defensive fallback for
+# sandboxes created before the kit grew that declaration.
 if ! "$sbx" ports "$sandbox" --json 2>/dev/null \
         | "$jq" -e '.[]|select(.sandbox_port==22 and .host_ip=="127.0.0.1")' >/dev/null; then
     "$sbx" ports "$sandbox" --publish 22/tcp >/dev/null

--- a/codex-app-server/spec.yaml
+++ b/codex-app-server/spec.yaml
@@ -3,9 +3,13 @@ kind: mixin
 name: codex-app-server
 extends: codex
 displayName: Codex app-server (via SSH)
-description: Runs sshd in the sandbox and pre-populates `authorized_keys` from the host's forwarded SSH agent, so the Codex Mac GUI can add the sandbox as an SSH Connection and drive `codex app-server` remotely. Pair with `sbx ports --publish 2222:22/tcp`.
+description: Runs sshd in the sandbox and pre-populates `authorized_keys` from the host's forwarded SSH agent, so the Codex Mac GUI can add the sandbox as an SSH Connection and drive `codex app-server` remotely. The kit declares port 22 in `network.publishedPorts`, so the runtime exposes sshd on an ephemeral host port at sandbox start.
 
 network:
+  publishedPorts:
+    - container: 22
+      protocol: tcp
+      name: sshd
   allowedDomains:
     # `apt-get update` (run by commands.install[0]) refreshes metadata for
     # every configured apt source. The codex-docker base template
@@ -95,12 +99,14 @@ memory: |
 
   sshd is running inside the sandbox on port 22, and your host's SSH
   identities (from the forwarded agent socket) are pre-populated in
-  `/home/agent/.ssh/authorized_keys`. Publish the port from your host
-  with `sbx ports <sandbox> --publish 2222:22/tcp`, then add an SSH
-  connection in the Codex Mac app:
+  `/home/agent/.ssh/authorized_keys`. The kit declares port 22 in its
+  `publishedPorts`, so the runtime exposes sshd on an ephemeral host
+  port automatically. Discover the assigned port with
+  `sbx ports <sandbox>`, then add an SSH connection in the Codex Mac
+  app:
 
       Host: localhost
-      Port: 2222
+      Port: <host-port from sbx ports>
       User: agent
 
   The Codex GUI will SSH in and run `codex app-server` over stdio.


### PR DESCRIPTION
## Summary

PR #46 added the declarative `network.publishedPorts` field. Wire it into the two kits that currently document a manual `sbx ports --publish` step so the runtime publishes the port automatically at sandbox start:

- **code-server** (port 8080): declares `publishedPorts` and drops the manual `sbx ports --publish 8080:8080/tcp` step from the README. Users now run `sbx ports <sandbox>` once to discover the assigned ephemeral host port.
- **codex-app-server** (port 22, sshd): declares `publishedPorts`, refreshes the kit description and `memory:` block. The `sbx-codex-attach` helper and embedded `proxy.sh` keep their publish-if-missing fallback (re-comment as a defensive path) so sandboxes created before this lands keep working.

## Why

Today's UX is exactly what PR #46 set out to fix: every port-exposing kit ships a "now run `sbx ports --publish`" footnote that the runtime should be doing for the user. With `publishedPorts` declared in the spec, the engine wires the port on start and the only host-side step is discovery.

## Test plan

- [x] `go test ./spec/` passes
- [ ] Smoke test `sbx run claude --kit ./code-server/ ~/some-project` against an engine that consumes the new field, confirm `sbx ports` lists 8080 without a `--publish` call
- [ ] Smoke test the codex-app-server flow with `sbx-codex-attach` on a freshly created sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)
