### PR TITLE
feat(phase4): lift nanoclaw + claude-ollama; settings: → LegacySettings shim

### DIFF
--- a/claude-ollama/spec.yaml
+++ b/claude-ollama/spec.yaml
@@ -14,16 +14,37 @@ environment:
   variables:
     CLAUDE_OLLAMA_MODEL: "gemma4:e4b-it-q4_K_M"
 
-settings:
-  containerSettings:
-    claude: true
-
 network:
   allowedDomains:
     - "localhost:11434"
 
 commands:
+  # Phase 4 lifts the former `settings: { containerSettings: { claude: true } }`
+  # block into the kit. ~/.claude.json carries only the credential-independent
+  # bypass flags (static init file, native onlyIfMissing idempotency). The
+  # settings.json is seeded in commands.startup below. Content SYNCed with the
+  # claude kit.
+  #
+  # This kit declares NO credential service (Ollama is a local model; the
+  # claude-ollama wrapper unsets ANTHROPIC_API_KEY and points Claude Code at
+  # http://host.docker.internal:11434), so the Stage B emitter never sets
+  # SBX_CRED_ANTHROPIC_MODE. The startup branch therefore always takes the
+  # unset → "none" path: settings.json is written WITHOUT apiKeyHelper, which
+  # is correct since there is no proxy-managed cloud credential.
   initFiles:
+    - path: /home/agent/.claude.json
+      content: |
+        {
+          "bypassPermissionsModeAccepted": true,
+          "hasCompletedOnboarding": true,
+          "projects": {
+              "/": {
+              "hasTrustDialogAccepted": true
+            }
+          }
+        }
+      onlyIfMissing: true
+      description: Claude bypass flags (mode-independent)
     - path: /home/agent/.local/bin/claude-ollama
       mode: "0755"
       description: Wrapper script that routes Claude Code to the local Ollama instance
@@ -41,6 +62,36 @@ commands:
         export CLAUDE_CODE_SUBAGENT_MODEL="$CLAUDE_OLLAMA_MODEL"
 
         exec claude "$@"
+  startup:
+    # Seed ~/.claude/settings.json. This kit declares no credential service, so
+    # SBX_CRED_ANTHROPIC_MODE is never set in the container env and the branch
+    # always falls through to the unset → "none" path: settings.json is written
+    # WITHOUT apiKeyHelper. The test -f guard makes resume re-runs a no-op and
+    # never clobbers a user-edited file. settings.json content SYNCed with the
+    # claude kit (none path).
+    - command:
+        - sh
+        - -c
+        - |
+          set -e
+          mkdir -p /home/agent/.claude
+          if [ ! -f /home/agent/.claude/settings.json ]; then
+            HELPER=''
+            if [ "${SBX_CRED_ANTHROPIC_MODE:-none}" != none ]; then
+              HELPER='  "apiKeyHelper": "echo proxy-managed",
+          '
+            fi
+            printf '%s' "{
+            \"themeId\": 1,
+            \"alwaysThinkingEnabled\": true,
+          ${HELPER}  \"defaultMode\": \"bypassPermissions\",
+            \"bypassPermissionsModeAccepted\": true
+          }
+          " > /home/agent/.claude/settings.json
+          fi
+          chown -R agent:agent /home/agent/.claude
+      user: "root"
+      description: Seed Claude settings.json (none path; no credential service)
 
 memory: |
   ## Sandbox environment

--- a/nanoclaw/spec.yaml
+++ b/nanoclaw/spec.yaml
@@ -40,11 +40,58 @@ environment:
   variables:
     IS_SANDBOX: "1"
 
-settings:
-  containerSettings:
-    claude: true
-
 commands:
+  # ~/.claude.json carries only the bypass flags and is credential-independent,
+  # so it is a static init file (native onlyIfMissing idempotency). Phase 4
+  # lifts the former `settings: { containerSettings: { claude: true } }` block
+  # into the kit; the SBX_CRED_<SERVICE>_MODE-driven settings.json is seeded in
+  # commands.startup below. Content SYNCed with the claude kit.
+  initFiles:
+    - path: /home/agent/.claude.json
+      content: |
+        {
+          "bypassPermissionsModeAccepted": true,
+          "hasCompletedOnboarding": true,
+          "projects": {
+              "/": {
+              "hasTrustDialogAccepted": true
+            }
+          }
+        }
+      onlyIfMissing: true
+      description: Claude bypass flags (mode-independent)
+  startup:
+    # Seed ~/.claude/settings.json, branching on the auth mode surfaced via the
+    # SBX_CRED_ANTHROPIC_MODE container env var (this kit declares the
+    # "anthropic" credential service, same as the claude kit).
+    # apiKeyHelper="echo proxy-managed" is included only when a credential
+    # resolved (mode != none); without it Claude Code prompts for /login.
+    # Idempotent via test -f so resume re-runs are a no-op and never clobber a
+    # user-edited file. Replaces the former platform-side claude:true setting
+    # (Phase 4 lift). settings.json content SYNCed with the claude kit.
+    - command:
+        - sh
+        - -c
+        - |
+          set -e
+          mkdir -p /home/agent/.claude
+          if [ ! -f /home/agent/.claude/settings.json ]; then
+            HELPER=''
+            if [ "${SBX_CRED_ANTHROPIC_MODE:-none}" != none ]; then
+              HELPER='  "apiKeyHelper": "echo proxy-managed",
+          '
+            fi
+            printf '%s' "{
+            \"themeId\": 1,
+            \"alwaysThinkingEnabled\": true,
+          ${HELPER}  \"defaultMode\": \"bypassPermissions\",
+            \"bypassPermissionsModeAccepted\": true
+          }
+          " > /home/agent/.claude/settings.json
+          fi
+          chown -R agent:agent /home/agent/.claude
+      user: "root"
+      description: Seed Claude settings.json from SBX_CRED_ANTHROPIC_MODE
   install:
     - command: "npm config set proxy $HTTP_PROXY && npm config set https-proxy $HTTP_PROXY"
       user: "1000"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -40,7 +40,7 @@ Later phases extend the script as their PRs land. See [`docs/specs/2026-05-27-un
 ### What it doesn't migrate
 
 - **Engine-side workspace state** — sandboxes you've already created will have a `kits-memory/` directory in their workspace. The sandboxes engine handles that rename transparently on the next kit add/run; no need to migrate it manually.
-- **Per-kit shell-script bodies** — settings-block code that the v2 spec moves into kit-author shell scripts. The script prints a notice when it encounters a `settings:` block but cannot auto-translate the platform-side shell logic into a kit-side equivalent. See the v2 spec doc's Phase 4 plan for the migration recipe.
+- **The `settings:` block** — in v2 the per-kit container-settings behavior is lifted into the kit's own `initFiles`/`commands.startup` entries, not a spec-level field. The script can't auto-translate it (the v2 replacement is kit-side setup, not spec data), so it prints the settings deprecation/lift notice when it encounters a `settings:` block and leaves the rest of the spec transformed. Lift it yourself using the built-in kits (e.g. `sandboxlib/kit/agents/{claude,codex}/spec.yaml`) as templates; see the v2 spec doc's Phase 4 plan for the recipe.
 
 ### Tests
 

--- a/scripts/migrate-v1-to-v2.go
+++ b/scripts/migrate-v1-to-v2.go
@@ -155,13 +155,11 @@ func migrateSpec(data []byte) ([]byte, []string, error) {
 
 	out := buildV2(a, srcSandbox)
 
+	// normalizeLegacySettings (in the spec package) now emits the settings:
+	// deprecation/lift notice into a.Warnings, so the dead Artifact.Settings
+	// detector that used to live here is gone — the notice flows through the
+	// warnings fold below.
 	changes := append([]string(nil), a.Warnings...)
-	// normalize() carries settings: onto Artifact.Settings but never warns:
-	// settings is removed in v2 and we drop it from the emitted spec. Surface
-	// that as a change so the author knows to re-home the behavior.
-	if a.Settings != nil {
-		changes = append(changes, `deprecated field "settings": removed in v2; move agent-specific setup to commands.initFiles (kit-spec v2)`)
-	}
 
 	if len(changes) == 0 {
 		return data, nil, nil

--- a/spec/artifact.go
+++ b/spec/artifact.go
@@ -138,7 +138,6 @@ func parseArtifactBytes(data []byte) (*Artifact, error) {
 		Caps:           spec.Caps,
 		Credentials:    spec.Credentials.List,
 		Environment:    spec.Environment,
-		Settings:       spec.Settings,
 		Commands:       spec.Commands,
 		AgentContext:   spec.AgentContext,
 		Warnings:       w.messages,

--- a/spec/artifact_test.go
+++ b/spec/artifact_test.go
@@ -23,7 +23,6 @@ func TestLoadFromDirectory(t *testing.T) {
 		require.NotEmpty(t, a.PublishedPorts)
 		require.NotNil(t, a.Credentials)
 		require.NotNil(t, a.Environment)
-		require.NotNil(t, a.Settings)
 		require.NotNil(t, a.Commands)
 		require.NotEmpty(t, a.Files, "should have static files")
 	})
@@ -118,6 +117,20 @@ func TestLoadFromDirectory(t *testing.T) {
 		_, err := LoadFromDirectory("testdata/sample-mixin/spec.yaml")
 		require.ErrorContains(t, err, "not a directory")
 	})
+}
+
+// TestV1Settings_AbsorbedWithDeprecationWarning asserts the Phase 4 behavior:
+// a v1 `settings:` block must still PARSE under strict decoding (the
+// LegacySettings shim absorbs it) and normalize must emit a deprecation
+// warning naming `settings` — not strict-reject. The canonical
+// Artifact.Settings surface is gone (removed in Phase 4); strict-reject is the
+// Phase 6 cutover's job. The sample-mixin fixture still carries a settings:
+// block, so it exercises the shim directly.
+func TestV1Settings_AbsorbedWithDeprecationWarning(t *testing.T) {
+	a, err := LoadFromDirectory("testdata/sample-mixin")
+	require.NoError(t, err, "v1 settings: must load (absorb-and-warn), not strict-reject in Phase 4")
+	require.Contains(t, strings.Join(a.Warnings, "\n"), "settings",
+		"v1 settings: must emit a deprecation warning; got %v", a.Warnings)
 }
 
 func TestLoadFromFS(t *testing.T) {

--- a/spec/kit_settings_lift_ollama_test.go
+++ b/spec/kit_settings_lift_ollama_test.go
@@ -1,6 +1,7 @@
 package spec
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -19,8 +20,10 @@ func TestClaudeOllamaSettingsLift(t *testing.T) {
 	a, err := LoadFromDirectory("../claude-ollama")
 	require.NoError(t, err)
 
-	// (a) settings: block removed.
-	require.Nil(t, a.Settings, "claude-ollama settings block must be removed")
+	// (a) settings: block removed (no settings deprecation warning means the
+	// kit no longer carries a v1 settings: block for the shim to absorb).
+	require.NotContains(t, strings.Join(a.Warnings, "\n"), "settings",
+		"claude-ollama settings block must be removed; got warnings %v", a.Warnings)
 
 	// (b) a commands.startup entry exists.
 	require.NotNil(t, a.Commands)

--- a/spec/kit_settings_lift_ollama_test.go
+++ b/spec/kit_settings_lift_ollama_test.go
@@ -1,0 +1,38 @@
+package spec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestClaudeOllamaSettingsLift verifies the Phase 4 Stage C lift of the
+// claude-ollama kit. Shared helpers (findSettingsStartup, runStartupScript)
+// and the oracle constants live in kit_settings_lift_test.go.
+//
+// claude-ollama declares no credential service (Ollama is a local model; the
+// wrapper unsets ANTHROPIC_API_KEY and routes Claude Code at
+// host.docker.internal:11434), so SBX_CRED_ANTHROPIC_MODE is never set in the
+// real container. The lifted startup therefore always takes the unset -> none
+// path: settings.json without apiKeyHelper.
+func TestClaudeOllamaSettingsLift(t *testing.T) {
+	a, err := LoadFromDirectory("../claude-ollama")
+	require.NoError(t, err)
+
+	// (a) settings: block removed.
+	require.Nil(t, a.Settings, "claude-ollama settings block must be removed")
+
+	// (b) a commands.startup entry exists.
+	require.NotNil(t, a.Commands)
+	require.NotEmpty(t, a.Commands.Startup, "claude-ollama must have commands.startup")
+
+	sc := findSettingsStartup(t, a.Commands)
+	require.Contains(t, sc.Command[2], "SBX_CRED_ANTHROPIC_MODE")
+
+	// No credential service: both unset and explicit =none yield the none
+	// oracle (no apiKeyHelper).
+	require.Equal(t, claudeSettingsNone,
+		runStartupScript(t, sc.Command[2], "SBX_CRED_ANTHROPIC_MODE=none"))
+	require.Equal(t, claudeSettingsNone,
+		runStartupScript(t, sc.Command[2], "SBX_CRED_ANTHROPIC_MODE="))
+}

--- a/spec/kit_settings_lift_test.go
+++ b/spec/kit_settings_lift_test.go
@@ -1,0 +1,97 @@
+package spec
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Phase 4 Stage C lifted the former `settings: { containerSettings: { claude:
+// true } }` block out of the contrib claude-family kits and into a
+// commands.startup script that seeds ~/.claude/settings.json, branching on the
+// SBX_CRED_<SERVICE>_MODE container env var. These oracle strings are the exact
+// settings.json the verified claude kit produces for each auth mode; the
+// lifted scripts must reproduce them byte-for-byte.
+const (
+	claudeSettingsNone = `{
+  "themeId": 1,
+  "alwaysThinkingEnabled": true,
+  "defaultMode": "bypassPermissions",
+  "bypassPermissionsModeAccepted": true
+}
+`
+	claudeSettingsAPIKey = `{
+  "themeId": 1,
+  "alwaysThinkingEnabled": true,
+  "apiKeyHelper": "echo proxy-managed",
+  "defaultMode": "bypassPermissions",
+  "bypassPermissionsModeAccepted": true
+}
+`
+)
+
+// findSettingsStartup returns the lone `sh -c` startup command that seeds
+// settings.json (the one whose script references SBX_CRED_..._MODE).
+func findSettingsStartup(t *testing.T, c *CommandsPolicy) StartupCommand {
+	t.Helper()
+	require.NotNil(t, c, "kit must have commands")
+	for _, sc := range c.Startup {
+		if len(sc.Command) == 3 && sc.Command[0] == "sh" && sc.Command[1] == "-c" &&
+			strings.Contains(sc.Command[2], "settings.json") &&
+			strings.Contains(sc.Command[2], "_MODE") {
+			return sc
+		}
+	}
+	t.Fatalf("no settings.json-seeding startup command found")
+	return StartupCommand{}
+}
+
+// runStartupScript executes the kit's settings-seeding startup script in a
+// temp dir, rewriting the absolute /home/agent paths to the temp dir and
+// making chown non-fatal (the test process is not root), then returns the
+// content of the produced settings.json.
+func runStartupScript(t *testing.T, script, modeEnv string) string {
+	t.Helper()
+	tmp := t.TempDir()
+
+	// /home/agent -> tmp so the script writes inside the sandbox of the test.
+	script = strings.ReplaceAll(script, "/home/agent", tmp)
+	// chown will fail for a non-root test process; keep it non-fatal so the
+	// `set -e` script does not abort before/after writing the file.
+	script = strings.ReplaceAll(script, "chown -R agent:agent", "chown -R agent:agent 2>/dev/null || true #")
+
+	cmd := exec.Command("sh", "-c", script)
+	cmd.Env = append(os.Environ(), modeEnv)
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "startup script failed: %s", out)
+
+	data, err := os.ReadFile(filepath.Join(tmp, ".claude", "settings.json"))
+	require.NoError(t, err)
+	return string(data)
+}
+
+func TestNanoclawSettingsLift(t *testing.T) {
+	a, err := LoadFromDirectory("../nanoclaw")
+	require.NoError(t, err)
+
+	// (a) settings: block removed.
+	require.Nil(t, a.Settings, "nanoclaw settings block must be removed")
+
+	// (b) a commands.startup entry exists.
+	require.NotNil(t, a.Commands)
+	require.NotEmpty(t, a.Commands.Startup, "nanoclaw must have commands.startup")
+
+	sc := findSettingsStartup(t, a.Commands)
+	require.Contains(t, sc.Command[2], "SBX_CRED_ANTHROPIC_MODE",
+		"nanoclaw declares the anthropic credential service")
+
+	// (c) parity: apikey -> apiKeyHelper present; none -> absent.
+	require.Equal(t, claudeSettingsAPIKey,
+		runStartupScript(t, sc.Command[2], "SBX_CRED_ANTHROPIC_MODE=apikey"))
+	require.Equal(t, claudeSettingsNone,
+		runStartupScript(t, sc.Command[2], "SBX_CRED_ANTHROPIC_MODE=none"))
+}

--- a/spec/kit_settings_lift_test.go
+++ b/spec/kit_settings_lift_test.go
@@ -78,8 +78,10 @@ func TestNanoclawSettingsLift(t *testing.T) {
 	a, err := LoadFromDirectory("../nanoclaw")
 	require.NoError(t, err)
 
-	// (a) settings: block removed.
-	require.Nil(t, a.Settings, "nanoclaw settings block must be removed")
+	// (a) settings: block removed (no settings deprecation warning means the
+	// kit no longer carries a v1 settings: block for the shim to absorb).
+	require.NotContains(t, strings.Join(a.Warnings, "\n"), "settings",
+		"nanoclaw settings block must be removed; got warnings %v", a.Warnings)
 
 	// (b) a commands.startup entry exists.
 	require.NotNil(t, a.Commands)

--- a/spec/normalize.go
+++ b/spec/normalize.go
@@ -35,8 +35,24 @@ func (s *specFile) normalize(w *warnings) error {
 	s.normalizeLegacyPersistence(w)
 	s.normalizeLegacyKitDir(w)
 	s.normalizeLegacyTmpfs(w)
+	s.normalizeLegacySettings(w)
 	s.normalizeVolumes(w)
 	return nil
+}
+
+// normalizeLegacySettings drops the v1 `settings:` block with a deprecation
+// warning. Unlike the other Legacy folds there is no v2 field to map into —
+// the per-kit container-settings behavior (`~/.claude/settings.json`,
+// `~/.codex/config.toml`, etc.) was lifted into each kit's
+// initFiles/commands.startup in Phase 4, so the block is absorbed-and-dropped
+// here. The canonical Artifact.Settings field is gone; the SettingsPolicy
+// decode target survives only as this shim's target until Phase 6.
+func (s *specFile) normalizeLegacySettings(w *warnings) {
+	if s.LegacySettings == nil {
+		return
+	}
+	s.LegacySettings = nil
+	w.deprecate("settings", "container settings are now lifted into kit commands.startup; remove this block (kit-spec v2)")
 }
 
 // normalizeVolumes folds the specFile-level volumes wrapper into the

--- a/spec/types.go
+++ b/spec/types.go
@@ -411,7 +411,11 @@ type EnvironmentPolicy struct {
 }
 
 // SettingsPolicy defines container settings that control agent-specific
-// configuration file creation.
+// configuration file creation. As of Phase 4 it is no longer a canonical
+// Artifact surface — it survives only as the decode target for the
+// specFile.LegacySettings shim (the v1 `settings:` block), which
+// normalizeLegacySettings absorbs-and-drops with a deprecation warning.
+// Removed in the Phase 6 schema cutover.
 type SettingsPolicy struct {
 	// ContainerSettings controls which agent-container settings files are created.
 	ContainerSettings map[string]bool `json:"containerSettings,omitempty" yaml:"containerSettings,omitempty"`
@@ -531,9 +535,6 @@ type Artifact struct {
 
 	// Environment is the optional environment policy.
 	Environment *EnvironmentPolicy `json:"environment,omitempty"`
-
-	// Settings is the optional container settings.
-	Settings *SettingsPolicy `json:"settings,omitempty"`
 
 	// Commands is the optional startup commands and init files.
 	Commands *CommandsPolicy `json:"commands,omitempty"`
@@ -704,8 +705,14 @@ type specFile struct {
 	// into the top-level PublishedPorts. Removed in the Phase 6 schema cutover.
 	LegacyNetwork *NetworkPolicy     `yaml:"network,omitempty"`
 	Environment   *EnvironmentPolicy `yaml:"environment,omitempty"`
-	Settings      *SettingsPolicy    `yaml:"settings,omitempty"`
-	Commands      *CommandsPolicy    `yaml:"commands,omitempty"`
+	// LegacySettings absorbs the v1 `settings:` block. There is no v2 field
+	// to map it into — the container-settings behavior was lifted into each
+	// kit's initFiles/commands.startup (Phase 4) — so normalizeLegacySettings
+	// drops it with a deprecation warning. Kept only so KnownFields(true)
+	// strict decode still admits a stray `settings:` block instead of hard-
+	// rejecting it. Removed in the Phase 6 schema cutover.
+	LegacySettings *SettingsPolicy `yaml:"settings,omitempty"`
+	Commands       *CommandsPolicy `yaml:"commands,omitempty"`
 	// Caps is the v2 capabilities block (caps.network and any future
 	// caps.* surfaces). Decoded directly from YAML; the normalize step
 	// also populates Caps.Network from the v1 network.allowedDomains/

--- a/tck/suite.go
+++ b/tck/suite.go
@@ -57,7 +57,6 @@ func (s *Suite) RunAll(t *testing.T) {
 		s.RunCredentialPolicyTests(t)
 		s.RunEnvironmentPolicyTests(t)
 		s.RunCommandsValidationTests(t)
-		s.RunSettingsPolicyTests(t)
 		s.RunOAuthPolicyTests(t)
 
 		// Container tests — single container for all assertions
@@ -485,21 +484,6 @@ func (s *Suite) RunCommandsValidationTests(t *testing.T) {
 				"initFile [%d] path must not be empty", i)
 			require.True(t, strings.HasPrefix(f.Path, "/"),
 				"initFile [%d] path must be absolute (got %q)", i, f.Path)
-		}
-	})
-}
-
-// RunSettingsPolicyTests verifies the settings policy is well-formed.
-func (s *Suite) RunSettingsPolicyTests(t *testing.T) {
-	if s.Artifact.Settings == nil {
-		return
-	}
-
-	t.Run("settings_policy", func(t *testing.T) {
-		require.NotNil(t, s.Artifact.Settings.ContainerSettings,
-			"containerSettings map should not be nil when settings policy is present")
-		for key := range s.Artifact.Settings.ContainerSettings {
-			require.NotEmpty(t, key, "containerSettings key must not be empty")
 		}
 	})
 }

--- a/tck/tck_test.go
+++ b/tck/tck_test.go
@@ -210,12 +210,6 @@ func TestRunCommandsValidationTests(t *testing.T) {
 	suite.RunCommandsValidationTests(t)
 }
 
-func TestRunSettingsPolicyTests(t *testing.T) {
-	suite, err := NewSuiteFromDir("../spec/testdata/sample-mixin")
-	require.NoError(t, err)
-	suite.RunSettingsPolicyTests(t)
-}
-
 func TestRunOAuthPolicyTests(t *testing.T) {
 	// sample-mixin has no OAuth — verify it's a no-op
 	suite, err := NewSuiteFromDir("../spec/testdata/sample-mixin")


### PR DESCRIPTION
## Summary

Contrib side of **Phase 4** (unified-kit-spec v2 — settings-block removal). The host-side `settings:` mechanism is being deleted; this lifts the two contrib kits that used it into their own `commands.startup`, and converts the spec package's `settings:` field to a `LegacySettings` deprecation shim.

```release-note
NONE
```

Pairs with the sandboxes Phase-4 PR (lifts the embedded kits + deletes the host-side settings Go). The sandboxes PR re-pins to this once merged.

## What's here
- **Kit lifts** (one commit each): `nanoclaw` and `claude-ollama` — removed their `settings: { containerSettings: { claude: true } }` block; added `commands.initFiles` + `commands.startup` that seed `~/.claude/settings.json` + `~/.claude.json`, branching on the runtime `SBX_CRED_ANTHROPIC_MODE` env var (claude-ollama is the always-`none` case — local Ollama, no cloud credential). Verified byte-for-byte against the claude settings template.
- **Stage E — `LegacySettings` shim:** renamed `specFile.Settings` → `LegacySettings` (still decodes `settings:` so old kits don't hard-error), added `normalizeLegacySettings` (warn + drop, mirroring `LegacyPersistence`/`LegacyKitDir`/`LegacyTmpfs`), and **removed `Artifact.Settings`** (the field has no v2 home — behavior moved to author-side `commands.startup`). Also updated `scripts/migrate-v1-to-v2.go` (the lift notice now flows via warnings) and removed the TCK `RunSettingsPolicyTests` (it read the removed field — a conformance-surface change).

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` green
- [x] A `settings:` block still parses (no strict-decode error) and emits the deprecation warning (`TestV1Settings_AbsorbedWithDeprecationWarning`)
- [x] Both lifted kits reproduce the claude settings files byte-for-byte (apikey/none) via an sh-exec parity test
- [x] Cross-repo: sandboxes (with `Artifact.Settings` consumers removed) builds + tests green against this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)