### PR TITLE
feat(spec): accept P1 forward-compat fields mixins + sandbox.build (decode-only)

### DIFF
--- a/spec/artifact.go
+++ b/spec/artifact.go
@@ -133,6 +133,7 @@ func parseArtifactBytes(data []byte) (*Artifact, error) {
 	return &Artifact{
 		Manifest:       spec.Manifest,
 		Extends:        spec.Extends,
+		Mixins:         spec.Mixins,
 		Locked:         spec.Locked,
 		PublishedPorts: spec.PublishedPorts,
 		Caps:           spec.Caps,

--- a/spec/normalize.go
+++ b/spec/normalize.go
@@ -11,6 +11,7 @@ import (
 // collected on w; callers surface them via Artifact.Warnings.
 func (s *specFile) normalize(w *warnings) error {
 	s.normalizeKind(w)
+	s.normalizeMixins(w)
 	if err := s.normalizeSandbox(w); err != nil {
 		return err
 	}
@@ -141,6 +142,19 @@ func (s *specFile) normalizeKind(w *warnings) {
 	}
 }
 
+// normalizeMixins records that the forward-looking `mixins:` field was
+// declared. Mixin composition (resolve the extends chain, apply the kit's
+// own fields, then apply mixins in declaration order) is not wired in this
+// release; the field is accepted so kits and the published v2 docs can use
+// it, but it has no runtime effect yet. The value is carried through to
+// Artifact.Mixins unchanged.
+func (s *specFile) normalizeMixins(w *warnings) {
+	if len(s.Mixins) == 0 {
+		return
+	}
+	w.notImplemented("mixins", "mixin composition is accepted in the schema but not yet applied by the runtime")
+}
+
 // normalizeAgentContext maps the v1 `memory:` field onto AgentContext.
 // The v2 field wins if both are set.
 func (s *specFile) normalizeAgentContext(w *warnings) {
@@ -199,6 +213,19 @@ func (s *specFile) normalizeSandbox(w *warnings) error {
 	s.Template = s.Sandbox.Image
 	s.AIFilename = s.Sandbox.AIFilename
 	s.Resources = s.Sandbox.Resources
+	s.Build = s.Sandbox.Build
+
+	// `sandbox.build` is accepted in the schema (so kits and the published v2
+	// docs can declare it) but the runtime does not build images from it yet.
+	// Warn whenever it is used, and reject build-only kits: an image source is
+	// still required this release, so a kit that supplies only `build:` would
+	// otherwise fail later with the generic "template is required" error.
+	if s.Build != nil {
+		w.notImplemented("sandbox.build", "Dockerfile builds are accepted in the schema but not yet built by the runtime; the image is taken from sandbox.image")
+		if s.Sandbox.Image == "" {
+			return fmt.Errorf("sandbox.build is accepted in the schema but not yet implemented — specify sandbox.image")
+		}
+	}
 
 	if s.Sandbox.Entrypoint != nil {
 		if len(s.Sandbox.Entrypoint.Run) > 0 {

--- a/spec/p1_fields_test.go
+++ b/spec/p1_fields_test.go
@@ -1,0 +1,109 @@
+package spec
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// hasWarningContaining reports whether any warning message contains sub.
+func hasWarningContaining(warnings []string, sub string) bool {
+	for _, w := range warnings {
+		if strings.Contains(w, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// P1 forward-compat fields (mixins, sandbox.build) are accepted at decode
+// time so kits and the published v2 docs can declare them, but neither is
+// wired to runtime behavior yet. These tests pin that contract: the fields
+// decode and round-trip, a load-time warning fires on use, and a build-only
+// kit is rejected with an actionable error.
+
+func TestMixins_DecodeAndWarn(t *testing.T) {
+	yaml := []byte(`
+schemaVersion: "2"
+kind: sandbox
+name: test-kit
+mixins:
+  - dhi.io/python:3-debian13
+  - pandas
+sandbox:
+  image: my-image
+`)
+	art, err := LoadFromBytes(yaml)
+	require.NoError(t, err)
+	require.Equal(t, []string{"dhi.io/python:3-debian13", "pandas"}, art.Mixins,
+		"mixins must round-trip onto Artifact.Mixins unchanged")
+	require.True(t, hasWarningContaining(art.Warnings, "mixins"),
+		"using mixins must emit a not-yet-implemented warning, got: %v", art.Warnings)
+}
+
+func TestMixins_Absent_NoWarning(t *testing.T) {
+	yaml := []byte(`
+schemaVersion: "2"
+kind: sandbox
+name: test-kit
+sandbox:
+  image: my-image
+`)
+	art, err := LoadFromBytes(yaml)
+	require.NoError(t, err)
+	require.Empty(t, art.Mixins)
+	require.False(t, hasWarningContaining(art.Warnings, "mixins"),
+		"no mixins declared must not warn, got: %v", art.Warnings)
+}
+
+func TestBuild_WithImage_DecodesWarnsAndUsesImage(t *testing.T) {
+	yaml := []byte(`
+schemaVersion: "2"
+kind: sandbox
+name: test-kit
+sandbox:
+  image: my-image
+  build:
+    context: .
+    dockerfile: Dockerfile
+    args:
+      AGENT_VERSION: "1.4.2"
+    target: runtime
+    platforms:
+      - linux/amd64
+      - linux/arm64
+`)
+	art, err := LoadFromBytes(yaml)
+	require.NoError(t, err)
+
+	// Image remains the source of truth this release.
+	require.Equal(t, "my-image", art.Manifest.Template)
+
+	// build: decodes and round-trips onto the Manifest.
+	require.NotNil(t, art.Manifest.Build)
+	require.Equal(t, ".", art.Manifest.Build.Context)
+	require.Equal(t, "Dockerfile", art.Manifest.Build.Dockerfile)
+	require.Equal(t, map[string]string{"AGENT_VERSION": "1.4.2"}, art.Manifest.Build.Args)
+	require.Equal(t, "runtime", art.Manifest.Build.Target)
+	require.Equal(t, []string{"linux/amd64", "linux/arm64"}, art.Manifest.Build.Platforms)
+
+	require.True(t, hasWarningContaining(art.Warnings, "sandbox.build"),
+		"using build must emit a not-yet-implemented warning, got: %v", art.Warnings)
+}
+
+func TestBuild_Only_Rejected(t *testing.T) {
+	yaml := []byte(`
+schemaVersion: "2"
+kind: sandbox
+name: test-kit
+sandbox:
+  build:
+    context: .
+    dockerfile: Dockerfile
+`)
+	_, err := LoadFromBytes(yaml)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "sandbox.build is accepted in the schema but not yet implemented")
+	require.ErrorContains(t, err, "specify sandbox.image")
+}

--- a/spec/types.go
+++ b/spec/types.go
@@ -100,6 +100,15 @@ type Manifest struct {
 	// Resources optionally constrains container CPU, memory, and GPU.
 	Resources *Resources `json:"resources,omitempty" yaml:"resources,omitempty"`
 
+	// Build optionally describes how to build the sandbox image from a
+	// Dockerfile, as an alternative to pulling a pre-built Template (image).
+	// Forward-compat (RFC §490, P1): accepted at decode time so kits and the
+	// published v2 docs can declare it, but NOT yet wired — the runtime does
+	// not build images from this block in this release. A kit that sets
+	// `build:` must still set `sandbox.image`; build-only kits are rejected at
+	// load with an actionable error. See BuildConfig.
+	Build *BuildConfig `json:"build,omitempty" yaml:"build,omitempty"`
+
 	// Security defines container security settings.
 	Security *Security `json:"security,omitempty" yaml:"security,omitempty"`
 
@@ -190,6 +199,36 @@ type Resources struct {
 	// GPU is the GPU allocation as a string. Format is consumer-defined
 	// (e.g. "1", "all", a vendor-specific selector).
 	GPU string `json:"gpu,omitempty" yaml:"gpu,omitempty"`
+}
+
+// BuildConfig describes how to build a container image from a Dockerfile,
+// an alternative to referencing a pre-built image (RFC §490, P1).
+//
+// Forward-compat only: this block is accepted at decode time so kit authors
+// and the published v2 docs can declare it, but the runtime does NOT build
+// images from it in this release. A kit that sets `build:` must still set
+// `sandbox.image` (the image is the source of truth this release); a
+// build-only kit is rejected at load with an actionable error. When the
+// build path lands, omitted fields take their documented defaults
+// (Context ".", Dockerfile "Dockerfile") — defaults are intentionally not
+// applied here so the decoded form round-trips exactly as written.
+type BuildConfig struct {
+	// Context is the build context directory, relative to spec.yaml.
+	// Default "." when the build path is implemented.
+	Context string `json:"context,omitempty" yaml:"context,omitempty"`
+
+	// Dockerfile is the Dockerfile path, relative to Context.
+	// Default "Dockerfile" when the build path is implemented.
+	Dockerfile string `json:"dockerfile,omitempty" yaml:"dockerfile,omitempty"`
+
+	// Args are build arguments passed to `docker build --build-arg`.
+	Args map[string]string `json:"args,omitempty" yaml:"args,omitempty"`
+
+	// Target selects a multi-stage build target.
+	Target string `json:"target,omitempty" yaml:"target,omitempty"`
+
+	// Platforms lists target platforms (e.g. "linux/amd64", "linux/arm64").
+	Platforms []string `json:"platforms,omitempty" yaml:"platforms,omitempty"`
 }
 
 // NetworkPolicy defines network rules for which external domains the agent
@@ -471,6 +510,13 @@ type Artifact struct {
 	// Extends is the optional parent kit name for single-parent inheritance.
 	Extends string `json:"extends,omitempty"`
 
+	// Mixins lists horizontal-composition components applied after the
+	// extends chain resolves (RFC §362, P1). Forward-compat: accepted at
+	// decode time so kits and the published v2 docs can declare it, but
+	// mixin composition is not wired in this release — the field has no
+	// runtime effect yet (a load-time warning fires when it is used).
+	Mixins []string `json:"mixins,omitempty"`
+
 	// Locked lists dotted YAML paths (e.g. "agent.image") on this artifact
 	// that child kits must not override during single-parent inheritance.
 	// The spec library only validates well-formedness; enforcement lives
@@ -642,6 +688,7 @@ type specFile struct {
 	// Manifest.Volumes slice.
 	Volumes volumesField  `yaml:"volumes,omitempty"`
 	Extends string        `yaml:"extends,omitempty"`
+	Mixins  []string      `yaml:"mixins,omitempty"`
 	Locked  []string      `yaml:"locked,omitempty"`
 	Sandbox *sandboxBlock `yaml:"sandbox,omitempty"`
 	// LegacyAgent holds the v1 `agent:` block. The normalize step
@@ -791,6 +838,7 @@ func (v *volumesField) UnmarshalYAML(node *yaml.Node) error {
 // field rename to keep call sites legible.
 type sandboxBlock struct {
 	Image      string           `yaml:"image,omitempty"`
+	Build      *BuildConfig     `yaml:"build,omitempty"`
 	Entrypoint *entrypointBlock `yaml:"entrypoint,omitempty"`
 	AIFilename string           `yaml:"aiFilename,omitempty"`
 	Resources  *Resources       `yaml:"resources,omitempty"`

--- a/spec/warnings.go
+++ b/spec/warnings.go
@@ -16,3 +16,12 @@ type warnings struct {
 func (w *warnings) deprecate(field, note string) {
 	w.messages = append(w.messages, fmt.Sprintf("deprecated field %q: %s", field, note))
 }
+
+// notImplemented records that a forward-looking field was accepted at
+// decode time but has no runtime effect yet. Distinct from deprecate: the
+// field is a future canonical spelling (declared so kits and the published
+// v2 docs can use it), not a legacy one being phased out. note explains the
+// current limitation.
+func (w *warnings) notImplemented(field, note string) {
+	w.messages = append(w.messages, fmt.Sprintf("field %q is accepted but not yet implemented: %s", field, note))
+}


### PR DESCRIPTION
## Summary

Adds the two **P1** unified-kit-spec v2 fields the RFC defines but the spec package did not yet accept, so the **published v2 docs and the implemented schema agree**. Both are **decode-only / forward-compat** — accepted at load time, but with **no runtime behavior wired** in this release.

- **`mixins`** (RFC §362) — `[]string` on `specFile` + `Artifact`, carried through unchanged. Horizontal-composition resolution (resolve `extends`, apply kit fields, then apply mixins) is **not** wired.
- **`sandbox.build`** (RFC §490) — new `BuildConfig` (`context`/`dockerfile`/`args`/`target`/`platforms`) on `sandboxBlock` + `Manifest`. The runtime does **not** build images from it.

## Honesty guardrails (so authors aren't misled by docs)

- Declaring either field emits a **not-yet-implemented load warning** — a new `warnings.notImplemented` helper, deliberately distinct from `deprecate` (these are *future* canonical spellings, not legacy ones).
- `sandbox.image` remains the image source of truth. A **build-only kit is rejected at load** with an actionable error (`sandbox.build is accepted in the schema but not yet implemented — specify sandbox.image`) rather than failing later with the generic `template is required`.
- Defaults (`context: "."`, `dockerfile: "Dockerfile"`) are intentionally **not** applied at decode so the form round-trips exactly; they apply when the build path lands.

`provider` (also P1) is already a decode-only stub — no change needed.

## Scope

Schema-completeness only. No consumer in `sandboxes` reads these yet; wiring (mixin composition, the Dockerfile build path) is separate future work. Existing kits are unaffected (`omitempty`, additive).

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./...` all green
- [x] New `spec/p1_fields_test.go`: mixins decode + warn; absent ⇒ no warn; `build`+`image` decode/round-trip/warn/image-wins; build-only rejected with the actionable error

## Context

Surfaced by an RFC field-coverage audit of the v2 migration; these were two of the genuinely-absent P1 fields. Part of the broader unified-kit-spec v2 effort; independent of the phase chain and the open `oauth.resourceHosts` PR.