### PR TITLE
feat(agent-skills): new mixin — addyosmani's engineering skills for claude

### DIFF
--- a/agent-skills/README.md
+++ b/agent-skills/README.md
@@ -1,0 +1,31 @@
+# agent-skills
+
+A mixin kit (extends `claude`) installing
+[addyosmani/agent-skills](https://github.com/addyosmani/agent-skills) —
+24 production-grade engineering skills for AI coding agents, spanning
+Define, Plan, Build, Verify, Review, and Ship.
+
+## Usage
+
+```console
+$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=agent-skills" claude
+```
+
+Skills land in `~/.claude/skills/` (pinned to upstream tag `0.6.2`) and
+Claude Code discovers them automatically.
+
+## Design notes
+
+This is a **skills-only copy** — the kit deliberately skips upstream's
+plugin install path (`.claude-plugin/`, slash commands, hooks):
+
+- the plugin's `/review`, `/ship`, `/spec`, `/test`, `/plan` commands
+  would collide with other skill packs (e.g. the gstack kit);
+- the SessionStart hook needs `jq` and adds little in a sandbox;
+- `SKILL.md` files are self-contained (only `idea-refine/` carries a
+  helper script, which is offline and dependency-free).
+
+Composes cleanly with other skill packs — the long hyphenated skill
+names don't collide.
+
+No telemetry; only github.com is contacted, at install time.

--- a/agent-skills/spec.yaml
+++ b/agent-skills/spec.yaml
@@ -1,0 +1,32 @@
+schemaVersion: "1"
+kind: mixin
+name: agent-skills
+extends: claude
+displayName: Agent Skills (addyosmani)
+description: "Production-grade engineering skills for AI coding agents — 24 skills across Define/Plan/Build/Verify/Review/Ship, installed for Claude Code. Skills-only copy: no commands or hooks, so it composes cleanly with other skill packs."
+
+network:
+  allowedDomains:
+    - "github.com:443"
+    - "objects.githubusercontent.com:443"
+    - "release-assets.githubusercontent.com:443"
+
+commands:
+  install:
+    # Skills-only copy from the pinned tag. Deliberately skips the repo's
+    # plugin install path (.claude-plugin / commands / hooks): the slash
+    # commands (/review, /ship, /spec, ...) would collide with other skill
+    # packs, and the hooks need jq. SKILL.md files are self-contained.
+    - command: "set -e; git clone --depth 1 --branch 0.6.2 https://github.com/addyosmani/agent-skills.git /tmp/agent-skills; mkdir -p /home/agent/.claude/skills; cp -R /tmp/agent-skills/skills/* /home/agent/.claude/skills/; rm -rf /tmp/agent-skills"
+      user: "1000"
+      description: Install the 24 agent-skills SKILL.md packs (pinned tag 0.6.2)
+
+agentContext: |
+  ## Agent Skills
+
+  This sandbox has addyosmani/agent-skills installed under
+  `~/.claude/skills` — 24 production-grade engineering skills spanning
+  Define, Plan, Build, Verify, Review, and Ship phases (e.g.
+  idea-refine, code-review-and-quality, performance-optimization).
+  Claude Code discovers them automatically; invoke by describing the
+  task or naming the skill.


### PR DESCRIPTION
## Summary

New **mixin** kit (extends `claude`) installing [addyosmani/agent-skills](https://github.com/addyosmani/agent-skills) (★56k, one of the fastest-growing agentic repos) — 24 production-grade SKILL.md engineering skills across Define/Plan/Build/Verify/Review/Ship, pinned to tag `0.6.2`.

### Notes for review

- **Skills-only copy by design**: skips upstream's plugin path — the plugin's slash commands (`/review`, `/ship`, `/spec`, …) would collide with other skill packs (e.g. the gstack kit in #83), and its SessionStart hook needs `jq`. SKILL.md files are self-contained; long hyphenated names don't collide with anything.
- No telemetry; github.com contacted at install time only.

## Test plan

- [x] `sbx kit validate` VALID; TCK validation subtests pass
- [x] E2E (sbx v0.32.0): `sbx create --kit ./agent-skills claude` ~3s → all 24 skills under `~/.claude/skills`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
