### PR TITLE
feat(spec): add licenses field (SPDX identifiers)

### DIFF
--- a/spec/artifact.go
+++ b/spec/artifact.go
@@ -135,6 +135,7 @@ func parseArtifactBytes(data []byte) (*Artifact, error) {
 		Extends:        spec.Extends,
 		Mixins:         spec.Mixins,
 		Locked:         spec.Locked,
+		Licenses:       spec.Licenses,
 		PublishedPorts: spec.PublishedPorts,
 		Caps:           spec.Caps,
 		Credentials:    spec.Credentials.List,

--- a/spec/licenses_test.go
+++ b/spec/licenses_test.go
@@ -1,0 +1,65 @@
+package spec
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// licenses is a real declarative metadata field (SPDX identifiers governing
+// the kit), not a forward-compat stub. Unlike mixins/sandbox.build it decodes,
+// validates, and carries onto the Artifact with no "not yet implemented"
+// warning. These tests pin that contract.
+
+func TestLicenses_DecodeAndCarry(t *testing.T) {
+	yaml := []byte(`
+schemaVersion: "2"
+kind: sandbox
+name: test-kit
+licenses:
+  - MIT
+  - Apache-2.0
+sandbox:
+  image: my-image
+`)
+	art, err := LoadFromBytes(yaml)
+	require.NoError(t, err)
+	require.Equal(t, []string{"MIT", "Apache-2.0"}, art.Licenses,
+		"licenses must round-trip onto Artifact.Licenses unchanged")
+	require.False(t, hasWarningContaining(art.Warnings, "licenses"),
+		"licenses is a real field and must not emit a not-yet-implemented warning, got: %v", art.Warnings)
+}
+
+func TestLicenses_Absent_NoError(t *testing.T) {
+	yaml := []byte(`
+schemaVersion: "2"
+kind: sandbox
+name: test-kit
+sandbox:
+  image: my-image
+`)
+	art, err := LoadFromBytes(yaml)
+	require.NoError(t, err)
+	require.Empty(t, art.Licenses)
+}
+
+// LoadFromDirectory runs ValidateArtifact (unlike LoadFromBytes, which only
+// decodes/normalizes), so a malformed licenses list is rejected on a real
+// disk load — the path the engine and migration script use.
+func TestLicenses_InvalidRejectedAtLoad(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "spec.yaml"), []byte(`schemaVersion: "2"
+kind: sandbox
+name: test-kit
+licenses:
+  - MIT
+  - ""
+sandbox:
+  image: my-image
+`), 0o644))
+
+	_, err := LoadFromDirectory(dir)
+	require.ErrorContains(t, err, "must not be empty")
+}

--- a/spec/types.go
+++ b/spec/types.go
@@ -565,6 +565,12 @@ type Artifact struct {
 	// in the consumer that performs the merge.
 	Locked []string `json:"locked,omitempty"`
 
+	// Licenses lists SPDX license identifiers governing the kit (RFC §280,
+	// P2). The spec library only validates well-formedness; composition
+	// (union of parent/mixin licenses) lives in the consumer that performs
+	// the merge. Declarative metadata with no runtime effect.
+	Licenses []string `json:"licenses,omitempty"`
+
 	// PublishedPorts lists in-container ports the kit wants the runtime to
 	// publish on the host when the sandbox starts. It is a top-level
 	// canonical field in v2 — port publishing is inbound service exposure,
@@ -732,11 +738,12 @@ type specFile struct {
 	// Manifest.Volumes carries `yaml:"-"` so this field owns the decode;
 	// normalize folds Volumes.List + Volumes.LegacyMap into the canonical
 	// Manifest.Volumes slice.
-	Volumes volumesField  `yaml:"volumes,omitempty"`
-	Extends string        `yaml:"extends,omitempty"`
-	Mixins  []string      `yaml:"mixins,omitempty"`
-	Locked  []string      `yaml:"locked,omitempty"`
-	Sandbox *sandboxBlock `yaml:"sandbox,omitempty"`
+	Volumes  volumesField  `yaml:"volumes,omitempty"`
+	Extends  string        `yaml:"extends,omitempty"`
+	Mixins   []string      `yaml:"mixins,omitempty"`
+	Locked   []string      `yaml:"locked,omitempty"`
+	Licenses []string      `yaml:"licenses,omitempty"`
+	Sandbox  *sandboxBlock `yaml:"sandbox,omitempty"`
 	// LegacyAgent holds the v1 `agent:` block. The normalize step
 	// migrates its contents to Sandbox with a deprecation warning. Drop
 	// in the Phase 6 schema-cutover commit.

--- a/spec/validate.go
+++ b/spec/validate.go
@@ -274,6 +274,9 @@ func ValidateArtifact(a *Artifact) error {
 	if err := ValidateLocked(a.Locked); err != nil {
 		return err
 	}
+	if err := ValidateLicenses(a.Licenses); err != nil {
+		return err
+	}
 	if err := ValidatePublishedPorts(a.PublishedPorts); err != nil {
 		return err
 	}
@@ -320,6 +323,26 @@ func ValidateLocked(paths []string) error {
 			return fmt.Errorf("locked[%d] %q is duplicated", i, p)
 		}
 		seen[p] = struct{}{}
+	}
+	return nil
+}
+
+// ValidateLicenses validates the well-formedness of a licenses list (SPDX
+// identifiers governing the kit, RFC §280). Each entry must be a non-empty
+// string; duplicates are rejected. Per the RFC implementations SHOULD also
+// warn on unrecognized SPDX identifiers — that check is deferred (it needs an
+// embedded SPDX license list) and would surface as a warning, not an error.
+// Composition (union of parent/mixin licenses) is the merge consumer's job.
+func ValidateLicenses(licenses []string) error {
+	seen := make(map[string]struct{}, len(licenses))
+	for i, l := range licenses {
+		if l == "" {
+			return fmt.Errorf("licenses[%d] must not be empty", i)
+		}
+		if _, dup := seen[l]; dup {
+			return fmt.Errorf("licenses[%d] %q is duplicated", i, l)
+		}
+		seen[l] = struct{}{}
 	}
 	return nil
 }

--- a/spec/validate_test.go
+++ b/spec/validate_test.go
@@ -377,6 +377,24 @@ func TestValidateLocked(t *testing.T) {
 	})
 }
 
+func TestValidateLicenses(t *testing.T) {
+	t.Run("nil_is_valid", func(t *testing.T) {
+		require.NoError(t, ValidateLicenses(nil))
+	})
+
+	t.Run("spdx_identifiers", func(t *testing.T) {
+		require.NoError(t, ValidateLicenses([]string{"MIT", "Apache-2.0"}))
+	})
+
+	t.Run("empty_entry", func(t *testing.T) {
+		require.ErrorContains(t, ValidateLicenses([]string{"MIT", ""}), "must not be empty")
+	})
+
+	t.Run("duplicate", func(t *testing.T) {
+		require.ErrorContains(t, ValidateLicenses([]string{"MIT", "MIT"}), "duplicated")
+	})
+}
+
 func TestValidateOAuthPolicy(t *testing.T) {
 	t.Run("nil_is_valid", func(t *testing.T) {
 		require.NoError(t, ValidateOAuthPolicy(nil))


### PR DESCRIPTION
## What

Adds the v2 `licenses` top-level field (RFC §280, P2) to the spec package: a declarative list of SPDX license identifiers governing the kit.

## Why

`licenses` is one of the v2 RFC fields not yet present in the spec types. It's purely declarative metadata — no runtime functionality to wire — so it's a low-risk, self-contained addition that can land independently of the binding/consent stack and ahead of the Phase 6 cutover.

## How

Mirrors the existing `locked` field exactly:
- `spec/types.go` — `Licenses []string` on `Artifact` and `specFile`.
- `spec/artifact.go` — carried through on load.
- `spec/validate.go` — `ValidateLicenses` (non-empty entries, no duplicates), wired into `ValidateArtifact`.

## Scope / deferred

- **Composition** (union of parent/mixin licenses) is the merge consumer's job, consistent with how `locked`/`mixins` are handled — the spec library only declares + validates.
- **Warn on unrecognized SPDX identifiers** (RFC "SHOULD") is deferred — it needs an embedded SPDX license list and would surface as a warning, not an error.
- **No engine/sandboxes change required** — nothing consumes `licenses` yet.

## Tests (TDD)

- `TestValidateLicenses` — nil / valid / empty-entry / duplicate.
- `TestLicenses_DecodeAndCarry` — round-trips onto `Artifact.Licenses`, emits no warning (it's a real field, not a forward-compat stub like `mixins`).
- `TestLicenses_Absent_NoError`.
- `TestLicenses_InvalidRejectedAtLoad` — rejected via `LoadFromDirectory`.

gofmt clean, `go vet` clean, full module (`spec`, `bindings`, `scripts`, `tck`) builds and tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)