### PR TITLE
feat(kits): migrate all kits to schemaVersion 2 (comment-preserving)

### DIFF
--- a/amp/spec.yaml
+++ b/amp/spec.yaml
@@ -1,35 +1,36 @@
-schemaVersion: "1"
-kind: agent
+schemaVersion: "2"
+kind: sandbox
 name: amp
 displayName: Amp
 description: The frontier coding agent.
-
-agent:
-  image: "docker/sandbox-templates:shell-docker"
-  aiFilename: AGENTS.md
-  entrypoint:
-    run: [amp, --dangerously-allow-all]
-
-network:
-  serviceDomains:
-    ampcode.com: amp
-  serviceAuth:
-    amp:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-  allowedDomains:
-    - "ampcode.com:443"
-    - "*.ampcode.com:443"
-
+sandbox:
+    image: docker/sandbox-templates:shell-docker
+    aiFilename: AGENTS.md
+    entrypoint:
+        run:
+            - amp
+            - --dangerously-allow-all
+caps:
+    network:
+        allow:
+            - ampcode.com:443
+            - '*.ampcode.com:443'
+credentials:
+    - service: amp
+      apiKey:
+        name: ""
+        inject:
+            - domain: ampcode.com
+              header: Authorization
+              format: Bearer %s
 commands:
-  install:
-    - command: "curl -fsSL https://ampcode.com/install.sh | bash"
-      user: "1000"
-      description: Install Amp
+    install:
+        - command: curl -fsSL https://ampcode.com/install.sh | bash
+          user: "1000"
+          description: Install Amp
+agentContext: |
+    ## Sandbox environment
 
-memory: |
-  ## Sandbox environment
-
-  You are running inside a Docker sandbox. The workspace is mounted at
-  its absolute host path. `sudo` is passwordless; use it for package
-  installs.
+    You are running inside a Docker sandbox. The workspace is mounted at
+    its absolute host path. `sudo` is passwordless; use it for package
+    installs.

--- a/claude-model-runner/spec.yaml
+++ b/claude-model-runner/spec.yaml
@@ -1,4 +1,4 @@
-schemaVersion: "1"
+schemaVersion: "2"
 kind: mixin
 name: claude-model-runner
 # Reroutes Claude Code's Anthropic API; only meaningful on the claude base

--- a/claude-ollama/spec.yaml
+++ b/claude-ollama/spec.yaml
@@ -1,101 +1,98 @@
-schemaVersion: "1"
-kind: agent
+schemaVersion: "2"
+kind: sandbox
 name: claude-ollama
 displayName: Claude Code (Ollama)
 description: Claude Code wired to Ollama Anthropic-compatible API, with configurable model.
-
-agent:
-  image: "docker/sandbox-templates:claude-code-docker"
-  aiFilename: CLAUDE.md
-  entrypoint:
-    run: [/home/agent/.local/bin/claude-ollama]
-
+sandbox:
+    image: docker/sandbox-templates:claude-code-docker
+    aiFilename: CLAUDE.md
+    entrypoint:
+        run:
+            - /home/agent/.local/bin/claude-ollama
+caps:
+    network:
+        allow:
+            - localhost:11434
 environment:
-  variables:
-    CLAUDE_OLLAMA_MODEL: "gemma4:e4b-it-q4_K_M"
-
-network:
-  allowedDomains:
-    - "localhost:11434"
-
+    variables:
+        CLAUDE_OLLAMA_MODEL: gemma4:e4b-it-q4_K_M
 commands:
-  # Phase 4 lifts the former `settings: { containerSettings: { claude: true } }`
-  # block into the kit. ~/.claude.json carries only the credential-independent
-  # bypass flags (static init file, native onlyIfMissing idempotency). The
-  # settings.json is seeded in commands.install below. Content SYNCed with the
-  # claude kit.
-  #
-  # This kit declares NO credential service (Ollama is a local model; the
-  # claude-ollama wrapper unsets ANTHROPIC_API_KEY and points Claude Code at
-  # http://host.docker.internal:11434), so the Stage B emitter never sets
-  # SBX_CRED_ANTHROPIC_MODE. The install branch therefore always takes the
-  # unset → "none" path: settings.json is written WITHOUT apiKeyHelper, which
-  # is correct since there is no proxy-managed cloud credential.
-  install:
-    # Seed ~/.claude/settings.json early (install runs synchronously before the
-    # agent launches). This kit declares no credential service, so
-    # SBX_CRED_ANTHROPIC_MODE is never set in the container env and the branch
-    # always falls through to the unset → "none" path: settings.json is written
-    # WITHOUT apiKeyHelper. The test -f guard makes re-runs a no-op and never
-    # clobbers a user-edited file. settings.json content SYNCed with the claude
-    # kit (none path). root-write + chown because contrib base-image ownership
-    # of /home/agent/.claude is not guaranteed agent-owned.
-    - command: |
-        set -e
-        mkdir -p /home/agent/.claude
-        if [ ! -f /home/agent/.claude/settings.json ]; then
-          HELPER=''
-          if [ "${SBX_CRED_ANTHROPIC_MODE:-none}" != none ]; then
-            HELPER='  "apiKeyHelper": "echo proxy-managed",
-        '
-          fi
-          printf '%s' "{
-          \"themeId\": 1,
-          \"alwaysThinkingEnabled\": true,
-        ${HELPER}  \"defaultMode\": \"bypassPermissions\",
-          \"bypassPermissionsModeAccepted\": true
-        }
-        " > /home/agent/.claude/settings.json
-        fi
-        chown -R agent:agent /home/agent/.claude
-      user: "root"
-      description: Seed Claude settings.json (none path; no credential service)
-  initFiles:
-    - path: /home/agent/.claude.json
-      content: |
-        {
-          "bypassPermissionsModeAccepted": true,
-          "hasCompletedOnboarding": true,
-          "projects": {
-              "/": {
-              "hasTrustDialogAccepted": true
+    # Phase 4 lifts the former `settings: { containerSettings: { claude: true } }`
+    # block into the kit. ~/.claude.json carries only the credential-independent
+    # bypass flags (static init file, native onlyIfMissing idempotency). The
+    # settings.json is seeded in commands.install below. Content SYNCed with the
+    # claude kit.
+    #
+    # This kit declares NO credential service (Ollama is a local model; the
+    # claude-ollama wrapper unsets ANTHROPIC_API_KEY and points Claude Code at
+    # http://host.docker.internal:11434), so the Stage B emitter never sets
+    # SBX_CRED_ANTHROPIC_MODE. The install branch therefore always takes the
+    # unset → "none" path: settings.json is written WITHOUT apiKeyHelper, which
+    # is correct since there is no proxy-managed cloud credential.
+    install:
+        # Seed ~/.claude/settings.json early (install runs synchronously before the
+        # agent launches). This kit declares no credential service, so
+        # SBX_CRED_ANTHROPIC_MODE is never set in the container env and the branch
+        # always falls through to the unset → "none" path: settings.json is written
+        # WITHOUT apiKeyHelper. The test -f guard makes re-runs a no-op and never
+        # clobbers a user-edited file. settings.json content SYNCed with the claude
+        # kit (none path). root-write + chown because contrib base-image ownership
+        # of /home/agent/.claude is not guaranteed agent-owned.
+        - command: |
+            set -e
+            mkdir -p /home/agent/.claude
+            if [ ! -f /home/agent/.claude/settings.json ]; then
+              HELPER=''
+              if [ "${SBX_CRED_ANTHROPIC_MODE:-none}" != none ]; then
+                HELPER='  "apiKeyHelper": "echo proxy-managed",
+            '
+              fi
+              printf '%s' "{
+              \"themeId\": 1,
+              \"alwaysThinkingEnabled\": true,
+            ${HELPER}  \"defaultMode\": \"bypassPermissions\",
+              \"bypassPermissionsModeAccepted\": true
             }
-          }
-        }
-      onlyIfMissing: true
-      description: Claude bypass flags (mode-independent)
-    - path: /home/agent/.local/bin/claude-ollama
-      mode: "0755"
-      description: Wrapper script that routes Claude Code to the local Ollama instance
-      content: |
-        #!/usr/bin/env bash
-        set -euo pipefail
+            " > /home/agent/.claude/settings.json
+            fi
+            chown -R agent:agent /home/agent/.claude
+          user: root
+          description: Seed Claude settings.json (none path; no credential service)
+    initFiles:
+        - path: /home/agent/.claude.json
+          content: |
+            {
+              "bypassPermissionsModeAccepted": true,
+              "hasCompletedOnboarding": true,
+              "projects": {
+                  "/": {
+                  "hasTrustDialogAccepted": true
+                }
+              }
+            }
+          onlyIfMissing: true
+          description: Claude bypass flags (mode-independent)
+        - path: /home/agent/.local/bin/claude-ollama
+          content: |
+            #!/usr/bin/env bash
+            set -euo pipefail
 
-        export ANTHROPIC_AUTH_TOKEN="ollama"
-        unset ANTHROPIC_API_KEY
-        export ANTHROPIC_BASE_URL="http://host.docker.internal:11434"
+            export ANTHROPIC_AUTH_TOKEN="ollama"
+            unset ANTHROPIC_API_KEY
+            export ANTHROPIC_BASE_URL="http://host.docker.internal:11434"
 
-        export ANTHROPIC_DEFAULT_OPUS_MODEL="$CLAUDE_OLLAMA_MODEL"
-        export ANTHROPIC_DEFAULT_SONNET_MODEL="$CLAUDE_OLLAMA_MODEL"
-        export ANTHROPIC_DEFAULT_HAIKU_MODEL="$CLAUDE_OLLAMA_MODEL"
-        export CLAUDE_CODE_SUBAGENT_MODEL="$CLAUDE_OLLAMA_MODEL"
+            export ANTHROPIC_DEFAULT_OPUS_MODEL="$CLAUDE_OLLAMA_MODEL"
+            export ANTHROPIC_DEFAULT_SONNET_MODEL="$CLAUDE_OLLAMA_MODEL"
+            export ANTHROPIC_DEFAULT_HAIKU_MODEL="$CLAUDE_OLLAMA_MODEL"
+            export CLAUDE_CODE_SUBAGENT_MODEL="$CLAUDE_OLLAMA_MODEL"
 
-        exec claude "$@"
+            exec claude "$@"
+          mode: "0755"
+          description: Wrapper script that routes Claude Code to the local Ollama instance
+agentContext: |
+    ## Sandbox environment
 
-memory: |
-  ## Sandbox environment
-
-  You are running inside a Docker sandbox. All API calls are routed to a local
-  Ollama instance on the host (http://host.docker.internal:11434) — Anthropic's
-  API is not reachable. The workspace is mounted at its absolute host path.
-  `sudo` is passwordless; use it for package installs.
+    You are running inside a Docker sandbox. All API calls are routed to a local
+    Ollama instance on the host (http://host.docker.internal:11434) — Anthropic's
+    API is not reachable. The workspace is mounted at its absolute host path.
+    `sudo` is passwordless; use it for package installs.

--- a/code-server/spec.yaml
+++ b/code-server/spec.yaml
@@ -1,4 +1,4 @@
-schemaVersion: "1"
+schemaVersion: "2"
 kind: mixin
 name: code-server
 # Layered onto the claude base agent (the bundled VS Code extension is Claude
@@ -8,46 +8,48 @@ requires:
   agent: claude
 displayName: code-server (web VS Code) with Claude Code
 description: Runs code-server on port 8080, opened on the sandbox workspace, with the Claude Code VS Code extension preinstalled. Pair with the built-in claude agent so the extension inherits the sandbox's Anthropic credentials.
-
-network:
-  publishedPorts:
+publishedPorts:
     - container: 8080
       protocol: tcp
       name: code-server
-  allowedDomains:
-    # `https://code-server.dev/install.sh` is a Cloudflare 302 redirect to
-    # `https://raw.githubusercontent.com/cdr/code-server/main/install.sh` —
-    # the install hook's `curl -fsSL https://code-server.dev/install.sh`
-    # transparently follows the redirect, so the kit needs both hosts
-    # allowed for the install script to even download.
-    - code-server.dev
-    - raw.githubusercontent.com
-    - github.com
-    # The code-server install.sh resolves the latest release via a
-    # `github.com/.../releases/latest` redirect, then follows the
-    # `github.com` release URL to the asset host. GitHub recently
-    # rotated asset downloads from `objects.githubusercontent.com` to
-    # `release-assets.githubusercontent.com`; both must be allowed.
-    - api.github.com
-    - objects.githubusercontent.com
-    - release-assets.githubusercontent.com
-    - open-vsx.org
-    - openvsx.eclipsecontent.org
-
+caps:
+    network:
+        allow:
+            # `https://code-server.dev/install.sh` is a Cloudflare 302 redirect to
+            # `https://raw.githubusercontent.com/cdr/code-server/main/install.sh` —
+            # the install hook's `curl -fsSL https://code-server.dev/install.sh`
+            # transparently follows the redirect, so the kit needs both hosts
+            # allowed for the install script to even download.
+            - code-server.dev
+            - raw.githubusercontent.com
+            - github.com
+            # The code-server install.sh resolves the latest release via a
+            # `github.com/.../releases/latest` redirect, then follows the
+            # `github.com` release URL to the asset host. GitHub recently
+            # rotated asset downloads from `objects.githubusercontent.com` to
+            # `release-assets.githubusercontent.com`; both must be allowed.
+            - api.github.com
+            - objects.githubusercontent.com
+            - release-assets.githubusercontent.com
+            - open-vsx.org
+            - openvsx.eclipsecontent.org
 commands:
-  install:
-    - command: "curl -fsSL https://code-server.dev/install.sh | sh"
-      description: Install code-server via the upstream install script
-    - command: "code-server --install-extension anthropic.claude-code"
-      user: "1000"
-      description: Pre-install the Claude Code extension from open-vsx so you have a native chat panel that talks to the claude agent's credentials
-  initFiles:
-    - path: /home/agent/.local/bin/start-code-server.sh
-      content: |
-        exec code-server --bind-addr 0.0.0.0:8080 --auth none "${WORKDIR}"
-      mode: "0755"
-      description: Startup wrapper with the workspace path baked in at sandbox start
-  startup:
-    - command: ["sh", "-c", "nohup /home/agent/.local/bin/start-code-server.sh > /tmp/code-server.log 2>&1 &"]
-      user: "1000"
-      description: Start code-server in the background, opened on the primary workspace
+    install:
+        - command: curl -fsSL https://code-server.dev/install.sh | sh
+          description: Install code-server via the upstream install script
+        - command: code-server --install-extension anthropic.claude-code
+          user: "1000"
+          description: Pre-install the Claude Code extension from open-vsx so you have a native chat panel that talks to the claude agent's credentials
+    startup:
+        - command:
+            - sh
+            - -c
+            - nohup /home/agent/.local/bin/start-code-server.sh > /tmp/code-server.log 2>&1 &
+          user: "1000"
+          description: Start code-server in the background, opened on the primary workspace
+    initFiles:
+        - path: /home/agent/.local/bin/start-code-server.sh
+          content: |
+            exec code-server --bind-addr 0.0.0.0:8080 --auth none "${WORKDIR}"
+          mode: "0755"
+          description: Startup wrapper with the workspace path baked in at sandbox start

--- a/codex-app-server/spec.yaml
+++ b/codex-app-server/spec.yaml
@@ -1,4 +1,4 @@
-schemaVersion: "1"
+schemaVersion: "2"
 kind: mixin
 name: codex-app-server
 # sshd + codex bridge; only meaningful on the codex base agent. Declares
@@ -8,111 +8,113 @@ requires:
   agent: codex
 displayName: Codex app-server (via SSH)
 description: Runs sshd in the sandbox and pre-populates `authorized_keys` from the host's forwarded SSH agent, so the Codex Mac GUI can add the sandbox as an SSH Connection and drive `codex app-server` remotely. The kit declares port 22 in `network.publishedPorts`, so the runtime exposes sshd on an ephemeral host port at sandbox start.
-
-network:
-  publishedPorts:
+publishedPorts:
     - container: 22
       protocol: tcp
       name: sshd
-  allowedDomains:
-    # `apt-get update` (run by commands.install[0]) refreshes metadata for
-    # every configured apt source. The codex-docker base template
-    # pre-configures Docker's apt repo, so `download.docker.com` must be
-    # allowed even though this kit only installs `openssh-server` from
-    # Ubuntu's main archive — apt-get exits 100 on the first source
-    # metadata fetch that returns non-2xx. Ubuntu hosts amd64 packages on
-    # archive/security and arm64 packages on ports.ubuntu.com, so all
-    # three Ubuntu hosts are listed for cross-arch coverage.
-    - archive.ubuntu.com        # Ubuntu archive (amd64 main)
-    - security.ubuntu.com       # Ubuntu security updates (amd64)
-    - ports.ubuntu.com          # Ubuntu archive/security (arm64)
-    - download.docker.com       # Docker's apt repo, pre-added by codex-docker
-
+caps:
+    network:
+        # `apt-get update` (run by commands.install[0]) refreshes metadata for
+        # every configured apt source. The codex-docker base template
+        # pre-configures Docker's apt repo, so `download.docker.com` must be
+        # allowed even though this kit only installs `openssh-server` from
+        # Ubuntu's main archive — apt-get exits 100 on the first source
+        # metadata fetch that returns non-2xx. Ubuntu hosts amd64 packages on
+        # archive/security and arm64 packages on ports.ubuntu.com, so all
+        # three Ubuntu hosts are listed for cross-arch coverage.
+        allow:
+            - archive.ubuntu.com        # Ubuntu archive (amd64 main)
+            - security.ubuntu.com       # Ubuntu security updates (amd64)
+            - ports.ubuntu.com          # Ubuntu archive/security (arm64)
+            - download.docker.com       # Docker's apt repo, pre-added by codex-docker
 commands:
-  initFiles:
-    - path: /home/agent/.local/bin/refresh-authorized-keys
-      mode: "0755"
-      description: Refresh /home/agent/.ssh/authorized_keys from the forwarded SSH agent. Invoked by the startup hook; safe to invoke manually too.
-      content: |
-        #!/bin/sh
-        # sbx runs startup hooks with a clean env (no SSH_AUTH_SOCK), so
-        # naïve `ssh-add -L` fails on every wake. Snapshot SSH_AUTH_SOCK
-        # from PID 1's environ — the socket file itself is available at
-        # startup time, just not the env var pointing at it.
-        if [ -z "$SSH_AUTH_SOCK" ]; then
-            SSH_AUTH_SOCK=$(tr '\0' '\n' < /proc/1/environ | grep -m1 '^SSH_AUTH_SOCK=' | cut -d= -f2-)
-            export SSH_AUTH_SOCK
-        fi
-        if [ ! -S "$SSH_AUTH_SOCK" ]; then
-            echo "[sbx-codex] no agent socket; keeping existing authorized_keys" >&2
-            exit 0
-        fi
-        keys=$(ssh-add -L 2>&1)
-        if [ $? -ne 0 ] || [ -z "$keys" ]; then
-            echo "[sbx-codex] ssh-add returned no keys; keeping existing authorized_keys" >&2
-            exit 0
-        fi
-        printf '%s\n' "$keys" > /home/agent/.ssh/authorized_keys
-        chmod 600 /home/agent/.ssh/authorized_keys
-  install:
-    - command: apt-get update -qq && apt-get install -y -qq openssh-server
-      user: "0"
-      description: Install openssh-server
-    - command: ssh-keygen -A
-      user: "0"
-      description: Generate sshd host keys
-    - command: install -d -m 0700 -o agent -g agent /home/agent/.ssh
-      user: "0"
-      description: Ensure /home/agent/.ssh exists with correct ownership
-    - command: |
-        cat > /usr/local/bin/codex <<'EOF'
-        #!/bin/bash
-        # sshd starts processes with a clean env, so codex spawned via SSH
-        # (which is how the Codex Mac GUI's Connections flow drives it)
-        # doesn't see HTTPS_PROXY, PROXY_CA_CERT_B64, the chatgpt-proxy
-        # bearer-token sentinel mechanism, SSH_AUTH_SOCK (which git-ssh-sign
-        # needs at signing time), etc. Snapshot the relevant vars from
-        # PID 1's environment and re-export them before handing off to
-        # the real codex binary.
-        while IFS= read -rd '' kv; do
-          case "$kv" in
-            HTTP_PROXY=*|HTTPS_PROXY=*|NO_PROXY=*|\
-            http_proxy=*|https_proxy=*|no_proxy=*|\
-            PROXY_CA_CERT_B64=*|NODE_USE_ENV_PROXY=*|NODE_EXTRA_CA_CERTS=*|\
-            SSL_CERT_FILE=*|REQUESTS_CA_BUNDLE=*|JAVA_TOOL_OPTIONS=*|\
-            CODEX_HOME=*|GH_TOKEN=*|SSH_AUTH_SOCK=*)
-              export "$kv"
-              ;;
-          esac
-        done < /proc/1/environ
-        exec /usr/local/share/npm-global/bin/codex "$@"
-        EOF
-        chmod 0755 /usr/local/bin/codex
-      user: "0"
-      description: Shadow `codex` on PATH with a bridge that imports PID 1's proxy env before exec'ing the real binary
-  startup:
-    - command: ["/home/agent/.local/bin/refresh-authorized-keys"]
-      user: "1000"
-      description: Refresh authorized_keys from the forwarded SSH agent
-    - command: ["sh", "-c", "pgrep -x sshd >/dev/null || { mkdir -p /var/run/sshd && /usr/sbin/sshd > /tmp/sshd.log 2>&1; }"]
-      user: "0"
-      description: Start sshd if not already running (recreates /var/run/sshd which is tmpfs-cleared on container restart)
+    install:
+        - command: apt-get update -qq && apt-get install -y -qq openssh-server
+          user: "0"
+          description: Install openssh-server
+        - command: ssh-keygen -A
+          user: "0"
+          description: Generate sshd host keys
+        - command: install -d -m 0700 -o agent -g agent /home/agent/.ssh
+          user: "0"
+          description: Ensure /home/agent/.ssh exists with correct ownership
+        - command: |
+            cat > /usr/local/bin/codex <<'EOF'
+            #!/bin/bash
+            # sshd starts processes with a clean env, so codex spawned via SSH
+            # (which is how the Codex Mac GUI's Connections flow drives it)
+            # doesn't see HTTPS_PROXY, PROXY_CA_CERT_B64, the chatgpt-proxy
+            # bearer-token sentinel mechanism, SSH_AUTH_SOCK (which git-ssh-sign
+            # needs at signing time), etc. Snapshot the relevant vars from
+            # PID 1's environment and re-export them before handing off to
+            # the real codex binary.
+            while IFS= read -rd '' kv; do
+              case "$kv" in
+                HTTP_PROXY=*|HTTPS_PROXY=*|NO_PROXY=*|\
+                http_proxy=*|https_proxy=*|no_proxy=*|\
+                PROXY_CA_CERT_B64=*|NODE_USE_ENV_PROXY=*|NODE_EXTRA_CA_CERTS=*|\
+                SSL_CERT_FILE=*|REQUESTS_CA_BUNDLE=*|JAVA_TOOL_OPTIONS=*|\
+                CODEX_HOME=*|GH_TOKEN=*|SSH_AUTH_SOCK=*)
+                  export "$kv"
+                  ;;
+              esac
+            done < /proc/1/environ
+            exec /usr/local/share/npm-global/bin/codex "$@"
+            EOF
+            chmod 0755 /usr/local/bin/codex
+          user: "0"
+          description: Shadow `codex` on PATH with a bridge that imports PID 1's proxy env before exec'ing the real binary
+    startup:
+        - command:
+            - /home/agent/.local/bin/refresh-authorized-keys
+          user: "1000"
+          description: Refresh authorized_keys from the forwarded SSH agent
+        - command:
+            - sh
+            - -c
+            - pgrep -x sshd >/dev/null || { mkdir -p /var/run/sshd && /usr/sbin/sshd > /tmp/sshd.log 2>&1; }
+          user: "0"
+          description: Start sshd if not already running (recreates /var/run/sshd which is tmpfs-cleared on container restart)
+    initFiles:
+        - path: /home/agent/.local/bin/refresh-authorized-keys
+          content: |
+            #!/bin/sh
+            # sbx runs startup hooks with a clean env (no SSH_AUTH_SOCK), so
+            # naïve `ssh-add -L` fails on every wake. Snapshot SSH_AUTH_SOCK
+            # from PID 1's environ — the socket file itself is available at
+            # startup time, just not the env var pointing at it.
+            if [ -z "$SSH_AUTH_SOCK" ]; then
+                SSH_AUTH_SOCK=$(tr '\0' '\n' < /proc/1/environ | grep -m1 '^SSH_AUTH_SOCK=' | cut -d= -f2-)
+                export SSH_AUTH_SOCK
+            fi
+            if [ ! -S "$SSH_AUTH_SOCK" ]; then
+                echo "[sbx-codex] no agent socket; keeping existing authorized_keys" >&2
+                exit 0
+            fi
+            keys=$(ssh-add -L 2>&1)
+            if [ $? -ne 0 ] || [ -z "$keys" ]; then
+                echo "[sbx-codex] ssh-add returned no keys; keeping existing authorized_keys" >&2
+                exit 0
+            fi
+            printf '%s\n' "$keys" > /home/agent/.ssh/authorized_keys
+            chmod 600 /home/agent/.ssh/authorized_keys
+          mode: "0755"
+          description: Refresh /home/agent/.ssh/authorized_keys from the forwarded SSH agent. Invoked by the startup hook; safe to invoke manually too.
+agentContext: |
+    ## Codex app-server over SSH
 
-memory: |
-  ## Codex app-server over SSH
+    sshd is running inside the sandbox on port 22, and your host's SSH
+    identities (from the forwarded agent socket) are pre-populated in
+    `/home/agent/.ssh/authorized_keys`. The kit declares port 22 in its
+    `publishedPorts`, so the runtime exposes sshd on an ephemeral host
+    port automatically. Discover the assigned port with
+    `sbx ports <sandbox>`, then add an SSH connection in the Codex Mac
+    app:
 
-  sshd is running inside the sandbox on port 22, and your host's SSH
-  identities (from the forwarded agent socket) are pre-populated in
-  `/home/agent/.ssh/authorized_keys`. The kit declares port 22 in its
-  `publishedPorts`, so the runtime exposes sshd on an ephemeral host
-  port automatically. Discover the assigned port with
-  `sbx ports <sandbox>`, then add an SSH connection in the Codex Mac
-  app:
+        Host: localhost
+        Port: <host-port from sbx ports>
+        User: agent
 
-      Host: localhost
-      Port: <host-port from sbx ports>
-      User: agent
-
-  The Codex GUI will SSH in and run `codex app-server` over stdio.
-  Model traffic continues to route through the codex agent's OpenAI
-  credential proxy, so no API key lives in the sandbox.
+    The Codex GUI will SSH in and run `codex app-server` over stdio.
+    Model traffic continues to route through the codex agent's OpenAI
+    credential proxy, so no API key lives in the sandbox.

--- a/crush/spec.yaml
+++ b/crush/spec.yaml
@@ -1,194 +1,204 @@
-schemaVersion: "1"
-kind: agent
+schemaVersion: "2"
+kind: sandbox
 name: crush
 displayName: Crush
 description: Multi-provider AI coding agent from Charm, with proxy-mediated auth for 15 model providers.
-
-agent:
-  image: "docker/sandbox-templates:shell-docker"
-  aiFilename: AGENTS.md
-  entrypoint:
-    run: [crush]
-    args: ["--yolo"]
-
-environment:
-  proxyManaged:
-    - ANTHROPIC_API_KEY
-    - AWS_ACCESS_KEY_ID
-    - AZURE_OPENAI_API_KEY
-    - CEREBRAS_API_KEY
-    - GEMINI_API_KEY
-    - GOOGLE_GENERATIVE_AI_API_KEY
-    - GROQ_API_KEY
-    - HF_TOKEN
-    - IONET_API_KEY
-    - MINIMAX_API_KEY
-    - MISTRAL_API_KEY
-    - OPENAI_API_KEY
-    - OPENROUTER_API_KEY
-    - SYNTHETIC_API_KEY
-    - VERCEL_API_KEY
-    - ZAI_API_KEY
-
+sandbox:
+    image: docker/sandbox-templates:shell-docker
+    aiFilename: AGENTS.md
+    entrypoint:
+        run:
+            - crush
+        args:
+            - --yolo
+caps:
+    network:
+        allow:
+            - repo.charm.sh
+            # `apt-get update` (run by the install hooks) refreshes metadata for
+            # every configured apt source — failing on any one of them returns
+            # exit 100 even if the kit's package would come from a different
+            # repo. The shell-docker template ships with three sources, so all
+            # three must be allowed for the kit's install to succeed under
+            # `deny-all`. Ubuntu hosts amd64 packages on archive/security and
+            # arm64 packages on ports.ubuntu.com, so all three Ubuntu hosts are
+            # listed to keep the kit working cross-arch.
+            - archive.ubuntu.com        # Ubuntu archive (amd64 main)
+            - security.ubuntu.com       # Ubuntu security updates (amd64)
+            - ports.ubuntu.com          # Ubuntu archive/security (arm64)
+            - download.docker.com       # Docker's apt repo, pre-added by shell-docker
+            # Charm distributes the actual `crush` .deb via Gemfury's S3-accelerated
+            # bucket — `repo.charm.sh` only serves the apt index; package payloads
+            # are signed-URL redirects to this host.
+            - gemfury.s3-accelerate.dualstack.amazonaws.com
+            - api.anthropic.com
+            - api.openai.com
+            - '*.openai.azure.com'
+            - generativelanguage.googleapis.com
+            - api.mistral.ai
+            - api.groq.com
+            - groq.com
+            - api.cerebras.ai
+            - openrouter.ai
+            - api-inference.huggingface.co
+            - api.io.net
+            - api.minimax.chat
+            - api.synthetic.com
+            - api.zai.com
+            - v0.dev
+            - bedrock-runtime.*.amazonaws.com
+            - bedrock.*.amazonaws.com
 credentials:
-  sources:
-    anthropic:
-      env: [ANTHROPIC_API_KEY]
-    aws:
-      env: [AWS_ACCESS_KEY_ID]
-    azure-openai:
-      env: [AZURE_OPENAI_API_KEY]
-    cerebras:
-      env: [CEREBRAS_API_KEY]
-    google:
-      env: [GEMINI_API_KEY, GOOGLE_GENERATIVE_AI_API_KEY]
-    groq:
-      env: [GROQ_API_KEY]
-    huggingface:
-      env: [HF_TOKEN]
-    ionet:
-      env: [IONET_API_KEY]
-    minimax:
-      env: [MINIMAX_API_KEY]
-    mistral:
-      env: [MISTRAL_API_KEY]
-    openai:
-      env: [OPENAI_API_KEY]
-    openrouter:
-      env: [OPENROUTER_API_KEY]
-    synthetic:
-      env: [SYNTHETIC_API_KEY]
-    vercel:
-      env: [VERCEL_API_KEY]
-    zai:
-      env: [ZAI_API_KEY]
-
-network:
-  serviceDomains:
-    api.anthropic.com: anthropic
-    api.openai.com: openai
-    "*.openai.azure.com": azure-openai
-    generativelanguage.googleapis.com: google
-    api.mistral.ai: mistral
-    api.groq.com: groq
-    groq.com: groq
-    api.cerebras.ai: cerebras
-    openrouter.ai: openrouter
-    api-inference.huggingface.co: huggingface
-    api.io.net: ionet
-    api.minimax.chat: minimax
-    api.synthetic.com: synthetic
-    api.zai.com: zai
-    v0.dev: vercel
-    "bedrock-runtime.*.amazonaws.com": aws
-    "bedrock.*.amazonaws.com": aws
-  serviceAuth:
-    anthropic:
-      headerName: x-api-key
-      valueFormat: "%s"
-    openai:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-    azure-openai:
-      headerName: api-key
-      valueFormat: "%s"
-    google:
-      headerName: x-goog-api-key
-      valueFormat: "%s"
-    mistral:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-    groq:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-    cerebras:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-    openrouter:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-    huggingface:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-    ionet:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-    minimax:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-    synthetic:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-    vercel:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-    zai:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-    aws:
-      headerName: Authorization
-      valueFormat: "AWS4-HMAC-SHA256 Credential=%s/"
-  allowedDomains:
-    - repo.charm.sh
-    # `apt-get update` (run by the install hooks) refreshes metadata for
-    # every configured apt source — failing on any one of them returns
-    # exit 100 even if the kit's package would come from a different
-    # repo. The shell-docker template ships with three sources, so all
-    # three must be allowed for the kit's install to succeed under
-    # `deny-all`. Ubuntu hosts amd64 packages on archive/security and
-    # arm64 packages on ports.ubuntu.com, so all three Ubuntu hosts are
-    # listed to keep the kit working cross-arch.
-    - archive.ubuntu.com        # Ubuntu archive (amd64 main)
-    - security.ubuntu.com       # Ubuntu security updates (amd64)
-    - ports.ubuntu.com          # Ubuntu archive/security (arm64)
-    - download.docker.com       # Docker's apt repo, pre-added by shell-docker
-    # Charm distributes the actual `crush` .deb via Gemfury's S3-accelerated
-    # bucket — `repo.charm.sh` only serves the apt index; package payloads
-    # are signed-URL redirects to this host.
-    - gemfury.s3-accelerate.dualstack.amazonaws.com
-    - api.anthropic.com
-    - api.openai.com
-    - "*.openai.azure.com"
-    - generativelanguage.googleapis.com
-    - api.mistral.ai
-    - api.groq.com
-    - groq.com
-    - api.cerebras.ai
-    - openrouter.ai
-    - api-inference.huggingface.co
-    - api.io.net
-    - api.minimax.chat
-    - api.synthetic.com
-    - api.zai.com
-    - v0.dev
-    - "bedrock-runtime.*.amazonaws.com"
-    - "bedrock.*.amazonaws.com"
-
+    - service: anthropic
+      apiKey:
+        name: ANTHROPIC_API_KEY
+        proxyManaged: true
+        inject:
+            - domain: api.anthropic.com
+              header: x-api-key
+              format: '%s'
+    - service: aws
+      apiKey:
+        name: AWS_ACCESS_KEY_ID
+        proxyManaged: true
+        inject:
+            - domain: bedrock-runtime.*.amazonaws.com
+              header: Authorization
+              format: AWS4-HMAC-SHA256 Credential=%s/
+            - domain: bedrock.*.amazonaws.com
+              header: Authorization
+              format: AWS4-HMAC-SHA256 Credential=%s/
+    - service: azure-openai
+      apiKey:
+        name: AZURE_OPENAI_API_KEY
+        proxyManaged: true
+        inject:
+            - domain: '*.openai.azure.com'
+              header: api-key
+              format: '%s'
+    - service: cerebras
+      apiKey:
+        name: CEREBRAS_API_KEY
+        proxyManaged: true
+        inject:
+            - domain: api.cerebras.ai
+              header: Authorization
+              format: Bearer %s
+    - service: google
+      apiKey:
+        name: GEMINI_API_KEY
+        proxyManaged: true
+        inject:
+            - domain: generativelanguage.googleapis.com
+              header: x-goog-api-key
+              format: '%s'
+    - service: groq
+      apiKey:
+        name: GROQ_API_KEY
+        proxyManaged: true
+        inject:
+            - domain: api.groq.com
+              header: Authorization
+              format: Bearer %s
+            - domain: groq.com
+              header: Authorization
+              format: Bearer %s
+    - service: huggingface
+      apiKey:
+        name: HF_TOKEN
+        proxyManaged: true
+        inject:
+            - domain: api-inference.huggingface.co
+              header: Authorization
+              format: Bearer %s
+    - service: ionet
+      apiKey:
+        name: IONET_API_KEY
+        proxyManaged: true
+        inject:
+            - domain: api.io.net
+              header: Authorization
+              format: Bearer %s
+    - service: minimax
+      apiKey:
+        name: MINIMAX_API_KEY
+        proxyManaged: true
+        inject:
+            - domain: api.minimax.chat
+              header: Authorization
+              format: Bearer %s
+    - service: mistral
+      apiKey:
+        name: MISTRAL_API_KEY
+        proxyManaged: true
+        inject:
+            - domain: api.mistral.ai
+              header: Authorization
+              format: Bearer %s
+    - service: openai
+      apiKey:
+        name: OPENAI_API_KEY
+        proxyManaged: true
+        inject:
+            - domain: api.openai.com
+              header: Authorization
+              format: Bearer %s
+    - service: openrouter
+      apiKey:
+        name: OPENROUTER_API_KEY
+        proxyManaged: true
+        inject:
+            - domain: openrouter.ai
+              header: Authorization
+              format: Bearer %s
+    - service: synthetic
+      apiKey:
+        name: SYNTHETIC_API_KEY
+        proxyManaged: true
+        inject:
+            - domain: api.synthetic.com
+              header: Authorization
+              format: Bearer %s
+    - service: vercel
+      apiKey:
+        name: VERCEL_API_KEY
+        proxyManaged: true
+        inject:
+            - domain: v0.dev
+              header: Authorization
+              format: Bearer %s
+    - service: zai
+      apiKey:
+        name: ZAI_API_KEY
+        proxyManaged: true
+        inject:
+            - domain: api.zai.com
+              header: Authorization
+              format: Bearer %s
 commands:
-  install:
-    - command: |
-        set -euo pipefail
-        mkdir -p /etc/apt/keyrings
-        curl -fsSL https://repo.charm.sh/apt/gpg.key | gpg --dearmor -o /etc/apt/keyrings/charm.gpg
-      user: "0"
-      description: Add Charm GPG key
-    - command: |
-        echo 'deb [signed-by=/etc/apt/keyrings/charm.gpg] https://repo.charm.sh/apt/ * *' \
-          > /etc/apt/sources.list.d/charm.list
-      user: "0"
-      description: Add Charm apt repository
-    - command: apt-get update -qq && apt-get install -y -qq crush
-      user: "0"
-      description: Install Crush from Charm apt repository
+    install:
+        - command: |
+            set -euo pipefail
+            mkdir -p /etc/apt/keyrings
+            curl -fsSL https://repo.charm.sh/apt/gpg.key | gpg --dearmor -o /etc/apt/keyrings/charm.gpg
+          user: "0"
+          description: Add Charm GPG key
+        - command: |
+            echo 'deb [signed-by=/etc/apt/keyrings/charm.gpg] https://repo.charm.sh/apt/ * *' \
+              > /etc/apt/sources.list.d/charm.list
+          user: "0"
+          description: Add Charm apt repository
+        - command: apt-get update -qq && apt-get install -y -qq crush
+          user: "0"
+          description: Install Crush from Charm apt repository
+agentContext: |
+    ## Crush
 
-memory: |
-  ## Crush
+    Crush is a multi-provider AI coding agent from Charm. It is installed
+    as `crush` on `PATH` and started with `--yolo` so it skips interactive
+    permission prompts (the sandbox itself is the safety boundary).
 
-  Crush is a multi-provider AI coding agent from Charm. It is installed
-  as `crush` on `PATH` and started with `--yolo` so it skips interactive
-  permission prompts (the sandbox itself is the safety boundary).
-
-  Set any of the provider API keys on your host (e.g. `ANTHROPIC_API_KEY`,
-  `OPENAI_API_KEY`, `GROQ_API_KEY`) and the sandbox proxy will inject them
-  on outbound requests to the matching provider. See
-  <https://github.com/charmbracelet/crush> for usage.
+    Set any of the provider API keys on your host (e.g. `ANTHROPIC_API_KEY`,
+    `OPENAI_API_KEY`, `GROQ_API_KEY`) and the sandbox proxy will inject them
+    on outbound requests to the matching provider. See
+    <https://github.com/charmbracelet/crush> for usage.

--- a/git-ssh-sign/spec.yaml
+++ b/git-ssh-sign/spec.yaml
@@ -1,56 +1,53 @@
-schemaVersion: "1"
+schemaVersion: "2"
 kind: mixin
 name: git-ssh-sign
 displayName: Git SSH Commit Signing
 description: Configures git to sign commits using the SSH key forwarded from the host's SSH agent.
-
 commands:
-  initFiles:
-    - path: /home/agent/.config/git/ssh-signing-key-command
-      mode: "0755"
-      description: Resolve the forwarded SSH agent key for Git SSH signing
-      content: |
-        #!/bin/sh
-        set -e
+    install:
+        - command: |
+            git config --system gpg.format ssh
+            git config --system --unset-all user.signingKey || true
+            git config --system commit.gpgSign true
+            git config --system tag.gpgSign true
+            git config --system gpg.ssh.defaultKeyCommand /home/agent/.config/git/ssh-signing-key-command
+            git config --system gpg.ssh.allowedSignersFile /home/agent/.config/git/allowed_signers
+            if [ "$(git config --system --get core.hooksPath || true)" = "/home/agent/.config/git/hooks" ]; then
+                git config --system --unset-all core.hooksPath
+            fi
+          user: "0"
+          description: Configure SSH commit signing with a dynamic key command
+    initFiles:
+        - path: /home/agent/.config/git/ssh-signing-key-command
+          content: |
+            #!/bin/sh
+            set -e
 
-        if [ -z "$SSH_AUTH_SOCK" ]; then
-            echo "[git-ssh-sign] no SSH agent - cannot sign commits" >&2
-            exit 1
-        fi
+            if [ -z "$SSH_AUTH_SOCK" ]; then
+                echo "[git-ssh-sign] no SSH agent - cannot sign commits" >&2
+                exit 1
+            fi
 
-        key=$(ssh-add -L 2>/dev/null | head -n 1)
-        if [ -z "$key" ]; then
-            echo "[git-ssh-sign] no keys in SSH agent - cannot sign commits" >&2
-            exit 1
-        fi
+            key=$(ssh-add -L 2>/dev/null | head -n 1)
+            if [ -z "$key" ]; then
+                echo "[git-ssh-sign] no keys in SSH agent - cannot sign commits" >&2
+                exit 1
+            fi
 
-        config_dir="$GIT_SSH_SIGN_CONFIG_DIR"
-        if [ -z "$config_dir" ]; then
-            config_dir="/home/agent/.config/git"
-        fi
-        mkdir -p "$config_dir"
+            config_dir="$GIT_SSH_SIGN_CONFIG_DIR"
+            if [ -z "$config_dir" ]; then
+                config_dir="/home/agent/.config/git"
+            fi
+            mkdir -p "$config_dir"
 
-        email=$(git config user.email 2>/dev/null || printf '%s' "agent@sandbox.local")
-        printf '%s %s\n' "$email" "$key" > "$config_dir/allowed_signers"
-        printf 'key::%s\n' "$key"
+            email=$(git config user.email 2>/dev/null || printf '%s' "agent@sandbox.local")
+            printf '%s %s\n' "$email" "$key" > "$config_dir/allowed_signers"
+            printf 'key::%s\n' "$key"
+          mode: "0755"
+          description: Resolve the forwarded SSH agent key for Git SSH signing
+agentContext: |
+    ## Git commit signing
 
-  install:
-    - command: |
-        git config --system gpg.format ssh
-        git config --system --unset-all user.signingKey || true
-        git config --system commit.gpgSign true
-        git config --system tag.gpgSign true
-        git config --system gpg.ssh.defaultKeyCommand /home/agent/.config/git/ssh-signing-key-command
-        git config --system gpg.ssh.allowedSignersFile /home/agent/.config/git/allowed_signers
-        if [ "$(git config --system --get core.hooksPath || true)" = "/home/agent/.config/git/hooks" ]; then
-            git config --system --unset-all core.hooksPath
-        fi
-      user: "0"
-      description: Configure SSH commit signing with a dynamic key command
-
-memory: |
-  ## Git commit signing
-
-  This sandbox is configured to sign git commits with your host's SSH key.
-  Commits and tags are signed automatically. Use `git log --show-signature`
-  to verify signatures on existing commits.
+    This sandbox is configured to sign git commits with your host's SSH key.
+    Commits and tags are signed automatically. Use `git log --show-signature`
+    to verify signatures on existing commits.

--- a/github-ssh/spec.yaml
+++ b/github-ssh/spec.yaml
@@ -1,32 +1,29 @@
-schemaVersion: "1"
+schemaVersion: "2"
 kind: mixin
 name: github-ssh
 displayName: GitHub SSH
 description: Pre-populates GitHub host keys so SSH operations work without interactive host verification prompts.
-
-network:
-  allowedDomains:
-    - github.com
-    - api.github.com
-
+caps:
+    network:
+        allow:
+            - github.com
+            - api.github.com
 commands:
-  install:
-    - command: |
-        mkdir -p /home/agent/.ssh
-        chmod 700 /home/agent/.ssh
-        chown agent:agent /home/agent/.ssh
-        curl -s https://api.github.com/meta \
-          | jq -r '.ssh_keys[] | "github.com " + .' \
-          >> /home/agent/.ssh/known_hosts
-        chmod 644 /home/agent/.ssh/known_hosts
-        chown agent:agent /home/agent/.ssh/known_hosts
-      user: "0"
-      description: Fetch and install GitHub host keys from api.github.com/meta
+    install:
+        - command: |
+            mkdir -p /home/agent/.ssh
+            chmod 700 /home/agent/.ssh
+            chown agent:agent /home/agent/.ssh
+            curl -s https://api.github.com/meta \
+              | jq -r '.ssh_keys[] | "github.com " + .' \
+              >> /home/agent/.ssh/known_hosts
+            chmod 644 /home/agent/.ssh/known_hosts
+            chown agent:agent /home/agent/.ssh/known_hosts
+          user: "0"
+          description: Fetch and install GitHub host keys from api.github.com/meta
+agentContext: |
+    ## GitHub SSH authentication
 
-memory: |
-  ## GitHub SSH authentication
-
-  GitHub's host keys are pre-populated in `~/.ssh/known_hosts`, so SSH
-  operations to GitHub (clone, push, pull) work without interactive host
-  verification prompts.
-
+    GitHub's host keys are pre-populated in `~/.ssh/known_hosts`, so SSH
+    operations to GitHub (clone, push, pull) work without interactive host
+    verification prompts.

--- a/hermes-agent/spec.yaml
+++ b/hermes-agent/spec.yaml
@@ -1,73 +1,66 @@
-schemaVersion: "1"
-kind: agent
+schemaVersion: "2"
+kind: sandbox
 name: hermes-agent
 displayName: Hermes Agent
-description: "The self-improving AI agent by Nous Research — creates skills from experience, supports 200+ models via OpenRouter, and runs anywhere"
-
-agent:
-  image: "docker/sandbox-templates:shell-docker"
-  aiFilename: AGENTS.md
-  entrypoint:
-    run: ["/usr/local/bin/hermes-start"]
-
-network:
-  serviceDomains:
-    api.anthropic.com: anthropic
-    api.openai.com: openai
-    openrouter.ai: openrouter
-  serviceAuth:
-    anthropic:
-      headerName: x-api-key
-      valueFormat: "%s"
-    openai:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-    openrouter:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-  allowedDomains:
-    - github.com
-    - raw.githubusercontent.com
-    - objects.githubusercontent.com
-    - pypi.org
-    - files.pythonhosted.org
-    - astral.sh
-    - openrouter.ai
-    - "*.openrouter.ai"
-    - api.openai.com
-    - api.anthropic.com
-    - portal.nousresearch.com
-    - duckduckgo.com        # install.sh connectivity probe alongside pypi.org
-    - archive.ubuntu.com    # Ubuntu archive (amd64 main)
-    - security.ubuntu.com   # Ubuntu security updates (amd64)
-    - ports.ubuntu.com      # Ubuntu archive/security (arm64)
-    - download.docker.com   # Docker's apt repo
-
+description: The self-improving AI agent by Nous Research — creates skills from experience, supports 200+ models via OpenRouter, and runs anywhere
+sandbox:
+    image: docker/sandbox-templates:shell-docker
+    aiFilename: AGENTS.md
+    entrypoint:
+        run:
+            - /usr/local/bin/hermes-start
+caps:
+    network:
+        allow:
+            - github.com
+            - raw.githubusercontent.com
+            - objects.githubusercontent.com
+            - pypi.org
+            - files.pythonhosted.org
+            - astral.sh
+            - openrouter.ai
+            - '*.openrouter.ai'
+            - api.openai.com
+            - api.anthropic.com
+            - portal.nousresearch.com
+            - duckduckgo.com        # install.sh connectivity probe alongside pypi.org
+            - archive.ubuntu.com    # Ubuntu archive (amd64 main)
+            - security.ubuntu.com   # Ubuntu security updates (amd64)
+            - ports.ubuntu.com      # Ubuntu archive/security (arm64)
+            - download.docker.com   # Docker's apt repo
 credentials:
-  sources:
-    anthropic:
-      env:
-        - ANTHROPIC_API_KEY
-    openai:
-      env:
-        - OPENAI_API_KEY
-    openrouter:
-      env:
-        - OPENROUTER_API_KEY
-
+    - service: anthropic
+      apiKey:
+        name: ANTHROPIC_API_KEY
+        proxyManaged: true
+        inject:
+            - domain: api.anthropic.com
+              header: x-api-key
+              format: '%s'
+    - service: openai
+      apiKey:
+        name: OPENAI_API_KEY
+        proxyManaged: true
+        inject:
+            - domain: api.openai.com
+              header: Authorization
+              format: Bearer %s
+    - service: openrouter
+      apiKey:
+        name: OPENROUTER_API_KEY
+        proxyManaged: true
+        inject:
+            - domain: openrouter.ai
+              header: Authorization
+              format: Bearer %s
 environment:
-  proxyManaged:
-    - ANTHROPIC_API_KEY
-    - OPENAI_API_KEY
-    - OPENROUTER_API_KEY
-  variables:
-    HERMES_HOME: /home/agent/.hermes
-
+    variables:
+        HERMES_HOME: /home/agent/.hermes
 commands:
-  install:
-    - command: "printf '#!/bin/sh\\nif ! [ -f /home/agent/.hermes-installed ]; then\\n  echo \"Waiting for Hermes Agent installation (~3 min)...\" >&2\\n  until [ -f /home/agent/.hermes-installed ]; do sleep 3; done\\nfi\\nexec /home/agent/.local/bin/hermes \"$@\"\\n' > /usr/local/bin/hermes-start && chmod +x /usr/local/bin/hermes-start"
-      user: "0"
-      description: Create entrypoint wrapper that polls for install completion before launching hermes
-    - command: "printf '#!/bin/bash\\nset -e\\ncurl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --skip-setup\\ntouch /home/agent/.hermes-installed\\n' > /home/agent/hermes-install.sh && chmod +x /home/agent/hermes-install.sh && setsid /home/agent/hermes-install.sh > /home/agent/hermes-install.log 2>&1 &"
-      user: "1000"
-      description: Install Hermes Agent via official installer in detached background session (~3 minutes; writes .hermes-installed flag on completion)
+    install:
+        - command: printf '#!/bin/sh\nif ! [ -f /home/agent/.hermes-installed ]; then\n  echo "Waiting for Hermes Agent installation (~3 min)..." >&2\n  until [ -f /home/agent/.hermes-installed ]; do sleep 3; done\nfi\nexec /home/agent/.local/bin/hermes "$@"\n' > /usr/local/bin/hermes-start && chmod +x /usr/local/bin/hermes-start
+          user: "0"
+          description: Create entrypoint wrapper that polls for install completion before launching hermes
+        - command: printf '#!/bin/bash\nset -e\ncurl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --skip-setup\ntouch /home/agent/.hermes-installed\n' > /home/agent/hermes-install.sh && chmod +x /home/agent/hermes-install.sh && setsid /home/agent/hermes-install.sh > /home/agent/hermes-install.log 2>&1 &
+          user: "1000"
+          description: Install Hermes Agent via official installer in detached background session (~3 minutes; writes .hermes-installed flag on completion)

--- a/junie/spec.yaml
+++ b/junie/spec.yaml
@@ -1,81 +1,78 @@
-schemaVersion: "1"
-kind: agent
+schemaVersion: "2"
+kind: sandbox
 name: junie
 displayName: Junie
 description: The AI coding agent by JetBrains.
-
-agent:
-  image: "docker/sandbox-templates:shell-docker"
-  aiFilename: AGENTS.md
-  entrypoint:
-    run: [junie]
-
-network:
-  serviceDomains:
-    junie.jetbrains.com: junie
-    api.anthropic.com: anthropic
-    api.openai.com: openai
-    generativelanguage.googleapis.com: google
-    api.x.ai: xai
-    openrouter.ai: openrouter
-  serviceAuth:
-    junie:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-    anthropic:
-      headerName: x-api-key
-      valueFormat: "%s"
-    openai:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-    google:
-      headerName: x-goog-api-key
-      valueFormat: "%s"
-    xai:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-    openrouter:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-  allowedDomains:
-    - "junie.jetbrains.com"
-    - "api.jetbrains.ai"
-    - "github.com"
-    - "raw.githubusercontent.com"
-    - "release-assets.githubusercontent.com"
-    - "api.anthropic.com"
-    - "api.openai.com"
-    - "generativelanguage.googleapis.com"
-    - "api.x.ai"
-    - "openrouter.ai"
-
+sandbox:
+    image: docker/sandbox-templates:shell-docker
+    aiFilename: AGENTS.md
+    entrypoint:
+        run:
+            - junie
+caps:
+    network:
+        allow:
+            - junie.jetbrains.com
+            - api.jetbrains.ai
+            - github.com
+            - raw.githubusercontent.com
+            - release-assets.githubusercontent.com
+            - api.anthropic.com
+            - api.openai.com
+            - generativelanguage.googleapis.com
+            - api.x.ai
+            - openrouter.ai
 credentials:
-  sources:
-    junie:
-      env: [JUNIE_API_KEY]
-    anthropic:
-      env: [ANTHROPIC_API_KEY]
-    openai:
-      env: [OPENAI_API_KEY]
-    google:
-      env: [GEMINI_API_KEY, GOOGLE_GENERATIVE_AI_API_KEY]
-    xai:
-      env: [XAI_API_KEY]
-    openrouter:
-      env: [OPENROUTER_API_KEY]
-
-environment:
-  proxyManaged:
-    - JUNIE_API_KEY
-    - ANTHROPIC_API_KEY
-    - OPENAI_API_KEY
-    - GEMINI_API_KEY
-    - GOOGLE_GENERATIVE_AI_API_KEY
-    - XAI_API_KEY
-    - OPENROUTER_API_KEY
-
+    - service: anthropic
+      apiKey:
+        name: ANTHROPIC_API_KEY
+        proxyManaged: true
+        inject:
+            - domain: api.anthropic.com
+              header: x-api-key
+              format: '%s'
+    - service: google
+      apiKey:
+        name: GEMINI_API_KEY
+        proxyManaged: true
+        inject:
+            - domain: generativelanguage.googleapis.com
+              header: x-goog-api-key
+              format: '%s'
+    - service: junie
+      apiKey:
+        name: JUNIE_API_KEY
+        proxyManaged: true
+        inject:
+            - domain: junie.jetbrains.com
+              header: Authorization
+              format: Bearer %s
+    - service: openai
+      apiKey:
+        name: OPENAI_API_KEY
+        proxyManaged: true
+        inject:
+            - domain: api.openai.com
+              header: Authorization
+              format: Bearer %s
+    - service: openrouter
+      apiKey:
+        name: OPENROUTER_API_KEY
+        proxyManaged: true
+        inject:
+            - domain: openrouter.ai
+              header: Authorization
+              format: Bearer %s
+    - service: xai
+      apiKey:
+        name: XAI_API_KEY
+        proxyManaged: true
+        inject:
+            - domain: api.x.ai
+              header: Authorization
+              format: Bearer %s
 commands:
-  install:
-    - command: "curl -fsSL https://junie.jetbrains.com/install.sh | bash"
-      user: "1000"
-      description: Install Junie
+    install:
+        - command: curl -fsSL https://junie.jetbrains.com/install.sh | bash
+          user: "1000"
+          description: Install Junie

--- a/mise/spec.yaml
+++ b/mise/spec.yaml
@@ -1,72 +1,70 @@
-schemaVersion: "1"
+schemaVersion: "2"
 kind: mixin
 name: mise
 displayName: mise (mise-en-place)
-description: "The polyglot dev-tool version manager (https://mise.jdx.dev) — installs the mise CLI and wires up shell activation so the agent can run `mise install`, `mise use`, and per-project `.mise.toml` resolutions in the sandbox."
-
-network:
-  allowedDomains:
-    # github.com — release tag URLs for the install-time tarball AND for mise's `ubi`
-    # backend at runtime (https://github.com/<owner>/<repo>/releases/download/...).
-    # The download then 302-redirects to release-assets.githubusercontent.com.
-    - github.com
-    # api.github.com — mise queries the GitHub releases API to resolve `<tool>@latest`
-    # and similar version selectors for any github-hosted tool. Without this, even
-    # `mise install <github-tool>@<exact-version>` fails because the resolver still
-    # touches the API to validate the tag.
-    - api.github.com
-    - release-assets.githubusercontent.com
-    # Runtime tool installs (`mise install <tool>`) hit per-language hosts beyond GitHub
-    # (nodejs.org, pypi.org, go.dev, crates.io, etc.) that vary by what the user asks
-    # mise to install. Fork and extend `allowedDomains` with the hosts you actually
-    # need — see the README for a starter list.
-
+description: The polyglot dev-tool version manager (https://mise.jdx.dev) — installs the mise CLI and wires up shell activation so the agent can run `mise install`, `mise use`, and per-project `.mise.toml` resolutions in the sandbox.
+caps:
+    network:
+        allow:
+            # github.com — release tag URLs for the install-time tarball AND for mise's `ubi`
+            # backend at runtime (https://github.com/<owner>/<repo>/releases/download/...).
+            # The download then 302-redirects to release-assets.githubusercontent.com.
+            - github.com
+            # api.github.com — mise queries the GitHub releases API to resolve `<tool>@latest`
+            # and similar version selectors for any github-hosted tool. Without this, even
+            # `mise install <github-tool>@<exact-version>` fails because the resolver still
+            # touches the API to validate the tag.
+            - api.github.com
+            - release-assets.githubusercontent.com
+            # Runtime tool installs (`mise install <tool>`) hit per-language hosts beyond GitHub
+            # (nodejs.org, pypi.org, go.dev, crates.io, etc.) that vary by what the user asks
+            # mise to install. Fork and extend `allowedDomains` with the hosts you actually
+            # need — see the README for a starter list.
 environment:
-  variables:
-    # Treat the whole sandbox filesystem as trusted so `.mise.toml` files don't trigger an
-    # interactive trust prompt. This is appropriate inside a sandbox: the user has already
-    # opted into running this code by attaching the workspace.
-    MISE_TRUSTED_CONFIG_PATHS: "/"
-
+    variables:
+        # Treat the whole sandbox filesystem as trusted so `.mise.toml` files don't trigger an
+        # interactive trust prompt. This is appropriate inside a sandbox: the user has already
+        # opted into running this code by attaching the workspace.
+        MISE_TRUSTED_CONFIG_PATHS: /
 commands:
-  install:
-    # Install mise from a pinned, digest-verified GitHub release tarball. The official
-    # `curl https://mise.run | sh` flow is fine for a workstation, but inside a sandbox
-    # we want the version and binary digest captured in git. To bump: change MISE_VERSION
-    # and the per-arch SHA256 below (sourced from the release's SHASUMS256.txt).
-    - command: |
-        set -euo pipefail
-        MISE_VERSION=2026.5.2
-        ARCH=$(dpkg --print-architecture)
-        case "$ARCH" in
-          amd64)
-            TARBALL="mise-v${MISE_VERSION}-linux-x64.tar.gz"
-            SHA256="cdf616b3d8554bece574cb1a5c0f19cc0f551dffbecf66037df1cc06569a42ef"
-            ;;
-          arm64)
-            TARBALL="mise-v${MISE_VERSION}-linux-arm64.tar.gz"
-            SHA256="a746ad85fe8a7b62a6c72939da5fb4231074fd16c482f6334a598bd92926f41e"
-            ;;
-          *)
-            echo "unsupported sandbox arch: $ARCH (expected amd64 or arm64)" >&2
-            exit 1
-            ;;
-        esac
-        URL="https://github.com/jdx/mise/releases/download/v${MISE_VERSION}/${TARBALL}"
-        curl --proto '=https' --tlsv1.2 -fsSL -o /tmp/mise.tgz "$URL"
-        echo "${SHA256}  /tmp/mise.tgz" | sha256sum -c -
-        tar -C /tmp -xzf /tmp/mise.tgz mise/bin/mise
-        install -m 0755 /tmp/mise/bin/mise /usr/local/bin/mise
-        rm -rf /tmp/mise /tmp/mise.tgz
-        mise --version
-      user: "0"
-      description: "Install mise CLI v2026.5.2, version+digest pinned"
-    # Wire shell activation into the agent user's bashrc so interactive shells get
-    # `mise activate` (PATH shimming + auto-`mise install` on cd). Append rather than
-    # overwrite so we don't clobber whatever the template image already ships.
-    - command: |
-        set -euo pipefail
-        grep -qF 'mise activate bash' ~/.bashrc 2>/dev/null || \
-          printf '\n# mise (added by sbx-kits-contrib/mise)\neval "$(mise activate bash)"\n' >> ~/.bashrc
-      user: "1000"
-      description: "Hook `mise activate bash` into ~/.bashrc for interactive shells"
+    install:
+        # Install mise from a pinned, digest-verified GitHub release tarball. The official
+        # `curl https://mise.run | sh` flow is fine for a workstation, but inside a sandbox
+        # we want the version and binary digest captured in git. To bump: change MISE_VERSION
+        # and the per-arch SHA256 below (sourced from the release's SHASUMS256.txt).
+        - command: |
+            set -euo pipefail
+            MISE_VERSION=2026.5.2
+            ARCH=$(dpkg --print-architecture)
+            case "$ARCH" in
+              amd64)
+                TARBALL="mise-v${MISE_VERSION}-linux-x64.tar.gz"
+                SHA256="cdf616b3d8554bece574cb1a5c0f19cc0f551dffbecf66037df1cc06569a42ef"
+                ;;
+              arm64)
+                TARBALL="mise-v${MISE_VERSION}-linux-arm64.tar.gz"
+                SHA256="a746ad85fe8a7b62a6c72939da5fb4231074fd16c482f6334a598bd92926f41e"
+                ;;
+              *)
+                echo "unsupported sandbox arch: $ARCH (expected amd64 or arm64)" >&2
+                exit 1
+                ;;
+            esac
+            URL="https://github.com/jdx/mise/releases/download/v${MISE_VERSION}/${TARBALL}"
+            curl --proto '=https' --tlsv1.2 -fsSL -o /tmp/mise.tgz "$URL"
+            echo "${SHA256}  /tmp/mise.tgz" | sha256sum -c -
+            tar -C /tmp -xzf /tmp/mise.tgz mise/bin/mise
+            install -m 0755 /tmp/mise/bin/mise /usr/local/bin/mise
+            rm -rf /tmp/mise /tmp/mise.tgz
+            mise --version
+          user: "0"
+          description: Install mise CLI v2026.5.2, version+digest pinned
+        # Wire shell activation into the agent user's bashrc so interactive shells get
+        # `mise activate` (PATH shimming + auto-`mise install` on cd). Append rather than
+        # overwrite so we don't clobber whatever the template image already ships.
+        - command: |
+            set -euo pipefail
+            grep -qF 'mise activate bash' ~/.bashrc 2>/dev/null || \
+              printf '\n# mise (added by sbx-kits-contrib/mise)\neval "$(mise activate bash)"\n' >> ~/.bashrc
+          user: "1000"
+          description: Hook `mise activate bash` into ~/.bashrc for interactive shells

--- a/nanobot/spec.yaml
+++ b/nanobot/spec.yaml
@@ -1,49 +1,49 @@
-schemaVersion: "1"
-kind: agent
+schemaVersion: "2"
+kind: sandbox
 name: nanobot
 displayName: Nanobot
-description: "Lightweight personal AI assistant with multi-platform chat and multi-provider LLM support"
-
-agent:
-  image: "docker/sandbox-templates:shell-docker"
-  aiFilename: AGENTS.md
-  entrypoint:
-    run: ["nanobot", "agent", "--config", "/home/agent/.nanobot/config.json"]
-
-network:
-  serviceDomains:
-    api.anthropic.com: anthropic
-    console.anthropic.com: anthropic
-    claude.ai: anthropic
-  serviceAuth:
-    anthropic:
-      headerName: x-api-key
-      valueFormat: "%s"
-  allowedDomains:
-    - pypi.org
-    - files.pythonhosted.org
-    - "*.telegram.org"
-    - "*.discord.com"
-    - gateway.discord.gg
-    - "*.whatsapp.com"
-    - "*.whatsapp.net"
-    - "*.slack.com"
-    - "*.feishu.cn"
-
+description: Lightweight personal AI assistant with multi-platform chat and multi-provider LLM support
+sandbox:
+    image: docker/sandbox-templates:shell-docker
+    aiFilename: AGENTS.md
+    entrypoint:
+        run:
+            - nanobot
+            - agent
+            - --config
+            - /home/agent/.nanobot/config.json
+caps:
+    network:
+        allow:
+            - pypi.org
+            - files.pythonhosted.org
+            - '*.telegram.org'
+            - '*.discord.com'
+            - gateway.discord.gg
+            - '*.whatsapp.com'
+            - '*.whatsapp.net'
+            - '*.slack.com'
+            - '*.feishu.cn'
 credentials:
-  sources:
-    anthropic:
-      env:
-        - ANTHROPIC_API_KEY
-
+    - service: anthropic
+      apiKey:
+        name: ANTHROPIC_API_KEY
+        proxyManaged: true
+        inject:
+            - domain: api.anthropic.com
+              header: x-api-key
+              format: '%s'
+            - domain: claude.ai
+              header: x-api-key
+              format: '%s'
+            - domain: console.anthropic.com
+              header: x-api-key
+              format: '%s'
 environment:
-  variables:
-    NANOBOT_AGENTS__DEFAULTS__WORKSPACE: /home/agent/nanobot
-  proxyManaged:
-    - ANTHROPIC_API_KEY
-
+    variables:
+        NANOBOT_AGENTS__DEFAULTS__WORKSPACE: /home/agent/nanobot
 commands:
-  install:
-    - command: "pip install --break-system-packages nanobot-ai"
-      user: "1000"
-      description: Install nanobot
+    install:
+        - command: pip install --break-system-packages nanobot-ai
+          user: "1000"
+          description: Install nanobot

--- a/openclaw/spec.yaml
+++ b/openclaw/spec.yaml
@@ -1,62 +1,62 @@
-schemaVersion: "1"
-kind: agent
+schemaVersion: "2"
+kind: sandbox
 name: openclaw
 displayName: OpenClaw
-description: "Personal AI assistant with multi-platform chat, skills, and gateway support"
-
-agent:
-  image: "docker/sandbox-templates:shell-docker"
-  aiFilename: AGENTS.md
-  entrypoint:
-    run: ["/usr/local/bin/openclaw-start"]
-
-network:
-  serviceDomains:
-    api.anthropic.com: anthropic
-    console.anthropic.com: anthropic
-    claude.ai: anthropic
-  serviceAuth:
-    anthropic:
-      headerName: x-api-key
-      valueFormat: "%s"
-  allowedDomains:
-    - registry.npmjs.org
-    - "*.npmjs.org"
-    - "nodejs.org:443"
-    - "*.telegram.org"
-    - "*.discord.com"
-    - gateway.discord.gg
-    - "*.whatsapp.com"
-    - "*.whatsapp.net"
-    - "*.slack.com"
-    - openclaw.ai
-    - docs.openclaw.ai
-
+description: Personal AI assistant with multi-platform chat, skills, and gateway support
+sandbox:
+    image: docker/sandbox-templates:shell-docker
+    aiFilename: AGENTS.md
+    entrypoint:
+        run:
+            - /usr/local/bin/openclaw-start
+caps:
+    network:
+        allow:
+            - registry.npmjs.org
+            - '*.npmjs.org'
+            - nodejs.org:443
+            - '*.telegram.org'
+            - '*.discord.com'
+            - gateway.discord.gg
+            - '*.whatsapp.com'
+            - '*.whatsapp.net'
+            - '*.slack.com'
+            - openclaw.ai
+            - docs.openclaw.ai
 credentials:
-  sources:
-    anthropic:
-      env:
-        - ANTHROPIC_API_KEY
-
+    - service: anthropic
+      apiKey:
+        name: ANTHROPIC_API_KEY
+        proxyManaged: true
+        inject:
+            - domain: api.anthropic.com
+              header: x-api-key
+              format: '%s'
+            - domain: claude.ai
+              header: x-api-key
+              format: '%s'
+            - domain: console.anthropic.com
+              header: x-api-key
+              format: '%s'
 environment:
-  variables:
-    OPENCLAW_STATE_DIR: /home/agent/.openclaw
-  proxyManaged:
-    - ANTHROPIC_API_KEY
-
+    variables:
+        OPENCLAW_STATE_DIR: /home/agent/.openclaw
 commands:
-  install:
-    - command: "npm config set proxy $HTTP_PROXY && npm config set https-proxy $HTTP_PROXY"
-      user: "0"
-      description: Configure npm proxy
-    - command: "printf '#!/bin/sh\\nif ! [ -f /home/agent/.openclaw-installed ]; then\\n  echo \"Waiting for OpenClaw installation to complete...\" >&2\\n  until [ -f /home/agent/.openclaw-installed ]; do sleep 2; done\\nfi\\nexec /usr/local/share/npm-global/bin/openclaw chat\\n' > /usr/local/bin/openclaw-start && chmod +x /usr/local/bin/openclaw-start"
-      user: "0"
-      description: Create agent entrypoint early; polls for install flag before starting openclaw
-    - command: "printf '#!/bin/sh\\nnpm install -g n && n install 22 && npm install -g --maxsockets=1 --fetch-timeout=600000 openclaw@latest && touch /home/agent/.openclaw-installed\\n' > /home/agent/openclaw-install.sh && chmod +x /home/agent/openclaw-install.sh && setsid /home/agent/openclaw-install.sh > /home/agent/openclaw-install.log 2>&1 &"
-      user: "0"
-      description: Upgrade to Node.js 22 and install OpenClaw in detached background session (~3 minutes; .openclaw-installed flag written on completion)
-  startup:
-    - command: [sh, -c, "until [ -f /home/agent/.openclaw-installed ]; do sleep 5; done; /usr/local/share/npm-global/bin/openclaw gateway run --allow-unconfigured"]
-      user: "1000"
-      background: true
-      description: Wait for install then start OpenClaw gateway
+    install:
+        - command: npm config set proxy $HTTP_PROXY && npm config set https-proxy $HTTP_PROXY
+          user: "0"
+          description: Configure npm proxy
+        - command: printf '#!/bin/sh\nif ! [ -f /home/agent/.openclaw-installed ]; then\n  echo "Waiting for OpenClaw installation to complete..." >&2\n  until [ -f /home/agent/.openclaw-installed ]; do sleep 2; done\nfi\nexec /usr/local/share/npm-global/bin/openclaw chat\n' > /usr/local/bin/openclaw-start && chmod +x /usr/local/bin/openclaw-start
+          user: "0"
+          description: Create agent entrypoint early; polls for install flag before starting openclaw
+        - command: printf '#!/bin/sh\nnpm install -g n && n install 22 && npm install -g --maxsockets=1 --fetch-timeout=600000 openclaw@latest && touch /home/agent/.openclaw-installed\n' > /home/agent/openclaw-install.sh && chmod +x /home/agent/openclaw-install.sh && setsid /home/agent/openclaw-install.sh > /home/agent/openclaw-install.log 2>&1 &
+          user: "0"
+          description: Upgrade to Node.js 22 and install OpenClaw in detached background session (~3 minutes; .openclaw-installed flag written on completion)
+    startup:
+        - command:
+            - sh
+            - -c
+            - until [ -f /home/agent/.openclaw-installed ]; do sleep 5; done; /usr/local/share/npm-global/bin/openclaw gateway run --allow-unconfigured
+          user: "1000"
+          background: true
+          description: Wait for install then start OpenClaw gateway

--- a/opencode-model-runner/spec.yaml
+++ b/opencode-model-runner/spec.yaml
@@ -1,38 +1,37 @@
-schemaVersion: "1"
-kind: agent
+schemaVersion: "2"
+kind: sandbox
 name: opencode-model-runner
 displayName: OpenCode (Docker Model Runner)
 description: OpenCode wired to a local Docker Model Runner instance via its OpenAI-compatible API, with automatic model discovery.
-
-agent:
-  image: "docker/sandbox-templates:opencode-docker"
-  aiFilename: AGENTS.md
-  entrypoint:
-    run: [opencode]
-
+sandbox:
+    image: docker/sandbox-templates:opencode-docker
+    aiFilename: AGENTS.md
+    entrypoint:
+        run:
+            - opencode
 commands:
-  initFiles:
-    - path: /home/agent/.config/opencode/opencode.json
-      mode: "0644"
-      description: Configure OpenCode to use the local Docker Model Runner
-      content: |
-        {
-          "$schema": "https://opencode.ai/config.json",
-          "plugin": [
-            ["opencode-models-discovery", {
-              "smartModelName": false
-            }]
-          ],
-          "provider": {
-            "dmr": {
-              "npm": "@ai-sdk/openai-compatible",
-              "name": "Docker Model Runner",
-              "options": {
-                "baseURL": "http://host.docker.internal:12434/v1",
-                "modelsDiscovery": {
-                  "enabled": true
+    initFiles:
+        - path: /home/agent/.config/opencode/opencode.json
+          content: |
+            {
+              "$schema": "https://opencode.ai/config.json",
+              "plugin": [
+                ["opencode-models-discovery", {
+                  "smartModelName": false
+                }]
+              ],
+              "provider": {
+                "dmr": {
+                  "npm": "@ai-sdk/openai-compatible",
+                  "name": "Docker Model Runner",
+                  "options": {
+                    "baseURL": "http://host.docker.internal:12434/v1",
+                    "modelsDiscovery": {
+                      "enabled": true
+                    }
+                  }
                 }
               }
             }
-          }
-        }
+          mode: "0644"
+          description: Configure OpenCode to use the local Docker Model Runner

--- a/packages-through-sfw/spec.yaml
+++ b/packages-through-sfw/spec.yaml
@@ -1,111 +1,110 @@
-schemaVersion: "1"
+schemaVersion: "2"
 kind: mixin
 name: packages-through-sfw
 displayName: Packages through SFW
-description: "Installs Socket Firewall Free and routes npm, pip, pip3, and python3 -m pip commands through sfw when resolved through PATH."
-
-network:
-  allowedDomains:
-    - "github.com:443"
-    - "release-assets.githubusercontent.com:443"
-    - "api.socket.dev:443"
-    - "socket.dev:443"
-    - "registry.npmjs.org:443"
-    - "pypi.org:443"
-    - "files.pythonhosted.org:443"
-    # `apt-get update` (run by the first install hook) refreshes metadata
-    # for every configured apt source. The shell-docker base template
-    # ships three sources, all of which must succeed for the update to
-    # exit 0, regardless of which one our install actually fetches from.
-    # Ubuntu hosts amd64 packages on archive/security and arm64 packages
-    # on ports.ubuntu.com, so all three Ubuntu hosts are listed for
-    # cross-arch coverage.
-    - "archive.ubuntu.com:80"        # Ubuntu archive (amd64 main, HTTP)
-    - "security.ubuntu.com:80"       # Ubuntu security updates (amd64, HTTP)
-    - "ports.ubuntu.com:80"          # Ubuntu archive/security (arm64, HTTP)
-    - "download.docker.com:443"      # Docker's apt repo, pre-added by shell-docker
-
+description: Installs Socket Firewall Free and routes npm, pip, pip3, and python3 -m pip commands through sfw when resolved through PATH.
+caps:
+    network:
+        allow:
+            - github.com:443
+            - release-assets.githubusercontent.com:443
+            - api.socket.dev:443
+            - socket.dev:443
+            - registry.npmjs.org:443
+            - pypi.org:443
+            - files.pythonhosted.org:443
+            # `apt-get update` (run by the first install hook) refreshes metadata
+            # for every configured apt source. The shell-docker base template
+            # ships three sources, all of which must succeed for the update to
+            # exit 0, regardless of which one our install actually fetches from.
+            # Ubuntu hosts amd64 packages on archive/security and arm64 packages
+            # on ports.ubuntu.com, so all three Ubuntu hosts are listed for
+            # cross-arch coverage.
+            - archive.ubuntu.com:80        # Ubuntu archive (amd64 main, HTTP)
+            - security.ubuntu.com:80       # Ubuntu security updates (amd64, HTTP)
+            - ports.ubuntu.com:80          # Ubuntu archive/security (arm64, HTTP)
+            - download.docker.com:443      # Docker's apt repo, pre-added by shell-docker
 commands:
-  install:
-    - command: "apt-get update && apt-get install -y --no-install-recommends ca-certificates curl nodejs npm python3-pip && rm -rf /var/lib/apt/lists/*"
-      user: "0"
-      description: Install package-manager prerequisites
-    - command: |
-        set -euo pipefail
-        SFW_VERSION=1.10.0
-        case "$(uname -m)" in
-          x86_64|amd64)
-            ASSET="sfw-free-linux-x86_64"
-            SHA256="1ea16f15f1217bde66ac9c7d0262c7126b7bb1b2d60e14e8fa0982456139ae6e"
-            ;;
-          aarch64|arm64)
-            ASSET="sfw-free-linux-arm64"
-            SHA256="d7e969c17e6d23ac1cb0dea81ff87ef9bca2d83570270d91aab14b2a7fb66ad4"
-            ;;
-          *)
-            echo "unsupported sandbox arch: $(uname -m) (expected amd64 or arm64)" >&2
-            exit 1
-            ;;
-        esac
-        URL="https://github.com/SocketDev/sfw-free/releases/download/v${SFW_VERSION}/${ASSET}"
-        curl --proto '=https' --tlsv1.2 -fsSL -o /tmp/sfw "$URL"
-        echo "${SHA256}  /tmp/sfw" | sha256sum -c -
-        install -m 0755 /tmp/sfw /usr/local/bin/sfw
-        rm -f /tmp/sfw
-        sfw --version
-      user: "0"
-      description: "Install Socket Firewall Free v1.10.0, version+digest pinned"
-    - command: |
-        set -euo pipefail
-        mkdir -p /usr/local/lib/packages-through-sfw/shims
+    install:
+        - command: apt-get update && apt-get install -y --no-install-recommends ca-certificates curl nodejs npm python3-pip && rm -rf /var/lib/apt/lists/*
+          user: "0"
+          description: Install package-manager prerequisites
+        - command: |
+            set -euo pipefail
+            SFW_VERSION=1.10.0
+            case "$(uname -m)" in
+              x86_64|amd64)
+                ASSET="sfw-free-linux-x86_64"
+                SHA256="1ea16f15f1217bde66ac9c7d0262c7126b7bb1b2d60e14e8fa0982456139ae6e"
+                ;;
+              aarch64|arm64)
+                ASSET="sfw-free-linux-arm64"
+                SHA256="d7e969c17e6d23ac1cb0dea81ff87ef9bca2d83570270d91aab14b2a7fb66ad4"
+                ;;
+              *)
+                echo "unsupported sandbox arch: $(uname -m) (expected amd64 or arm64)" >&2
+                exit 1
+                ;;
+            esac
+            URL="https://github.com/SocketDev/sfw-free/releases/download/v${SFW_VERSION}/${ASSET}"
+            curl --proto '=https' --tlsv1.2 -fsSL -o /tmp/sfw "$URL"
+            echo "${SHA256}  /tmp/sfw" | sha256sum -c -
+            install -m 0755 /tmp/sfw /usr/local/bin/sfw
+            rm -f /tmp/sfw
+            sfw --version
+          user: "0"
+          description: Install Socket Firewall Free v1.10.0, version+digest pinned
+        - command: |
+            set -euo pipefail
+            mkdir -p /usr/local/lib/packages-through-sfw/shims
 
-        cat > /usr/local/lib/packages-through-sfw/shims/npm <<'SCRIPT'
-        #!/bin/sh
-        PATH="/usr/sbin:/usr/bin:/sbin:/bin" exec /usr/local/bin/sfw npm "$@"
-        SCRIPT
+            cat > /usr/local/lib/packages-through-sfw/shims/npm <<'SCRIPT'
+            #!/bin/sh
+            PATH="/usr/sbin:/usr/bin:/sbin:/bin" exec /usr/local/bin/sfw npm "$@"
+            SCRIPT
 
-        cat > /usr/local/lib/packages-through-sfw/shims/pip <<'SCRIPT'
-        #!/bin/sh
-        exec env -u PIP_CERT -u REQUESTS_CA_BUNDLE -u SSL_CERT_FILE PATH="/usr/sbin:/usr/bin:/sbin:/bin" /usr/local/bin/sfw pip "$@"
-        SCRIPT
+            cat > /usr/local/lib/packages-through-sfw/shims/pip <<'SCRIPT'
+            #!/bin/sh
+            exec env -u PIP_CERT -u REQUESTS_CA_BUNDLE -u SSL_CERT_FILE PATH="/usr/sbin:/usr/bin:/sbin:/bin" /usr/local/bin/sfw pip "$@"
+            SCRIPT
 
-        cat > /usr/local/lib/packages-through-sfw/shims/pip3 <<'SCRIPT'
-        #!/bin/sh
-        exec env -u PIP_CERT -u REQUESTS_CA_BUNDLE -u SSL_CERT_FILE PATH="/usr/sbin:/usr/bin:/sbin:/bin" /usr/local/bin/sfw pip3 "$@"
-        SCRIPT
+            cat > /usr/local/lib/packages-through-sfw/shims/pip3 <<'SCRIPT'
+            #!/bin/sh
+            exec env -u PIP_CERT -u REQUESTS_CA_BUNDLE -u SSL_CERT_FILE PATH="/usr/sbin:/usr/bin:/sbin:/bin" /usr/local/bin/sfw pip3 "$@"
+            SCRIPT
 
-        cat > /usr/local/lib/packages-through-sfw/shims/python3 <<'SCRIPT'
-        #!/bin/sh
-        if [ "$1" = "-m" ] && [ "$2" = "pip" ]; then
-          shift 2
-          exec env -u PIP_CERT -u REQUESTS_CA_BUNDLE -u SSL_CERT_FILE PATH="/usr/sbin:/usr/bin:/sbin:/bin" /usr/local/bin/sfw pip "$@"
-        fi
-        PATH="/usr/sbin:/usr/bin:/sbin:/bin" exec python3 "$@"
-        SCRIPT
+            cat > /usr/local/lib/packages-through-sfw/shims/python3 <<'SCRIPT'
+            #!/bin/sh
+            if [ "$1" = "-m" ] && [ "$2" = "pip" ]; then
+              shift 2
+              exec env -u PIP_CERT -u REQUESTS_CA_BUNDLE -u SSL_CERT_FILE PATH="/usr/sbin:/usr/bin:/sbin:/bin" /usr/local/bin/sfw pip "$@"
+            fi
+            PATH="/usr/sbin:/usr/bin:/sbin:/bin" exec python3 "$@"
+            SCRIPT
 
-        install -m 0755 /usr/local/lib/packages-through-sfw/shims/npm /usr/local/bin/npm
-        install -m 0755 /usr/local/lib/packages-through-sfw/shims/pip /usr/local/bin/pip
-        install -m 0755 /usr/local/lib/packages-through-sfw/shims/pip3 /usr/local/bin/pip3
-        install -m 0755 /usr/local/lib/packages-through-sfw/shims/python3 /usr/local/bin/python3
+            install -m 0755 /usr/local/lib/packages-through-sfw/shims/npm /usr/local/bin/npm
+            install -m 0755 /usr/local/lib/packages-through-sfw/shims/pip /usr/local/bin/pip
+            install -m 0755 /usr/local/lib/packages-through-sfw/shims/pip3 /usr/local/bin/pip3
+            install -m 0755 /usr/local/lib/packages-through-sfw/shims/python3 /usr/local/bin/python3
 
-        cat > /etc/profile.d/packages-through-sfw.sh <<'SCRIPT'
-        # Route package-manager installs through Socket Firewall Free.
-        if [ -x /usr/local/bin/npm ]; then
-          npm() { /usr/local/bin/npm "$@"; }
-        fi
-        if [ -x /usr/local/bin/pip ]; then
-          pip() { /usr/local/bin/pip "$@"; }
-        fi
-        if [ -x /usr/local/bin/pip3 ]; then
-          pip3() { /usr/local/bin/pip3 "$@"; }
-        fi
-        SCRIPT
-        chmod 0644 /etc/profile.d/packages-through-sfw.sh
-      user: "0"
-      description: Configure sfw PATH shims and shell wrappers
-    - command: |
-        set -euo pipefail
-        grep -qF '/etc/profile.d/packages-through-sfw.sh' ~/.bashrc 2>/dev/null || \
-          printf '\n# Packages through SFW wrappers (added by sbx-kits-contrib/packages-through-sfw)\n[ -f /etc/profile.d/packages-through-sfw.sh ] && . /etc/profile.d/packages-through-sfw.sh\n' >> ~/.bashrc
-      user: "1000"
-      description: Source sfw wrappers from ~/.bashrc for interactive Bash shells
+            cat > /etc/profile.d/packages-through-sfw.sh <<'SCRIPT'
+            # Route package-manager installs through Socket Firewall Free.
+            if [ -x /usr/local/bin/npm ]; then
+              npm() { /usr/local/bin/npm "$@"; }
+            fi
+            if [ -x /usr/local/bin/pip ]; then
+              pip() { /usr/local/bin/pip "$@"; }
+            fi
+            if [ -x /usr/local/bin/pip3 ]; then
+              pip3() { /usr/local/bin/pip3 "$@"; }
+            fi
+            SCRIPT
+            chmod 0644 /etc/profile.d/packages-through-sfw.sh
+          user: "0"
+          description: Configure sfw PATH shims and shell wrappers
+        - command: |
+            set -euo pipefail
+            grep -qF '/etc/profile.d/packages-through-sfw.sh' ~/.bashrc 2>/dev/null || \
+              printf '\n# Packages through SFW wrappers (added by sbx-kits-contrib/packages-through-sfw)\n[ -f /etc/profile.d/packages-through-sfw.sh ] && . /etc/profile.d/packages-through-sfw.sh\n' >> ~/.bashrc
+          user: "1000"
+          description: Source sfw wrappers from ~/.bashrc for interactive Bash shells

--- a/pi/spec.yaml
+++ b/pi/spec.yaml
@@ -1,39 +1,35 @@
-schemaVersion: "1"
-kind: agent
+schemaVersion: "2"
+kind: sandbox
 name: pi
 displayName: Pi
-description: "Minimal terminal coding agent with extensible tools, skills, and TUI"
-
-agent:
-  image: "docker/sandbox-templates:shell-docker"
-  aiFilename: AGENTS.md
-  entrypoint:
-    run: [pi]
-
-network:
-  serviceDomains:
-    api.anthropic.com: anthropic
-    console.anthropic.com: anthropic
-    claude.ai: anthropic
-  serviceAuth:
-    anthropic:
-      headerName: x-api-key
-      valueFormat: "%s"
-  allowedDomains:
-    - registry.npmjs.org
-
+description: Minimal terminal coding agent with extensible tools, skills, and TUI
+sandbox:
+    image: docker/sandbox-templates:shell-docker
+    aiFilename: AGENTS.md
+    entrypoint:
+        run:
+            - pi
+caps:
+    network:
+        allow:
+            - registry.npmjs.org
 credentials:
-  sources:
-    anthropic:
-      env:
-        - ANTHROPIC_API_KEY
-
-environment:
-  proxyManaged:
-    - ANTHROPIC_API_KEY
-
+    - service: anthropic
+      apiKey:
+        name: ANTHROPIC_API_KEY
+        proxyManaged: true
+        inject:
+            - domain: api.anthropic.com
+              header: x-api-key
+              format: '%s'
+            - domain: claude.ai
+              header: x-api-key
+              format: '%s'
+            - domain: console.anthropic.com
+              header: x-api-key
+              format: '%s'
 commands:
-  install:
-    - command: "npm config set proxy $HTTP_PROXY && npm config set https-proxy $HTTP_PROXY && i=0; while [ $i -lt 5 ]; do npm install -g --maxsockets=1 --fetch-timeout=600000 @earendil-works/pi-coding-agent && break; i=$((i+1)); echo \"Retrying ($i/5)...\"; done"
-      user: "1000"
-      description: "Configure npm proxy and install pi coding agent globally (with retries)"
+    install:
+        - command: npm config set proxy $HTTP_PROXY && npm config set https-proxy $HTTP_PROXY && i=0; while [ $i -lt 5 ]; do npm install -g --maxsockets=1 --fetch-timeout=600000 @earendil-works/pi-coding-agent && break; i=$((i+1)); echo "Retrying ($i/5)..."; done
+          user: "1000"
+          description: Configure npm proxy and install pi coding agent globally (with retries)

--- a/smolagents/spec.yaml
+++ b/smolagents/spec.yaml
@@ -1,30 +1,31 @@
-schemaVersion: "1"
+schemaVersion: "2"
 kind: mixin
 name: smolagents
 displayName: smolagents
 description: "Installs Hugging Face smolagents in an isolated Python virtual environment and exposes the smolagent and webagent CLIs inside the sandbox."
 
-network:
-  allowedDomains:
-    # pip install path for smolagents and its Python dependencies.
-    - "pypi.org:443"
-    - "files.pythonhosted.org:443"
-    # Hugging Face Hub and Inference Providers, used by InferenceClientModel and
-    # hub-backed agent/tool loading at runtime.
-    - "huggingface.co:443"
-    - "hf.co:443"
-    - "router.huggingface.co:443"
-    # DuckDuckGo-backed search tools from the optional toolkit extra. Webpage
-    # fetches still require allowing the target sites you ask the agent to visit.
-    - "duckduckgo.com:443"
-    - "html.duckduckgo.com:443"
-    - "www.duckduckgo.com:443"
-    # `apt-get update` refreshes every configured apt source from the base
-    # template. Keep all template sources allowed for amd64 and arm64 sandboxes.
-    - "archive.ubuntu.com:80"
-    - "security.ubuntu.com:80"
-    - "ports.ubuntu.com:80"
-    - "download.docker.com:443"
+caps:
+  network:
+    allow:
+      # pip install path for smolagents and its Python dependencies.
+      - "pypi.org:443"
+      - "files.pythonhosted.org:443"
+      # Hugging Face Hub and Inference Providers, used by InferenceClientModel and
+      # hub-backed agent/tool loading at runtime.
+      - "huggingface.co:443"
+      - "hf.co:443"
+      - "router.huggingface.co:443"
+      # DuckDuckGo-backed search tools from the optional toolkit extra. Webpage
+      # fetches still require allowing the target sites you ask the agent to visit.
+      - "duckduckgo.com:443"
+      - "html.duckduckgo.com:443"
+      - "www.duckduckgo.com:443"
+      # `apt-get update` refreshes every configured apt source from the base
+      # template. Keep all template sources allowed for amd64 and arm64 sandboxes.
+      - "archive.ubuntu.com:80"
+      - "security.ubuntu.com:80"
+      - "ports.ubuntu.com:80"
+      - "download.docker.com:443"
 
 environment:
   variables:

--- a/task/spec.yaml
+++ b/task/spec.yaml
@@ -1,39 +1,38 @@
-schemaVersion: "1"
+schemaVersion: "2"
 kind: mixin
 name: task
 displayName: Task
 description: Installs the Task CLI so sandbox agents can run Taskfiles.
-
-network:
-  allowedDomains:
-    - github.com
-    - release-assets.githubusercontent.com
-
+caps:
+    network:
+        allow:
+            - github.com
+            - release-assets.githubusercontent.com
 commands:
-  install:
-    - command: |
-        set -euo pipefail
-        TASK_VERSION=3.50.0
-        ARCH=$(dpkg --print-architecture)
-        case "$ARCH" in
-          amd64)
-            TARBALL="task_linux_amd64.tar.gz"
-            SHA256="d449ba85ab85a0769989d78f8b9872938e4ba9347f7f4f925f73d98272a0a655"
-            ;;
-          arm64)
-            TARBALL="task_linux_arm64.tar.gz"
-            SHA256="ee67e7d999a4a70711bff1946c70bf76628012c91d9be55626ee90ba976897da"
-            ;;
-          *)
-            echo "unsupported sandbox arch: $ARCH (expected amd64 or arm64)" >&2
-            exit 1
-            ;;
-        esac
-        URL="https://github.com/go-task/task/releases/download/v${TASK_VERSION}/${TARBALL}"
-        curl --proto '=https' --tlsv1.2 -fsSL -o /tmp/task.tgz "$URL"
-        echo "${SHA256}  /tmp/task.tgz" | sha256sum -c -
-        tar -C /usr/local/bin -xzf /tmp/task.tgz task
-        rm /tmp/task.tgz
-        task --version
-      user: "0"
-      description: "Install Task CLI v3.50.0, version+digest pinned"
+    install:
+        - command: |
+            set -euo pipefail
+            TASK_VERSION=3.50.0
+            ARCH=$(dpkg --print-architecture)
+            case "$ARCH" in
+              amd64)
+                TARBALL="task_linux_amd64.tar.gz"
+                SHA256="d449ba85ab85a0769989d78f8b9872938e4ba9347f7f4f925f73d98272a0a655"
+                ;;
+              arm64)
+                TARBALL="task_linux_arm64.tar.gz"
+                SHA256="ee67e7d999a4a70711bff1946c70bf76628012c91d9be55626ee90ba976897da"
+                ;;
+              *)
+                echo "unsupported sandbox arch: $ARCH (expected amd64 or arm64)" >&2
+                exit 1
+                ;;
+            esac
+            URL="https://github.com/go-task/task/releases/download/v${TASK_VERSION}/${TARBALL}"
+            curl --proto '=https' --tlsv1.2 -fsSL -o /tmp/task.tgz "$URL"
+            echo "${SHA256}  /tmp/task.tgz" | sha256sum -c -
+            tar -C /usr/local/bin -xzf /tmp/task.tgz task
+            rm /tmp/task.tgz
+            task --version
+          user: "0"
+          description: Install Task CLI v3.50.0, version+digest pinned

--- a/trivy/spec.yaml
+++ b/trivy/spec.yaml
@@ -1,61 +1,61 @@
-schemaVersion: "1"
-kind: agent
+schemaVersion: "2"
+kind: sandbox
 name: trivy
 displayName: Trivy
-description: "Aqua's open source vulnerability scanner — sandboxed because security scanners shouldn't be able to compromise their hosts (TeamPCP, March 2026)."
-
-agent:
-  image: "docker/sandbox-templates:shell-docker"
-  aiFilename: AGENTS.md
-  # Drop into bash with trivy on PATH and the workspace as cwd. Run `trivy fs .` to scan.
-  entrypoint:
-    run: [bash, -l]
-
-network:
-  allowedDomains:
-    # Release tarball download (install time, one-shot).
-    # github.com 302-redirects to release-assets.githubusercontent.com for binary downloads.
-    - github.com
-    - release-assets.githubusercontent.com
-    # Vulnerability DB pull at runtime. Trivy's default chain is mirror.gcr.io (primary)
-    # with ghcr.io as a fallback for the trivy-db OCI artifact; we declare both openly in
-    # the allowlist rather than relying on env-var overrides to redirect the source.
-    # The trust footprint is intentionally explicit at the policy layer; tightening this
-    # is part of the v2 path (hardened-distribution-channel install).
-    - mirror.gcr.io
-    - ghcr.io
-    - pkg-containers.githubusercontent.com
-
+description: Aqua's open source vulnerability scanner — sandboxed because security scanners shouldn't be able to compromise their hosts (TeamPCP, March 2026).
+sandbox:
+    image: docker/sandbox-templates:shell-docker
+    aiFilename: AGENTS.md
+    # Drop into bash with trivy on PATH and the workspace as cwd. Run `trivy fs .` to scan.
+    entrypoint:
+        run:
+            - bash
+            - -l
+caps:
+    network:
+        allow:
+            # Release tarball download (install time, one-shot).
+            # github.com 302-redirects to release-assets.githubusercontent.com for binary downloads.
+            - github.com
+            - release-assets.githubusercontent.com
+            # Vulnerability DB pull at runtime. Trivy's default chain is mirror.gcr.io (primary)
+            # with ghcr.io as a fallback for the trivy-db OCI artifact; we declare both openly in
+            # the allowlist rather than relying on env-var overrides to redirect the source.
+            # The trust footprint is intentionally explicit at the policy layer; tightening this
+            # is part of the v2 path (hardened-distribution-channel install).
+            - mirror.gcr.io
+            - ghcr.io
+            - pkg-containers.githubusercontent.com
 commands:
-  install:
-    # Install Trivy from a pinned, digest-verified GitHub release.
-    # Why not the official `install.sh`: that pattern (curl|sh) is exactly what TeamPCP
-    # weaponized in March 2026 against tag-rewriteable references. We pin a known-good
-    # release by version AND SHA256, in the kit, in git. To bump: change TRIVY_VERSION
-    # plus the per-arch SHA256 below (sourced from the release's checksums.txt).
-    - command: |
-        set -euo pipefail
-        TRIVY_VERSION=0.70.0
-        ARCH=$(dpkg --print-architecture)
-        case "$ARCH" in
-          amd64)
-            TARBALL="trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
-            SHA256="8b4376d5d6befe5c24d503f10ff136d9e0c49f9127a4279fd110b727929a5aa9"
-            ;;
-          arm64)
-            TARBALL="trivy_${TRIVY_VERSION}_Linux-ARM64.tar.gz"
-            SHA256="2f6bb988b553a1bbac6bdd1ce890f5e412439564e17522b88a4541b4f364fc8d"
-            ;;
-          *)
-            echo "unsupported sandbox arch: $ARCH (expected amd64 or arm64)" >&2
-            exit 1
-            ;;
-        esac
-        URL="https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/${TARBALL}"
-        curl --proto '=https' --tlsv1.2 -fsSL -o /tmp/trivy.tgz "$URL"
-        echo "${SHA256}  /tmp/trivy.tgz" | sha256sum -c -
-        tar -C /usr/local/bin -xzf /tmp/trivy.tgz trivy
-        rm /tmp/trivy.tgz
-        trivy --version
-      user: "0"
-      description: "Install Trivy CLI v0.70.0, version+digest pinned"
+    install:
+        # Install Trivy from a pinned, digest-verified GitHub release.
+        # Why not the official `install.sh`: that pattern (curl|sh) is exactly what TeamPCP
+        # weaponized in March 2026 against tag-rewriteable references. We pin a known-good
+        # release by version AND SHA256, in the kit, in git. To bump: change TRIVY_VERSION
+        # plus the per-arch SHA256 below (sourced from the release's checksums.txt).
+        - command: |
+            set -euo pipefail
+            TRIVY_VERSION=0.70.0
+            ARCH=$(dpkg --print-architecture)
+            case "$ARCH" in
+              amd64)
+                TARBALL="trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
+                SHA256="8b4376d5d6befe5c24d503f10ff136d9e0c49f9127a4279fd110b727929a5aa9"
+                ;;
+              arm64)
+                TARBALL="trivy_${TRIVY_VERSION}_Linux-ARM64.tar.gz"
+                SHA256="2f6bb988b553a1bbac6bdd1ce890f5e412439564e17522b88a4541b4f364fc8d"
+                ;;
+              *)
+                echo "unsupported sandbox arch: $ARCH (expected amd64 or arm64)" >&2
+                exit 1
+                ;;
+            esac
+            URL="https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/${TARBALL}"
+            curl --proto '=https' --tlsv1.2 -fsSL -o /tmp/trivy.tgz "$URL"
+            echo "${SHA256}  /tmp/trivy.tgz" | sha256sum -c -
+            tar -C /usr/local/bin -xzf /tmp/trivy.tgz trivy
+            rm /tmp/trivy.tgz
+            trivy --version
+          user: "0"
+          description: Install Trivy CLI v0.70.0, version+digest pinned

--- a/vale/spec.yaml
+++ b/vale/spec.yaml
@@ -1,55 +1,53 @@
-schemaVersion: "1"
+schemaVersion: "2"
 kind: mixin
 name: vale
 displayName: Vale
 description: Installs the Vale prose linter from a pinned GitHub release.
-
-network:
-  allowedDomains:
-    # Release tarball download (install time, one-shot).
-    # github.com 302-redirects to release-assets.githubusercontent.com for binary downloads.
-    - github.com
-    - release-assets.githubusercontent.com
-
+caps:
+    network:
+        allow:
+            # Release tarball download (install time, one-shot).
+            # github.com 302-redirects to release-assets.githubusercontent.com for binary downloads.
+            - github.com
+            - release-assets.githubusercontent.com
 commands:
-  install:
-    # Install Vale from a pinned, SHA256-verified GitHub release. We deliberately
-    # do NOT query api.github.com for `releases/latest`: unauthenticated API calls
-    # from shared CI runner IPs hit the 60-req/hr rate limit and 403, making installs
-    # flaky. Pinning by version + SHA256 (in the kit, in git) is also the safer supply
-    # chain. To bump: change VALE_VERSION plus the per-arch SHA256 below (sourced from
-    # the release's checksums.txt).
-    - command: |
-        set -euo pipefail
-        VALE_VERSION=3.14.2
-        ARCH=$(dpkg --print-architecture)
-        case "$ARCH" in
-          amd64)
-            TARBALL="vale_${VALE_VERSION}_Linux_64-bit.tar.gz"
-            SHA256="469cf88ec58a374dca14b2564c4391d2c9a1c632210aa0b642758b794082e05f"
-            ;;
-          arm64)
-            TARBALL="vale_${VALE_VERSION}_Linux_arm64.tar.gz"
-            SHA256="b11fa9955b93814f993442568b9b922604cc4b574643037b84900e9514860802"
-            ;;
-          *)
-            echo "unsupported arch: $ARCH" >&2
-            exit 1
-            ;;
-        esac
-        curl --proto '=https' --tlsv1.2 -fsSL \
-          -o /tmp/vale.tgz \
-          "https://github.com/vale-cli/vale/releases/download/v${VALE_VERSION}/${TARBALL}"
-        echo "${SHA256}  /tmp/vale.tgz" | sha256sum -c -
-        tar -C /usr/local/bin -xzf /tmp/vale.tgz vale
-        rm /tmp/vale.tgz
-        vale --version
-      user: "0"
-      description: "Install pinned Vale CLI"
+    install:
+        # Install Vale from a pinned, SHA256-verified GitHub release. We deliberately
+        # do NOT query api.github.com for `releases/latest`: unauthenticated API calls
+        # from shared CI runner IPs hit the 60-req/hr rate limit and 403, making installs
+        # flaky. Pinning by version + SHA256 (in the kit, in git) is also the safer supply
+        # chain. To bump: change VALE_VERSION plus the per-arch SHA256 below (sourced from
+        # the release's checksums.txt).
+        - command: |
+            set -euo pipefail
+            VALE_VERSION=3.14.2
+            ARCH=$(dpkg --print-architecture)
+            case "$ARCH" in
+              amd64)
+                TARBALL="vale_${VALE_VERSION}_Linux_64-bit.tar.gz"
+                SHA256="469cf88ec58a374dca14b2564c4391d2c9a1c632210aa0b642758b794082e05f"
+                ;;
+              arm64)
+                TARBALL="vale_${VALE_VERSION}_Linux_arm64.tar.gz"
+                SHA256="b11fa9955b93814f993442568b9b922604cc4b574643037b84900e9514860802"
+                ;;
+              *)
+                echo "unsupported arch: $ARCH" >&2
+                exit 1
+                ;;
+            esac
+            curl --proto '=https' --tlsv1.2 -fsSL \
+              -o /tmp/vale.tgz \
+              "https://github.com/vale-cli/vale/releases/download/v${VALE_VERSION}/${TARBALL}"
+            echo "${SHA256}  /tmp/vale.tgz" | sha256sum -c -
+            tar -C /usr/local/bin -xzf /tmp/vale.tgz vale
+            rm /tmp/vale.tgz
+            vale --version
+          user: "0"
+          description: Install pinned Vale CLI
+agentContext: |
+    ## Vale prose linter
 
-memory: |
-  ## Vale prose linter
-
-  The `vale` CLI is installed and available on `PATH`. Use it to lint
-  prose in Markdown, AsciiDoc, reStructuredText, and other text formats.
-  Run `vale --version` to confirm, and `vale <file>` to lint a file.
+    The `vale` CLI is installed and available on `PATH`. Use it to lint
+    prose in Markdown, AsciiDoc, reStructuredText, and other text formats.
+    Run `vale --version` to confirm, and `vale <file>` to lint a file.


### PR DESCRIPTION
## ⚠️ DRAFT — DO NOT MERGE until a v2-capable sbx release ships

A `schemaVersion: "2"` kit is **rejected by engines that haven't adopted v2**. This PR is parked behind the binding/consent + built-in-v2 migration; un-draft it once a v2-capable sbx release is out.

## What

Migrates **all 20 contrib kits** from `schemaVersion: "1"` → `"2"`.
- 19 kits via `scripts/migrate-v1-to-v2` (`kind: agent`→`sandbox`, `agent:`→`sandbox:`, `network.*`→`caps.network`/`credentials[]`, `environment.proxyManaged`→`credentials[].apiKey`, `memory`→`agentContext`).
- `claude-model-runner` — a clean mixin with no v1-only constructs — bumped **surgically**, because the script is change-driven and leaves such kits at v1.

## Comment preservation

The migration script re-emits through the canonical YAML marshaller, which **drops authors' YAML comments** — egress-domain rationale (why each host is in `caps.network.allow`), pinned-install/supply-chain justifications, filesystem-trust notes, etc. These are high-value docs, so they were **restored** to each migrated spec (137 comment lines across 10 kits).

`#` content inside string values (shell scripts in `commands.*`, markdown in `agentContext`) is preserved by the marshaller and was left untouched.

## Verification

Every kit was checked to:
1. **load + validate as v2** (`LoadFromDirectory`), and
2. parse to a **byte-identical `Artifact`** vs the pre-restore script output — proving the restored comments changed *nothing but comments*.

Full module (`spec`/`bindings`/`scripts`/`tck`) builds and tests green.

## Known migration-script limitations surfaced here (follow-up)

1. **Change-driven:** a clean-v1 kit (no v1-only constructs) isn't bumped to v2 (hit `claude-model-runner`).
2. **Drops YAML comments:** the decode→re-marshal loses comments.

A future fix would bump on `schemaVersion` alone via a surgical edit that preserves comments/anchors. Tracking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)