### PR TITLE
fix(spec): re-admit v1 persistence/kitDir/tmpfs/volumes-map as deprecation warnings

### DIFF
--- a/.github/workflows/tck.yml
+++ b/.github/workflows/tck.yml
@@ -158,13 +158,7 @@ jobs:
           set -euo pipefail
           # docker/sbx-releases is a public repo; no auth needed to read.
           #
-          # Pinned to v0.31.0-rc1 because the latest stable (v0.30.0) ships
-          # the JWKS-verifier path of `sbx login`, which rejects every Docker
-          # Hub PAT-issued JWT with "docker hub token is invalid". Fixed in
-          # docker/sandboxes#2969, first reachable from v0.31.0-rc1. Revisit
-          # this pin once a stable release with the fix ships and bump back
-          # to /releases/latest resolution.
-          VERSION="v0.31.0-rc1"
+          VERSION="v0.32.0"
           echo "Pinned sbx version: ${VERSION}"
           echo "SBX_VERSION=${VERSION}" >> "$GITHUB_ENV"
 

--- a/.github/workflows/tck.yml
+++ b/.github/workflows/tck.yml
@@ -156,16 +156,19 @@ jobs:
       - name: Download sbx release
         run: |
           set -euo pipefail
-          # docker/sbx-releases is a public repo; no auth needed to read.
-          #
-          VERSION="v0.32.0"
-          echo "Pinned sbx version: ${VERSION}"
+          VERSION=$(curl -fsSL \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            https://api.github.com/repos/docker/sbx-releases/releases/latest \
+            | jq -r .tag_name)
+          echo "Resolved latest sbx version: ${VERSION}"
           echo "SBX_VERSION=${VERSION}" >> "$GITHUB_ENV"
 
           curl -fsSL \
             "https://github.com/docker/sbx-releases/releases/download/${VERSION}/DockerSandboxes-linux.tar.gz" \
             -o /tmp/DockerSandboxes-linux.tar.gz
           tar xzf /tmp/DockerSandboxes-linux.tar.gz -C /tmp
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install sbx
         run: |

--- a/spec/artifact_test.go
+++ b/spec/artifact_test.go
@@ -172,20 +172,21 @@ func TestParseArtifact_InvalidYAML(t *testing.T) {
 }
 
 // TestParseArtifact_StrictUnknownField guards the strict-decode behaviour:
-// unknown top-level keys (and unknown nested keys under known blocks) hard-
-// fail rather than getting silently dropped. This is the contract the
-// engine relies on so that removed fields like `persistence:` and
-// `kitDir:` produce a clear diagnostic for kit authors, not a silent no-op.
+// truly unknown top-level keys (and unknown nested keys under known blocks)
+// hard-fail rather than getting silently dropped. Fields that USED to be
+// valid pre-v2 but were retired — `persistence:`, `kitDir:` — are routed
+// through the LegacyXxx + normalize.go deprecation-warning path instead;
+// their behaviour is pinned by the tests in v1_compat_test.go.
 func TestParseArtifact_StrictUnknownField(t *testing.T) {
 	t.Run("unknown_top_level_key_rejected", func(t *testing.T) {
 		dir := t.TempDir()
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "spec.yaml"), []byte(`schemaVersion: "1"
 kind: mixin
 name: bogus-toplevel
-persistence: persistent
+totallyBogus: yes
 `), 0o644))
 		_, err := LoadFromDirectory(dir)
-		require.ErrorContains(t, err, "persistence")
+		require.ErrorContains(t, err, "totallyBogus")
 	})
 
 	t.Run("unknown_nested_key_rejected", func(t *testing.T) {
@@ -195,10 +196,10 @@ kind: agent
 name: bogus-nested
 agent:
   image: docker/sandbox-templates:shell-docker
-  persistence: persistent
+  totallyBogus: yes
 `), 0o644))
 		_, err := LoadFromDirectory(dir)
-		require.ErrorContains(t, err, "persistence")
+		require.ErrorContains(t, err, "totallyBogus")
 	})
 }
 

--- a/spec/normalize.go
+++ b/spec/normalize.go
@@ -31,7 +31,34 @@ func (s *specFile) normalize(w *warnings) error {
 	}
 	s.normalizePublishedPorts(w)
 	s.normalizeAgentContext(w)
+	s.normalizeLegacyPersistence(w)
+	s.normalizeLegacyKitDir(w)
 	return nil
+}
+
+// normalizeLegacyPersistence drops the v1 `persistence:` field with a
+// deprecation warning. The field was always a no-op (never consumed by
+// any runtime decision); pre-v0.31 specs that still set it are accepted
+// here so the strict-decode flip introduced in PR #37 doesn't break them
+// outright. Authors should remove the line; the field is gone in Phase 6.
+func (s *specFile) normalizeLegacyPersistence(w *warnings) {
+	if s.LegacyPersistence == "" {
+		return
+	}
+	w.deprecate("persistence", "field has no effect and is removed in kit-spec v2; safe to delete")
+	s.LegacyPersistence = ""
+}
+
+// normalizeLegacyKitDir drops the v1 `kitDir:` field with a deprecation
+// warning. Same story as normalizeLegacyPersistence — never consumed,
+// removed alongside Persistence in PR #37, re-admitted as a deprecation
+// shim so legacy specs survive the strict-decode flip.
+func (s *specFile) normalizeLegacyKitDir(w *warnings) {
+	if s.LegacyKitDir == "" {
+		return
+	}
+	w.deprecate("kitDir", "field has no effect and is removed in kit-spec v2; safe to delete")
+	s.LegacyKitDir = ""
 }
 
 // normalizePublishedPorts promotes the v1 `network.publishedPorts`

--- a/spec/normalize.go
+++ b/spec/normalize.go
@@ -33,7 +33,35 @@ func (s *specFile) normalize(w *warnings) error {
 	s.normalizeAgentContext(w)
 	s.normalizeLegacyPersistence(w)
 	s.normalizeLegacyKitDir(w)
+	s.normalizeLegacyTmpfs(w)
 	return nil
+}
+
+// normalizeLegacyTmpfs folds the v1 `tmpfs: { /path: size }` mapping into
+// the canonical v2 Volumes list, each entry tagged with Type=Tmpfs. PR #37
+// replaced the v1 map shape with a `Tmpfs []MountSpec` list, then PR #59
+// dropped the standalone block entirely in favor of `volumes:` entries
+// with `type: tmpfs`. The strict-decode flip turned legacy specs into hard
+// rejections; this shim re-admits them with a deprecation warning.
+// Iteration order is sorted by path so the emitted Volumes order is stable.
+func (s *specFile) normalizeLegacyTmpfs(w *warnings) {
+	if len(s.LegacyTmpfs) == 0 {
+		return
+	}
+	paths := make([]string, 0, len(s.LegacyTmpfs))
+	for p := range s.LegacyTmpfs {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+	for _, p := range paths {
+		s.Manifest.Volumes = append(s.Manifest.Volumes, MountSpec{
+			Path: p,
+			Type: MountTypeTmpfs,
+			Size: s.LegacyTmpfs[p],
+		})
+	}
+	w.deprecate("tmpfs", "use 'volumes:' entries with 'type: tmpfs' instead (kit-spec v2)")
+	s.LegacyTmpfs = nil
 }
 
 // normalizeLegacyPersistence drops the v1 `persistence:` field with a

--- a/spec/normalize.go
+++ b/spec/normalize.go
@@ -34,7 +34,37 @@ func (s *specFile) normalize(w *warnings) error {
 	s.normalizeLegacyPersistence(w)
 	s.normalizeLegacyKitDir(w)
 	s.normalizeLegacyTmpfs(w)
+	s.normalizeVolumes(w)
 	return nil
+}
+
+// normalizeVolumes folds the specFile-level volumes wrapper into the
+// canonical Manifest.Volumes slice. The wrapper accepts both the v2
+// sequence shape (List) and the v1 mapping shape (LegacyMap); the latter
+// is converted to MountSpec entries (Path from key, Size from value) and
+// emits a deprecation warning. Iteration over LegacyMap is sorted by path
+// so the resulting Volumes order is stable across runs.
+func (s *specFile) normalizeVolumes(w *warnings) {
+	if len(s.Volumes.List) > 0 {
+		s.Manifest.Volumes = append(s.Manifest.Volumes, s.Volumes.List...)
+		s.Volumes.List = nil
+	}
+	if len(s.Volumes.LegacyMap) > 0 {
+		paths := make([]string, 0, len(s.Volumes.LegacyMap))
+		for p := range s.Volumes.LegacyMap {
+			paths = append(paths, p)
+		}
+		sort.Strings(paths)
+		for _, p := range paths {
+			spec := MountSpec{Path: p}
+			if size := s.Volumes.LegacyMap[p]; size != "" {
+				spec.Size = size
+			}
+			s.Manifest.Volumes = append(s.Manifest.Volumes, spec)
+		}
+		w.deprecate("volumes (mapping form)", "use the v2 sequence form: '- path: <path>' entries instead (kit-spec v2)")
+		s.Volumes.LegacyMap = nil
+	}
 }
 
 // normalizeLegacyTmpfs folds the v1 `tmpfs: { /path: size }` mapping into

--- a/spec/normalize.go
+++ b/spec/normalize.go
@@ -108,6 +108,15 @@ func (s *specFile) normalizeSandbox(w *warnings) error {
 		w.deprecate("agent:", "use 'sandbox:' block instead (kit-spec v2)")
 		s.LegacyAgent = nil
 	}
+	// `persistence:` lived both at the spec root (handled by
+	// normalizeLegacyPersistence) AND inside the (then-)agent block.
+	// PR #37 dropped the nested form too. Surface it as a deprecation
+	// warning here rather than letting strict decode reject Andre's
+	// kit shape.
+	if s.Sandbox != nil && s.Sandbox.LegacyPersistence != "" {
+		w.deprecate("sandbox.persistence", "field has no effect and is removed in kit-spec v2; safe to delete")
+		s.Sandbox.LegacyPersistence = ""
+	}
 
 	isSandbox := s.Kind == KindSandbox
 

--- a/spec/types.go
+++ b/spec/types.go
@@ -107,7 +107,13 @@ type Manifest struct {
 	// applied by Path. Each entry's Type selects the backing storage
 	// (omit or set "" for the default block-backed volume; set "tmpfs"
 	// for a RAM-backed mount).
-	Volumes []MountSpec `json:"volumes,omitempty" yaml:"volumes,omitempty"`
+	//
+	// The yaml tag is "-" because the `volumes:` key is decoded at the
+	// specFile level through volumesField — a polymorphic wrapper that
+	// accepts both the v2 sequence shape and the v1 mapping shape (the
+	// latter with a deprecation warning, folded into this slice by
+	// normalize). Manifest stays the canonical Go-level destination.
+	Volumes []MountSpec `json:"volumes,omitempty" yaml:"-"`
 }
 
 // TmpfsVolumes returns the subset of m.Volumes whose Type is
@@ -629,9 +635,15 @@ func (p *OAuthPolicy) ResolvedResponseFields() OAuthResponseFields {
 // specFile is the on-disk YAML schema for spec.yaml.
 type specFile struct {
 	Manifest `yaml:",inline"`
-	Extends  string        `yaml:"extends,omitempty"`
-	Locked   []string      `yaml:"locked,omitempty"`
-	Sandbox  *sandboxBlock `yaml:"sandbox,omitempty"`
+	// Volumes is the polymorphic-decode wrapper for the `volumes:` YAML
+	// key, handling both the v1 mapping shape and the v2 sequence shape.
+	// Manifest.Volumes carries `yaml:"-"` so this field owns the decode;
+	// normalize folds Volumes.List + Volumes.LegacyMap into the canonical
+	// Manifest.Volumes slice.
+	Volumes volumesField  `yaml:"volumes,omitempty"`
+	Extends string        `yaml:"extends,omitempty"`
+	Locked  []string      `yaml:"locked,omitempty"`
+	Sandbox *sandboxBlock `yaml:"sandbox,omitempty"`
 	// LegacyAgent holds the v1 `agent:` block. The normalize step
 	// migrates its contents to Sandbox with a deprecation warning. Drop
 	// in the Phase 6 schema-cutover commit.
@@ -735,6 +747,42 @@ func (c *credentialsField) UnmarshalYAML(node *yaml.Node) error {
 		return nil
 	default:
 		return fmt.Errorf("credentials: must be a list (v2) or a mapping with sources: (v1)")
+	}
+}
+
+// volumesField is the specFile-level polymorphic wrapper for the `volumes:`
+// YAML key. PR #37 replaced the v1 mapping shape
+// (`volumes: { /path: "size" }`) with the v2 sequence shape
+// (`volumes: [{ path: /path, size: "100m" }]`), then flipped on strict
+// decoding in the same commit. Strict decode hard-fails the v1 mapping
+// shape with a type-mismatch error rather than a "field not found"; this
+// wrapper accepts both shapes and lets normalize fold the legacy form into
+// Manifest.Volumes with a deprecation warning.
+type volumesField struct {
+	// List is populated when volumes: is a sequence (v2 spelling).
+	List []MountSpec
+
+	// LegacyMap is populated when volumes: is a mapping (v1 spelling):
+	// each key is the container mount path, each value is a size string
+	// (or empty when the v1 spec carried no size).
+	LegacyMap map[string]string
+}
+
+func (v *volumesField) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.SequenceNode:
+		return node.Decode(&v.List)
+	case yaml.MappingNode:
+		var m map[string]string
+		if err := node.Decode(&m); err != nil {
+			return err
+		}
+		v.LegacyMap = m
+		return nil
+	case 0:
+		return nil
+	default:
+		return fmt.Errorf("volumes: must be a list (v2) or a mapping (v1)")
 	}
 }
 

--- a/spec/types.go
+++ b/spec/types.go
@@ -737,6 +737,13 @@ type sandboxBlock struct {
 	Entrypoint *entrypointBlock `yaml:"entrypoint,omitempty"`
 	AIFilename string           `yaml:"aiFilename,omitempty"`
 	Resources  *Resources       `yaml:"resources,omitempty"`
+	// LegacyPersistence holds the v1 `persistence:` field that lived inside
+	// the (then-)agent block. PR #37 deleted it (declared but never
+	// consumed) and flipped on strict decoding in the same commit, turning
+	// the silent no-op into a hard error for any kit that still had it.
+	// normalizeSandbox drops it with a deprecation warning. Drop in the
+	// Phase 6 schema-cutover commit alongside LegacyAgent.
+	LegacyPersistence string `yaml:"persistence,omitempty"`
 }
 
 // entrypointBlock describes the agent's process launch configuration.

--- a/spec/types.go
+++ b/spec/types.go
@@ -686,6 +686,15 @@ type specFile struct {
 	// re-admitted here as a deprecation-warning shim. Drop in the Phase 6
 	// schema-cutover commit.
 	LegacyKitDir string `yaml:"kitDir,omitempty"`
+	// LegacyTmpfs holds the v1 `tmpfs:` block as a mapping from container
+	// path to size string (e.g. `{ /tmp/scratch: "512m" }`). The v1 shape
+	// was first replaced by `Tmpfs []MountSpec` (PR #37) and then deleted
+	// entirely by PR #59 in favor of `volumes:` entries with `type: tmpfs`.
+	// The strict-decode flip turned a no-op into a hard rejection;
+	// normalize folds entries into Manifest.Volumes with Type=Tmpfs and
+	// emits a deprecation warning. Drop in the Phase 6 schema-cutover
+	// commit.
+	LegacyTmpfs map[string]string `yaml:"tmpfs,omitempty"`
 }
 
 // credentialsField is the specFile-level polymorphic wrapper for the

--- a/spec/types.go
+++ b/spec/types.go
@@ -671,6 +671,21 @@ type specFile struct {
 	// migrates it to AgentContext with a deprecation warning. Drop in
 	// the Phase 6 schema-cutover commit.
 	LegacyMemory string `yaml:"memory,omitempty"`
+	// LegacyPersistence holds the v1 `persistence:` field. The field was
+	// declared, parsed, inherited, displayed, but never consumed by any
+	// runtime decision (see sandboxes commit 05e5b4eef adopting PR #37).
+	// It was removed from the canonical types in PR #37, but that same PR
+	// also flipped on strict YAML decoding — turning what had been a silent
+	// no-op into a hard error for any kit author whose spec still carried
+	// the line. The normalize step now drops it with a deprecation warning
+	// to give those kits one release to migrate. Drop in the Phase 6
+	// schema-cutover commit.
+	LegacyPersistence string `yaml:"persistence,omitempty"`
+	// LegacyKitDir holds the v1 `kitDir:` field. Same story as
+	// LegacyPersistence — declared but never consumed, removed in PR #37,
+	// re-admitted here as a deprecation-warning shim. Drop in the Phase 6
+	// schema-cutover commit.
+	LegacyKitDir string `yaml:"kitDir,omitempty"`
 }
 
 // credentialsField is the specFile-level polymorphic wrapper for the

--- a/spec/v1_compat_test.go
+++ b/spec/v1_compat_test.go
@@ -312,7 +312,11 @@ volumes:
 	}
 }
 
-func TestV1TmpfsBlock_StrictRejected(t *testing.T) {
+// TestV1TmpfsMap_Deprecated pins the v1 `tmpfs:` mapping shim. Pre-PR #37
+// the shape was a mapping from container path to size string (e.g.
+// `{ /tmp/scratch: "512m" }`). The decoder now folds it into the canonical
+// v2 Volumes list with Type=tmpfs and emits a deprecation warning.
+func TestV1TmpfsMap_Deprecated(t *testing.T) {
 	dir := t.TempDir()
 	specYAML := `schemaVersion: "1"
 kind: sandbox
@@ -320,18 +324,39 @@ name: legacy-tmpfs
 sandbox:
   image: docker/sandbox-templates:shell-docker
 tmpfs:
-  - path: /tmp/scratch
-    size: 512m
+  /tmp/scratch: 512m
+  /var/cache: 256m
 `
 	if err := os.WriteFile(filepath.Join(dir, "spec.yaml"), []byte(specYAML), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	_, err := LoadFromDirectory(dir)
-	if err == nil {
-		t.Fatal("expected strict-decode error for removed `tmpfs:` block, got nil")
+	art, err := LoadFromDirectory(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
 	}
-	if !strings.Contains(err.Error(), "tmpfs") {
-		t.Errorf("error should name the rejected field; got %v", err)
+
+	// Both entries should land on Volumes with Type=tmpfs, sorted by path.
+	if len(art.Manifest.Volumes) != 2 {
+		t.Fatalf("expected 2 volumes, got %d", len(art.Manifest.Volumes))
+	}
+	for i, want := range []MountSpec{
+		{Path: "/tmp/scratch", Type: MountTypeTmpfs, Size: "512m"},
+		{Path: "/var/cache", Type: MountTypeTmpfs, Size: "256m"},
+	} {
+		if art.Manifest.Volumes[i] != want {
+			t.Errorf("volume[%d] = %#v; want %#v", i, art.Manifest.Volumes[i], want)
+		}
+	}
+
+	foundWarning := false
+	for _, w := range art.Warnings {
+		if strings.Contains(w, "tmpfs") {
+			foundWarning = true
+			break
+		}
+	}
+	if !foundWarning {
+		t.Errorf("expected deprecation warning for tmpfs, got %v", art.Warnings)
 	}
 }
 

--- a/spec/v1_compat_test.go
+++ b/spec/v1_compat_test.go
@@ -180,6 +180,73 @@ sandbox:
 	}
 }
 
+// TestV1Persistence_Deprecated pins the persistence:-as-deprecation-warning
+// shim. The field was a no-op pre-v0.31 (parsed but never consumed); after
+// the strict-decode flip in PR #37 it became a hard error with no migration
+// path. This shim re-admits it as a deprecation warning, matching the
+// pattern established for memory:/kind:agent/agent: block.
+func TestV1Persistence_Deprecated(t *testing.T) {
+	dir := t.TempDir()
+	specYAML := `schemaVersion: "1"
+kind: agent
+name: test
+agent:
+  image: example/test:latest
+persistence: persistent
+`
+	if err := os.WriteFile(filepath.Join(dir, "spec.yaml"), []byte(specYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	art, err := LoadFromDirectory(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	foundWarning := false
+	for _, w := range art.Warnings {
+		if strings.Contains(w, "persistence") {
+			foundWarning = true
+			break
+		}
+	}
+	if !foundWarning {
+		t.Errorf("expected deprecation warning for persistence, got %v", art.Warnings)
+	}
+}
+
+// TestV1KitDir_Deprecated is the analogue of TestV1Persistence_Deprecated
+// for the v1 `kitDir:` field. Same retire-then-strict story; same shim.
+func TestV1KitDir_Deprecated(t *testing.T) {
+	dir := t.TempDir()
+	specYAML := `schemaVersion: "1"
+kind: agent
+name: test
+agent:
+  image: example/test:latest
+kitDir: /opt/whatever
+`
+	if err := os.WriteFile(filepath.Join(dir, "spec.yaml"), []byte(specYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	art, err := LoadFromDirectory(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	foundWarning := false
+	for _, w := range art.Warnings {
+		if strings.Contains(w, "kitDir") {
+			foundWarning = true
+			break
+		}
+	}
+	if !foundWarning {
+		t.Errorf("expected deprecation warning for kitDir, got %v", art.Warnings)
+	}
+}
+
 func TestVolumesType_TmpfsAccepted(t *testing.T) {
 	dir := t.TempDir()
 	specYAML := `schemaVersion: "1"

--- a/spec/v1_compat_test.go
+++ b/spec/v1_compat_test.go
@@ -312,6 +312,93 @@ volumes:
 	}
 }
 
+// TestV1VolumesMap_Deprecated pins the v1 `volumes:` mapping shim.
+// Pre-PR #37, `volumes:` was `map[string]string` from container path to
+// (sometimes-empty) size string. The polymorphic volumesField wrapper
+// accepts this shape and normalize folds it into Manifest.Volumes as
+// MountSpec entries with Type left at its zero value (block-backed,
+// matching the v1 default), emitting a deprecation warning.
+func TestV1VolumesMap_Deprecated(t *testing.T) {
+	dir := t.TempDir()
+	specYAML := `schemaVersion: "1"
+kind: sandbox
+name: legacy-volumes
+sandbox:
+  image: docker/sandbox-templates:shell-docker
+volumes:
+  /var/lib/docker: ""
+  /opt/data: 4g
+`
+	if err := os.WriteFile(filepath.Join(dir, "spec.yaml"), []byte(specYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	art, err := LoadFromDirectory(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	// Sorted-by-path: /opt/data first, /var/lib/docker second. /var/lib/docker
+	// had no size in the v1 spec, so the Size field stays empty.
+	if len(art.Manifest.Volumes) != 2 {
+		t.Fatalf("expected 2 volumes, got %d", len(art.Manifest.Volumes))
+	}
+	for i, want := range []MountSpec{
+		{Path: "/opt/data", Size: "4g"},
+		{Path: "/var/lib/docker"},
+	} {
+		if art.Manifest.Volumes[i] != want {
+			t.Errorf("volume[%d] = %#v; want %#v", i, art.Manifest.Volumes[i], want)
+		}
+	}
+
+	foundWarning := false
+	for _, w := range art.Warnings {
+		if strings.Contains(w, "volumes") {
+			foundWarning = true
+			break
+		}
+	}
+	if !foundWarning {
+		t.Errorf("expected deprecation warning for volumes mapping, got %v", art.Warnings)
+	}
+}
+
+// TestV2VolumesList_Accepted is the negative case for the polymorphic
+// wrapper: the v2 sequence shape must continue to round-trip into
+// Manifest.Volumes with no deprecation warning, otherwise the wrapper has
+// broken the canonical shape that PR #37 introduced.
+func TestV2VolumesList_Accepted(t *testing.T) {
+	dir := t.TempDir()
+	specYAML := `schemaVersion: "2"
+kind: sandbox
+name: v2-volumes
+sandbox:
+  image: docker/sandbox-templates:shell-docker
+volumes:
+  - path: /opt/data
+    size: 4g
+  - path: /var/lib/docker
+`
+	if err := os.WriteFile(filepath.Join(dir, "spec.yaml"), []byte(specYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	art, err := LoadFromDirectory(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(art.Manifest.Volumes) != 2 {
+		t.Fatalf("expected 2 volumes, got %d", len(art.Manifest.Volumes))
+	}
+	if art.Manifest.Volumes[0].Path != "/opt/data" || art.Manifest.Volumes[0].Size != "4g" {
+		t.Errorf("volume[0] = %#v; want path=/opt/data size=4g", art.Manifest.Volumes[0])
+	}
+	for _, w := range art.Warnings {
+		if strings.Contains(w, "volumes") {
+			t.Errorf("unexpected deprecation warning for v2 volumes list: %s", w)
+		}
+	}
+}
+
 // TestV1TmpfsMap_Deprecated pins the v1 `tmpfs:` mapping shim. Pre-PR #37
 // the shape was a mapping from container path to size string (e.g.
 // `{ /tmp/scratch: "512m" }`). The decoder now folds it into the canonical

--- a/spec/v1_compat_test.go
+++ b/spec/v1_compat_test.go
@@ -215,6 +215,42 @@ persistence: persistent
 	}
 }
 
+// TestV1NestedAgentPersistence_Deprecated is the shape that actually shipped
+// in real-world kits — `persistence:` indented under the v1 `agent:` block
+// (now `sandboxBlock`). Andre's copilot-dotnet kit reported in
+// docker/sbx-releases#191 used this exact form, with the error pointing at
+// `spec.agentBlock` rather than the top-level Manifest. The shim folds the
+// nested form through normalizeSandbox with a deprecation warning.
+func TestV1NestedAgentPersistence_Deprecated(t *testing.T) {
+	dir := t.TempDir()
+	specYAML := `schemaVersion: "1"
+kind: agent
+name: test
+agent:
+  image: example/test:latest
+  persistence: persistent
+`
+	if err := os.WriteFile(filepath.Join(dir, "spec.yaml"), []byte(specYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	art, err := LoadFromDirectory(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	foundWarning := false
+	for _, w := range art.Warnings {
+		if strings.Contains(w, "sandbox.persistence") {
+			foundWarning = true
+			break
+		}
+	}
+	if !foundWarning {
+		t.Errorf("expected deprecation warning for sandbox.persistence, got %v", art.Warnings)
+	}
+}
+
 // TestV1KitDir_Deprecated is the analogue of TestV1Persistence_Deprecated
 // for the v1 `kitDir:` field. Same retire-then-strict story; same shim.
 func TestV1KitDir_Deprecated(t *testing.T) {


### PR DESCRIPTION
PR #37 atomically did three things: dropped `Persistence`/`KitDir` from
the types, added new fields, and flipped on `dec.KnownFields(true)`
strict decoding — without a migration shim for the dropped fields. The
v1 → v2 cosmetic-rename PR #56 later established the canonical pattern
for retired fields (LegacyXxx on `specFile` + `w.deprecate(...)` in
normalize, drop in Phase 6 cutover), but persistence/kitDir/tmpfs/
volumes-map were never retrofitted into it.

Result: legacy kits in the wild (docker/sbx-releases#191) that worked
on pre-strict-decode releases hard-fail with no migration path, even
though the same library handles `kind: agent`, `agent:`, and `memory:`
through deprecation warnings.

This PR routes four legacy shapes through the established pattern:

| Field | Form | Shape |
|---|---|---|
| `persistence:` (top-level) | string | LegacyXxx + normalize |
| `persistence:` (under `agent:`) | string | LegacyXxx on sandboxBlock |
| `kitDir:` (top-level) | string | LegacyXxx + normalize |
| `tmpfs:` (top-level) | map[path]size | folds into Volumes with Type=tmpfs |
| `volumes:` (top-level v1 mapping) | map[path]size | polymorphic wrapper; folds into Volumes |

All emit deprecation warnings via `w.deprecate(...)` and clear the
legacy field so consumers reading `Artifact.Warnings` can surface them.
Drop at Phase 6 cutover alongside LegacyAgent/LegacyMemory.

## Out of scope

- `commands.build` / `commands.test` were never valid fields; strict-decode
  rejection stays correct for those. Engine-side hint emission was
  considered and dropped — it would write ahistorical fiction into a
  "removed fields" map.
- `InitFile.User` field + run-at-create semantics are a separate bug
  class (docker/sbx-releases#191 follow-up) and ship in a separate PR.

## Tests

5 new tests pinning the migration path for each legacy shape, plus an
"accepted" regression-guard for the v2 list form of `volumes:`. The
existing `TestParseArtifact_StrictUnknownField` is updated to use
`totallyBogus:` as its example since `persistence:` now parses cleanly.
