### PR TITLE
Revert "docs(kit-author): Phase 5 — sweep v1 spellings to v2 in user-facing docs"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ It applies the v2 renames (`memory:` → `agentContext:`, `kind: agent` → `kin
 Pick an existing kit closest in shape to what you want to build and read it end-to-end as a template:
 
 - **[`code-server/`](./code-server)** — mixin: `extends: claude`, `initFiles` with `${WORKDIR}` substitution, shipped config in `files/`.
-- **[`amp/`](./amp)** — `kind: sandbox` kit: custom image, `credentials[].apiKey.inject` for proxy-injected credentials, paired with a one-time `sbx secret set-custom` step.
+- **[`amp/`](./amp)** — `kind: agent` kit: custom image, `serviceDomains`/`serviceAuth` for proxy-injected credentials, paired with a one-time `sbx secret set-custom` step.
 
 ## Per-kit README
 
@@ -39,7 +39,7 @@ For kits that have a corresponding tutorial on [docs.docker.com](https://docs.do
 
 ## Network policy: declare every domain
 
-Your kit's `caps.network.allow` is the **complete** outbound contract — the CI e2e job runs under `deny-all`, so anything you don't list is blocked.
+Your kit's `network.allowedDomains` is the **complete** outbound contract — the CI e2e job runs under `deny-all`, so anything you don't list is blocked.
 
 Watch out for package managers: `apt-get update`, `npm install`, `pip install`, etc. each refresh metadata for every configured source, not just yours. For kits built on `shell-docker` / `*-docker` templates that means `download.docker.com` must be in your list even if you only `apt-get install` from Ubuntu's main archive — `apt-get update` fails the install otherwise. List `archive.ubuntu.com`, `security.ubuntu.com`, **and** `ports.ubuntu.com` so the kit works on both amd64 (CI) and arm64 (Apple Silicon).
 
@@ -153,7 +153,7 @@ For deeper background, see GitHub's docs on [managing commit signature verificat
 A useful PR description has:
 
 - **Summary** — what changed.
-- **Spec choices worth flagging for review** — decisions a reviewer should sanity-check (an unusual image choice, a deliberately narrow `caps.network.allow`, a workaround for a known bug).
+- **Spec choices worth flagging for review** — decisions a reviewer should sanity-check (an unusual image choice, a deliberately narrow `allowedDomains`, a workaround for a known bug).
 - **Test plan** — what CI covers, plus any manual end-to-end you ran.
 - **Origin** — where the kit came from. One sentence is enough.
 

--- a/README.md
+++ b/README.md
@@ -94,18 +94,17 @@ There's no per-kit test file to write — the shared `TestKitTCK` in `tck/kit_te
 2. Write your `spec.yaml`:
 
 ```yaml
-schemaVersion: "2"
+schemaVersion: "1"
 kind: mixin
 name: my-kit
 displayName: My Kit
 description: "Short description of what this kit does"
 
-caps:
-  network:
-    allow:
-      - example.com
-    deny:
-      - tracker.example.com
+network:
+  allowedDomains:
+    - example.com
+  deniedDomains:
+    - tracker.example.com
 
 environment:
   variables:
@@ -150,11 +149,11 @@ working directory set to the package directory (`./tck/`).
 
 ## Declare every domain your kit needs
 
-A kit's `caps.network.allow` is its **complete** outbound network contract. The CI e2e job runs with a `deny-all` default policy, so anything not in your `caps.network.allow` is blocked at request time — and any failed request inside an install hook surfaces as `sbx create` failing.
+A kit's `network.allowedDomains` is its **complete** outbound network contract. The CI e2e job runs with a `deny-all` default policy, so anything not in your `allowedDomains` is blocked at request time — and any failed request inside an install hook surfaces as `sbx create` failing.
 
 The non-obvious trap is **package managers refreshing every configured source**, not just the one you added:
 
-- `apt-get update` re-fetches metadata for every file in `/etc/apt/sources.list[.d/]` — including sources the base template added. If *any* of those returns non-2xx, `apt-get` exits non-zero even if the package you want is in a different source. For kits built on `shell-docker` / `*-docker` templates that means `download.docker.com` (Docker's apt repo, pre-added by the template) needs to be in your `caps.network.allow` even if you're only installing something from Ubuntu's main archive.
+- `apt-get update` re-fetches metadata for every file in `/etc/apt/sources.list[.d/]` — including sources the base template added. If *any* of those returns non-2xx, `apt-get` exits non-zero even if the package you want is in a different source. For kits built on `shell-docker` / `*-docker` templates that means `download.docker.com` (Docker's apt repo, pre-added by the template) needs to be in your `allowedDomains` even if you're only installing something from Ubuntu's main archive.
 - Ubuntu hosts amd64 packages on `archive.ubuntu.com` + `security.ubuntu.com` and arm64 packages on `ports.ubuntu.com`. List all three for cross-arch coverage; CI is amd64, your Mac is likely arm64.
 - `npm install`, `pip install`, `cargo`, `go get`, etc. each have their own registry/mirror hosts — declare them too.
 
@@ -180,7 +179,7 @@ sbx policy reset -f
 sbx policy set-default balanced   # or whichever preset you were on
 ```
 
-Every `Blocked requests` row is a domain your install or startup hook reached for under `deny-all`. Add the host (column `HOST`, e.g. `download.docker.com:443`) to `caps.network.allow` and re-probe until the block list is empty.
+Every `Blocked requests` row is a domain your install or startup hook reached for under `deny-all`. Add the host (column `HOST`, e.g. `download.docker.com:443`) to `allowedDomains` and re-probe until the block list is empty.
 
 ## TCK Test Coverage
 
@@ -188,7 +187,7 @@ The TCK validates your kit automatically:
 
 - **Validation** — `spec.yaml` parses correctly with required fields
 - **Network policy** — allowed domains and service auth are well-formed
-- **Credential policy** — `credentials[]` entries are properly defined
+- **Credential policy** — credential sources are properly defined
 - **Commands** — install/startup commands are well-formed
 - **Environment variables** — declared env vars are set in the container
 - **Container files** — files from `files/` are injected at the correct paths
@@ -202,7 +201,7 @@ The default TCK runs every kit assertion against a fabricated `testcontainers-go
 
 `tck/e2e_test.go` (build-tag `e2e`, function `TestE2ECreateSandbox`) drives one kit per run:
 
-1. Loads the kit at `$KIT_UNDER_TEST` and picks the agent argument — kit name for `kind: sandbox`, `claude` for `kind: mixin`.
+1. Loads the kit at `$KIT_UNDER_TEST` and picks the agent argument — kit name for `kind: agent`, `claude` for `kind: mixin`.
 2. Runs `sbx create --kit <kit> --name <unique> <agent> <tmpdir>` against a temporary workspace.
 3. Verifies, via `sbx exec`, that the running sandbox contains:
    - every `environment.variables` entry,
@@ -261,7 +260,7 @@ The `test-kit-e2e` job in [`.github/workflows/tck.yml`](.github/workflows/tck.ym
 By default, mixins use the `shell` template image. To extend a specific agent (e.g., Claude, Gemini), add the `extends` field:
 
 ```yaml
-schemaVersion: "2"
+schemaVersion: "1"
 kind: mixin
 name: my-claude-extension
 extends: claude

--- a/amp/README.md
+++ b/amp/README.md
@@ -1,6 +1,6 @@
 # amp
 
-A standalone agent kit (`kind: sandbox`) for the
+A standalone agent kit (`kind: agent`) for the
 [Amp](https://ampcode.com/) coding agent. The kit installs Amp into the
 sandbox at creation time, wires its API auth through the sandbox proxy,
 and runs `amp --dangerously-allow-all` as the entrypoint when you
@@ -61,16 +61,16 @@ sandbox.
 
 ## How auth works
 
-The kit's `credentials[]` and `caps.network` blocks declare two things:
+The kit's `network` block declares two things:
 
-- The `amp` service's `apiKey.inject` entry for `ampcode.com` tells the
+- `serviceDomains: ampcode.com -> amp` and `serviceAuth.amp` tell the
   proxy to inject `Authorization: Bearer <key>` on outbound requests
   to `ampcode.com`. The `<key>` value comes from the secret store
   entry registered above, matched by host.
-- `caps.network.allow` covers both the apex (`ampcode.com`) and the
+- `allowedDomains` covers both the apex (`ampcode.com`) and the
   install/CDN subdomains (`*.ampcode.com`).
 
-The injection `domain` is intentionally narrow: a wildcard there would push
+`serviceDomains` is intentionally narrow: a wildcard there would push
 the proxy into TLS-intercepting mode for every `*.ampcode.com` host,
 including the binary CDN the install script downloads from, which
 corrupts the install. List only the host that needs auth injection.

--- a/crush/README.md
+++ b/crush/README.md
@@ -1,6 +1,6 @@
 # crush
 
-A standalone agent kit (`kind: sandbox`) for [Crush](https://github.com/charmbracelet/crush),
+A standalone agent kit (`kind: agent`) for [Crush](https://github.com/charmbracelet/crush),
 Charm's multi-provider AI coding agent. The kit installs Crush from the
 official Charm apt repository, wires API auth for 15 model providers
 through the sandbox proxy, and runs `crush --yolo` as the entrypoint when
@@ -46,24 +46,22 @@ sandbox.
 
 ## How auth works
 
-The kit's `credentials[]` block declares one entry per supported
-provider, each with an `apiKey.inject` entry for that provider's API
-host describing the auth header (`Authorization: Bearer …`,
-`x-api-key: …`, etc). The user-side bindings file
-(`~/.config/sbx/credentials.yaml`) tells the proxy which host env var
-holds each provider's secret.
+The kit's `network` block declares a `serviceDomain` for every supported
+provider's API host and a matching `serviceAuth` entry describing the
+auth header (`Authorization: Bearer …`, `x-api-key: …`, etc). The
+`credentials.sources` block tells the proxy which host env var holds
+each provider's secret.
 
 When Crush makes a request to (say) `api.openai.com`, the proxy:
 
 1. Looks up the service for the domain (`openai`).
-2. Looks up the credential binding for that service (`OPENAI_API_KEY` on
+2. Looks up the credential source for that service (`OPENAI_API_KEY` on
    the host).
 3. Injects `Authorization: Bearer <real-key>` on the outbound request.
 
-The real key never enters the sandbox. The proxy-managed semantic on
-each `credentials[].apiKey.name` exposes a placeholder value for each
-`*_API_KEY` env var inside the container so Crush sees the variables it
-expects to find.
+The real key never enters the sandbox. The `environment.proxyManaged`
+list exposes a placeholder value for each `*_API_KEY` env var inside the
+container so Crush sees the variables it expects to find.
 
-`caps.network.allow` covers the install repo (`repo.charm.sh`) and every
+`allowedDomains` covers the install repo (`repo.charm.sh`) and every
 provider API host.

--- a/hermes-agent/README.md
+++ b/hermes-agent/README.md
@@ -1,6 +1,6 @@
 # hermes-agent
 
-A standalone agent kit (`kind: sandbox`) for
+A standalone agent kit (`kind: agent`) for
 [Hermes Agent](https://github.com/NousResearch/hermes-agent) — the
 self-improving AI agent by [Nous Research](https://nousresearch.com). It
 creates skills from experience, improves them during use, maintains persistent
@@ -68,7 +68,7 @@ start chatting.
 
 ## How auth works
 
-The kit's `credentials[]` block maps each provider's API host to a named service and
+The kit's `network` block maps each provider's API host to a named service and
 declares how the proxy should inject the credential:
 
 - `api.anthropic.com` → injects `x-api-key: <key>`

--- a/nanobot/README.md
+++ b/nanobot/README.md
@@ -1,6 +1,6 @@
 # nanobot
 
-A standalone agent kit (`kind: sandbox`) for
+A standalone agent kit (`kind: agent`) for
 [nanobot](https://pypi.org/project/nanobot-ai/) — a lightweight
 personal AI assistant with multi-platform chat (Telegram, Discord,
 WhatsApp, Slack, Feishu) and multi-provider LLM support. The kit
@@ -50,12 +50,12 @@ The kit drops `/home/agent/.nanobot/config.json` configured with:
 }
 ```
 
-The kit declares the Anthropic auth wiring (`credentials[].apiKey.inject[].domain`,
-`credentials[].apiKey.inject[].header`, `credentials[].service: anthropic`, and
-`credentials[].apiKey.name: ANTHROPIC_API_KEY`) so the sandbox proxy
+The kit declares the Anthropic auth wiring (`serviceDomains`,
+`serviceAuth`, `credentials.sources.anthropic`, and
+`environment.proxyManaged: ANTHROPIC_API_KEY`) so the sandbox proxy
 substitutes the real Anthropic credential on outbound requests to
 `api.anthropic.com`.
 
-The kit's `caps.network.allow` covers PyPI (for the install) and the
+The kit's `allowedDomains` covers PyPI (for the install) and the
 chat-platform hosts (Telegram, Discord, WhatsApp, Slack, Feishu)
 for any chat adapters the user later enables.

--- a/nanoclaw/README.md
+++ b/nanoclaw/README.md
@@ -1,6 +1,6 @@
 # nanoclaw
 
-A standalone agent kit (`kind: sandbox`) for
+A standalone agent kit (`kind: agent`) for
 [nanoclaw](https://github.com/qwibitai/nanoclaw) — a lightweight
 AI assistant runtime driven by Claude Code. The kit clones and
 builds the upstream repo at sandbox creation time and runs Claude
@@ -48,12 +48,12 @@ $ nanoclaw
 ## How auth works
 
 The kit declares the same Anthropic auth wiring as the built-in
-`claude` agent kit: `credentials[].apiKey.inject[].domain`/`credentials[].apiKey.inject[].header` for
+`claude` agent kit: `serviceDomains`/`serviceAuth` for
 `api.anthropic.com`, the OAuth flow against `platform.claude.com`,
 and the `proxy-managed` sentinel pattern. Credentials never enter
 the container — the sandbox proxy substitutes the real value on
 egress.
 
-The kit's `caps.network.allow` adds `registry.npmjs.org` (for the
+The kit's `allowedDomains` adds `registry.npmjs.org` (for the
 install), the WhatsApp hosts the bridge connects to (when the
 WhatsApp adapter is later added), and `nanoclaw.dev`.

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -1,6 +1,6 @@
 # openclaw
 
-A standalone agent kit (`kind: sandbox`) for
+A standalone agent kit (`kind: agent`) for
 [openclaw](https://www.npmjs.com/package/openclaw) — a personal AI
 assistant with multi-platform chat, skills, and a gateway service.
 The kit installs Node.js 22 (openclaw requires `>= 22.12.0`) and
@@ -26,9 +26,9 @@ on first run and stored in `/home/agent/.openclaw/openclaw.json`).
 
 ## How auth works
 
-The kit declares the Anthropic auth wiring (`credentials[].apiKey.inject[].domain`,
-`credentials[].apiKey.inject[].header`, `credentials[].service: anthropic`, and
-`credentials[].apiKey.name: ANTHROPIC_API_KEY`) so the sandbox proxy
+The kit declares the Anthropic auth wiring (`serviceDomains`,
+`serviceAuth`, `credentials.sources.anthropic`, and
+`environment.proxyManaged: ANTHROPIC_API_KEY`) so the sandbox proxy
 substitutes the real Anthropic credential on outbound requests to
 `api.anthropic.com`. The agent never sees the real key.
 
@@ -36,7 +36,7 @@ The kit sets `OPENCLAW_STATE_DIR=/home/agent/.openclaw` so openclaw
 writes its config and gateway token under the agent's home rather
 than the default location.
 
-The kit's `caps.network.allow` covers `deb.nodesource.com` (Node 22
+The kit's `allowedDomains` covers `deb.nodesource.com` (Node 22
 install), `registry.npmjs.org` (npm install), the chat-platform
 hosts for any adapters the user later enables, `openclaw.ai`, and
 `docs.openclaw.ai`.

--- a/pi/README.md
+++ b/pi/README.md
@@ -1,6 +1,6 @@
 # pi
 
-A standalone agent kit (`kind: sandbox`) for the
+A standalone agent kit (`kind: agent`) for the
 [`@earendil-works/pi-coding-agent`](https://www.npmjs.com/package/@earendil-works/pi-coding-agent)
 CLI — a minimal terminal coding agent with extensible tools, skills, and
 TUI. The kit installs `pi` via npm at sandbox creation time and runs
@@ -31,5 +31,5 @@ sentinel that's already in the default sandbox environment. The agent
 never sees the real key.
 
 `registry.npmjs.org` is the only domain the kit adds to
-`caps.network.allow` — it's needed for the install. `api.anthropic.com`
+`allowedDomains` — it's needed for the install. `api.anthropic.com`
 is reached via default sandbox policy, not a kit allowlist entry.

--- a/skills/kit-author/topics/spec-anatomy.md
+++ b/skills/kit-author/topics/spec-anatomy.md
@@ -88,13 +88,11 @@ sandbox:
   entrypoint:
     run: [claude, "--dangerously-skip-permissions"]   # binary + initial args
     args: ["-l"]                                # appended when --task is given
-    ttyArgs: []                                 # appended in interactive mode (P3 — pending sbx support)
-    pipeMode: prepend                           # "prepend"|"append"|"stream"|"ignore" (P3 — pending sbx support)
+    ttyArgs: []                                 # appended in interactive mode
+    pipeMode: prepend                           # one of: "prepend" | "append" | "stream" | "ignore"
 ```
 
 Use `image:` when you can layer the kit's behaviour onto an existing base image via `commands.install` and `commands.initFiles`.
-
-> **Pending sbx support (P3).** `entrypoint.run` and `entrypoint.args` are fully wired. `entrypoint.ttyArgs` and `entrypoint.pipeMode` are parsed and accepted today for forward compatibility but **not yet consumed by the runtime** — declare them now and they become enforceable once sbx wires them.
 
 `entrypoint.pipeMode` controls how piped stdin combines with `--task`. The field is optional; if you set it, it must be one of:
 
@@ -174,14 +172,12 @@ credentials:
         - domain: github.com                   # HTTPS git clone over HTTP Basic
           header: Authorization
           format: "Basic %s"
-          username: x-access-token             # literal HTTP Basic username (P3 — pending sbx support)
+          username: x-access-token             # literal HTTP Basic username
 ```
 
 `apiKey.name` is set to the literal `proxy-managed` inside the container by the engine — the sentinel-swap proxy replaces it on outbound requests. Authors **don't** put real values in the spec.
 
 **Validation:** every `apiKey.inject[].domain` MUST appear in `caps.network.allow`. The spec library rejects a kit whose injection domain isn't allow-listed — there is no auto-derived egress from credentials.
-
-> **Pending sbx support (P3).** `apiKey.inject[].username` (the HTTP Basic auth username) is parsed and accepted today for forward compatibility but **not yet propagated to the proxy** — for the built-in `github` service the proxy uses a hardcoded `x-access-token`. Declare it now for forward-compatible specs; custom-username injection becomes effective once sbx wires it.
 
 ### OAuth shape
 
@@ -385,7 +381,7 @@ Composition: all three lists **concatenate** in `--kit` order. `install` runs fo
 
 ## `settings` — **removed in v2**
 
-The v1 `settings` block (with its `containerSettings` map) hardcoded agent-specific setup. v2 removes it entirely. To write an agent-specific configuration file, use `commands.initFiles` for a **static** file, or `commands.install` when the file's contents depend on runtime state (e.g. a credential-gated settings file that branches on `SBX_CRED_<SERVICE>_MODE`) — `initFiles` writes fixed content and cannot branch. That's the migration path.
+The v1 `settings` block (with its `containerSettings` map) hardcoded agent-specific setup. v2 removes it entirely. If you need to write an agent-specific configuration file at startup, use `commands.initFiles` instead — that's the migration path.
 
 A v1 kit that still ships `settings:` will load via the legacy shims, but the field has no v2 home; see [`v1-migration.md`](v1-migration.md) for the recipe.
 

--- a/skills/kit-author/topics/v1-migration.md
+++ b/skills/kit-author/topics/v1-migration.md
@@ -60,7 +60,7 @@ A handful of v1 fields are removed outright with no v2 home. Strip them by hand:
 |---|---|---|
 | `kitDir` | Never used; confusing semantics. | Delete the field. |
 | `sandbox.persistence` | Parsed but never wired to runtime behavior in v1. | Declare volumes explicitly via `volumes:` instead. |
-| `settings` | Hardcoded agent-specific logic; replaced by kit `commands`. | Move **static** setup into `commands.initFiles` entries; move **credential/mode-dependent** setup (a script that branches on `SBX_CRED_<SERVICE>_MODE`) into `commands.install`, which runs before launch and can branch — `initFiles` writes fixed content only. |
+| `settings` | Hardcoded agent-specific logic; replaced by `commands.initFiles`. | Move the agent-specific setup logic into `commands.initFiles` entries. |
 
 ### Volumes redesign (Phase 2) — **manual**, **strict-rejected**
 

--- a/trivy/README.md
+++ b/trivy/README.md
@@ -1,6 +1,6 @@
 # trivy
 
-A standalone agent kit (`kind: sandbox`) for the [Trivy](https://trivy.dev/)
+A standalone agent kit (`kind: agent`) for the [Trivy](https://trivy.dev/)
 open-source vulnerability scanner from [Aqua Security](https://aquasec.com/).
 The kit installs `trivy` from a pinned, digest-verified GitHub release at
 sandbox creation time and drops you into a bash shell with the binary on
@@ -41,9 +41,9 @@ launches reuse the sandbox; the vuln DB is cached on a persistent volume.
 Trivy is fully open source — **no API key needed** for the standard scan
 flows (`fs`, `repo`, plain `image`). Aqua's commercial feeds (premium
 indicators, SaaS reporting) are out of scope for this kit; if you need
-them, fork and add the appropriate `credentials[].apiKey.inject[].domain` and `credentials`.
+them, fork and add the appropriate `serviceDomains` and `credentials`.
 
-The kit's `caps.network.allow` covers exactly five hosts:
+The kit's `allowedDomains` covers exactly five hosts:
 
 | Host | Why |
 | --- | --- |


### PR DESCRIPTION
Reverts docker/sbx-kits-contrib#80

The PR updated docs, but the spec files were not updated, so they grew out of sync. Deferring the readme updates to when we update the spec files as well.