### PR TITLE
feat(spec): apiKey.proxyManaged — per-credential in-container sentinel marker

### DIFF
--- a/scripts/migrate_v1_to_v2_test.go
+++ b/scripts/migrate_v1_to_v2_test.go
@@ -224,3 +224,28 @@ func TestMigrate_Idempotent(t *testing.T) {
 		t.Errorf("re-migrating canonical v2 output should be a no-op; got changes %v", changes)
 	}
 }
+
+// TestMigrateEmitsProxyManaged confirms a v1 environment.proxyManaged entry
+// folds onto credentials[].apiKey.proxyManaged: true in the migrated output.
+func TestMigrateEmitsProxyManaged(t *testing.T) {
+	v1 := []byte(`schemaVersion: "1"
+kind: agent
+name: t
+agent: {image: x}
+network:
+  serviceDomains: {api.openai.com: openai}
+  serviceAuth: {openai: {headerName: Authorization, valueFormat: "Bearer %s"}}
+credentials: {sources: {openai: {env: [OPENAI_API_KEY]}}}
+environment: {proxyManaged: [OPENAI_API_KEY]}
+`)
+	out, changes, err := migrateSpec(v1)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if len(changes) == 0 {
+		t.Fatalf("expected migration changes")
+	}
+	if !strings.Contains(string(out), "proxyManaged: true") {
+		t.Fatalf("migrated output missing 'proxyManaged: true':\n%s", out)
+	}
+}

--- a/scripts/testdata/v2-expected/spec.yaml
+++ b/scripts/testdata/v2-expected/spec.yaml
@@ -29,6 +29,7 @@ credentials:
     - service: anthropic
       apiKey:
         name: ANTHROPIC_API_KEY
+        proxyManaged: true
         inject:
             - domain: api.anthropic.com
               header: x-api-key

--- a/spec/normalize.go
+++ b/spec/normalize.go
@@ -28,6 +28,7 @@ func (s *specFile) normalize(w *warnings) error {
 	if err := s.normalizeLegacyOAuthBlock(w); err != nil {
 		return err
 	}
+	s.deriveProxyManagedEnv()
 	if err := s.normalizeCapsNetwork(w); err != nil {
 		return err
 	}
@@ -39,6 +40,40 @@ func (s *specFile) normalize(w *warnings) error {
 	s.normalizeLegacySettings(w)
 	s.normalizeVolumes(w)
 	return nil
+}
+
+// deriveProxyManagedEnv sets Environment.ProxyManaged to the names of the
+// credentials whose apiKey is marked ProxyManaged. This is the canonical v2
+// source of the in-container sentinel set: the v1 `environment.proxyManaged`
+// list folds onto `apiKey.proxyManaged` (normalizeLegacyCredentials), and v2
+// specs declare the marker directly. The list is recomputed here so the engine
+// consumer (which still reads Environment.ProxyManaged) sees one source of
+// truth regardless of v1/v2 input. It deliberately OVERRIDES any decoded list,
+// so a v1 entry that was only a discovery alias (not a credential name) drops
+// out — e.g. shell's GEMINI_API_KEY, whose google credential keeps the
+// canonical GOOGLE_API_KEY. The Environment.ProxyManaged field itself is slated
+// for removal in the Phase 6 schema cutover, when consumers move to reading the
+// credentials directly.
+func (s *specFile) deriveProxyManagedEnv() {
+	var names []string
+	seen := map[string]bool{}
+	for _, c := range s.Credentials.List {
+		if c.ApiKey != nil && c.ApiKey.ProxyManaged && c.ApiKey.Name != "" && !seen[c.ApiKey.Name] {
+			seen[c.ApiKey.Name] = true
+			names = append(names, c.ApiKey.Name)
+		}
+	}
+	sort.Strings(names)
+	if len(names) == 0 {
+		if s.Environment != nil {
+			s.Environment.ProxyManaged = nil
+		}
+		return
+	}
+	if s.Environment == nil {
+		s.Environment = &EnvironmentPolicy{}
+	}
+	s.Environment.ProxyManaged = names
 }
 
 // normalizeLegacySettings drops the v1 `settings:` block with a deprecation

--- a/spec/normalize.go
+++ b/spec/normalize.go
@@ -371,9 +371,10 @@ func (s *specFile) normalizeLegacyCredentials(w *warnings) error {
 	// LegacySources.required, then fold proxyManaged as the apiKey.Name
 	// fallback if LegacySources didn't supply one.
 	type pending struct {
-		required bool
-		envName  string // becomes ApiKey.Name
-		inject   []ApiKeyInject
+		required     bool
+		envName      string // becomes ApiKey.Name
+		proxyManaged bool   // becomes ApiKey.ProxyManaged
+		inject       []ApiKeyInject
 	}
 	byService := make(map[string]*pending)
 
@@ -465,6 +466,7 @@ func (s *specFile) normalizeLegacyCredentials(w *warnings) error {
 			if p.envName == "" {
 				p.envName = envName
 			}
+			p.proxyManaged = true
 		}
 	}
 
@@ -480,7 +482,7 @@ func (s *specFile) normalizeLegacyCredentials(w *warnings) error {
 		p := byService[svc]
 		c := Credential{Service: svc, Required: p.required}
 		if p.envName != "" || len(p.inject) > 0 {
-			c.ApiKey = &ApiKey{Name: p.envName, Inject: p.inject}
+			c.ApiKey = &ApiKey{Name: p.envName, ProxyManaged: p.proxyManaged, Inject: p.inject}
 		}
 		s.Credentials.List = append(s.Credentials.List, c)
 	}

--- a/spec/normalize_test.go
+++ b/spec/normalize_test.go
@@ -259,6 +259,36 @@ oauth:
 		"merged resourceHosts should be sorted and deduped")
 }
 
+func TestNormalizeFoldsProxyManagedToMarker(t *testing.T) {
+	in := []byte(`schemaVersion: "1"
+kind: agent
+name: t
+agent: {image: x}
+network:
+  serviceDomains: {generativelanguage.googleapis.com: google, api.github.com: github}
+  serviceAuth:
+    google: {headerName: x-goog-api-key, valueFormat: "%s"}
+    github: {headerName: Authorization, valueFormat: "Bearer %s"}
+credentials:
+  sources:
+    google: {env: [GOOGLE_API_KEY, GEMINI_API_KEY]}
+    github: {env: [GH_TOKEN]}
+environment:
+  proxyManaged: [GOOGLE_API_KEY, GEMINI_API_KEY]
+`)
+	a, err := LoadFromBytes(in)
+	require.NoError(t, err)
+	bySvc := map[string]*ApiKey{}
+	for i := range a.Credentials {
+		bySvc[a.Credentials[i].Service] = a.Credentials[i].ApiKey
+	}
+	require.NotNil(t, bySvc["google"])
+	require.Equal(t, "GOOGLE_API_KEY", bySvc["google"].Name) // primary; GEMINI not preserved
+	require.True(t, bySvc["google"].ProxyManaged)            // marked
+	require.NotNil(t, bySvc["github"])
+	require.False(t, bySvc["github"].ProxyManaged) // not in proxyManaged → unmarked
+}
+
 func TestDeriveServiceKey(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/spec/normalize_test.go
+++ b/spec/normalize_test.go
@@ -287,6 +287,32 @@ environment:
 	require.True(t, bySvc["google"].ProxyManaged)            // marked
 	require.NotNil(t, bySvc["github"])
 	require.False(t, bySvc["github"].ProxyManaged) // not in proxyManaged → unmarked
+
+	// Environment.ProxyManaged is DERIVED from the marked credentials: only
+	// google's canonical GOOGLE_API_KEY (GEMINI secondary dropped, github
+	// unmarked). This is the in-container sentinel set the engine reads.
+	require.NotNil(t, a.Environment)
+	require.Equal(t, []string{"GOOGLE_API_KEY"}, a.Environment.ProxyManaged)
+}
+
+// A v2 spec that declares apiKey.proxyManaged directly (no environment block)
+// gets Environment.ProxyManaged derived from the markers, so the engine sees
+// the in-container sentinel set without a v1 environment.proxyManaged list.
+func TestNormalizeDerivesProxyManagedFromV2Markers(t *testing.T) {
+	in := []byte(`schemaVersion: "2"
+kind: sandbox
+name: t
+sandbox: {image: x}
+credentials:
+  - service: openai
+    apiKey: {name: OPENAI_API_KEY, proxyManaged: true, inject: [{domain: api.openai.com, header: Authorization, format: "Bearer %s"}]}
+  - service: github
+    apiKey: {name: GH_TOKEN, inject: [{domain: api.github.com, header: Authorization, format: "Bearer %s"}]}
+`)
+	a, err := LoadFromBytes(in)
+	require.NoError(t, err)
+	require.NotNil(t, a.Environment)
+	require.Equal(t, []string{"OPENAI_API_KEY"}, a.Environment.ProxyManaged) // github unmarked → excluded
 }
 
 func TestDeriveServiceKey(t *testing.T) {

--- a/spec/types.go
+++ b/spec/types.go
@@ -370,8 +370,15 @@ func (c Credential) RoutingHosts() []string {
 // (set to the literal "proxy-managed" by the engine when this credential
 // is wired up).
 type ApiKey struct {
-	Name   string         `json:"name" yaml:"name"`
-	Inject []ApiKeyInject `json:"inject,omitempty" yaml:"inject,omitempty"`
+	Name string `json:"name" yaml:"name"`
+	// ProxyManaged, when true, makes the engine set Name to the literal
+	// "proxy-managed" sentinel inside the container (the sentinel-swap proxy
+	// replaces it on the matching inject domains). Default false: a credential
+	// is injected by the proxy on its domains but its env var is NOT set
+	// in-container unless this is set. Re-expresses the removed v1
+	// environment.proxyManaged list per-credential.
+	ProxyManaged bool           `json:"proxyManaged,omitempty" yaml:"proxyManaged,omitempty"`
+	Inject       []ApiKeyInject `json:"inject,omitempty" yaml:"inject,omitempty"`
 }
 
 // ApiKeyInject describes one (domain, header) injection rule for an

--- a/spec/types_test.go
+++ b/spec/types_test.go
@@ -6,6 +6,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestApiKeyProxyManagedRoundTrips(t *testing.T) {
+	t.Run("proxyManaged true", func(t *testing.T) {
+		in := []byte("schemaVersion: \"2\"\nkind: sandbox\nname: t\nsandbox:\n  image: x\ncredentials:\n  - service: openai\n    apiKey:\n      name: OPENAI_API_KEY\n      proxyManaged: true\n      inject:\n        - {domain: api.openai.com, header: Authorization, format: \"Bearer %s\"}\n")
+		a, err := LoadFromBytes(in)
+		require.NoError(t, err)
+		require.Len(t, a.Credentials, 1)
+		require.NotNil(t, a.Credentials[0].ApiKey)
+		require.True(t, a.Credentials[0].ApiKey.ProxyManaged)
+	})
+
+	t.Run("proxyManaged absent defaults to false", func(t *testing.T) {
+		in := []byte("schemaVersion: \"2\"\nkind: sandbox\nname: t\nsandbox:\n  image: x\ncredentials:\n  - service: openai\n    apiKey:\n      name: OPENAI_API_KEY\n      inject:\n        - {domain: api.openai.com, header: Authorization, format: \"Bearer %s\"}\n")
+		a, err := LoadFromBytes(in)
+		require.NoError(t, err)
+		require.Len(t, a.Credentials, 1)
+		require.NotNil(t, a.Credentials[0].ApiKey)
+		require.False(t, a.Credentials[0].ApiKey.ProxyManaged)
+	})
+}
+
 func TestCredentialRoutingHosts(t *testing.T) {
 	// apiKey-only
 	apiKeyCred := Credential{Service: "anthropic", ApiKey: &ApiKey{


### PR DESCRIPTION
## Summary

Re-expresses the removed v1 `environment.proxyManaged` list as a per-credential **`apiKey.proxyManaged: bool`** (default `false`). `normalize` folds v1 `proxyManaged` membership onto the marker; the migrate script emits it. This is the prerequisite for migrating the built-in agent specs (docker/sandboxes) to schemaVersion 2 — the engine will derive the in-container sentinel set from this marker instead of the v1 shim.

Stacked on the Phase 5 doc-sweep branch (#80).

## Why

A full-Artifact gap sweep of the 12 built-in specs showed `Environment.ProxyManaged` is the *only* field that differs v1→v2, and it's a **curated, non-derivable** authoring decision — "which credential env vars are exposed in-container as sentinels." It is **not** redundant with `apiKey.name`: `shell` proxy-manages the provider keys but not `github`; the agent kits (`claude`/`codex`/…) proxy-manage *nothing* despite having an `apiKey`. So v2 must represent it explicitly.

## For review (please flag if you object)

1. **Field name `proxyManaged` + the `false` default** — in-container exposure is opt-in (conservative/secure), vs. the RFC's implicit "`apiKey.name` is always in-container." The agent kits rely on it staying off.
2. **`aliases` / multi-name in-container exposure is intentionally NOT added (YAGNI).** The only case across the built-ins is `shell` exposing google under both `GOOGLE_API_KEY` and `GEMINI_API_KEY` (blanket coverage of a generic shell). We expose the canonical name only; a `GEMINI_API_KEY`-only tool (the `gemini` CLI) has its own dedicated kit. Purely additive later if a real need appears.

```release-note
NONE
```