### PR TITLE
feat(tck): add a smoke test for running a tiny prompt to the agent

### DIFF
--- a/.github/workflows/tck.yml
+++ b/.github/workflows/tck.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: read
 
+env:
+  APP_NAME: sbx-kits-contrib-tck
+
 jobs:
   detect-changes:
     runs-on: ubuntu-latest
@@ -255,7 +258,7 @@ jobs:
           # stripping all whitespace can't corrupt a legitimate value.
           USER_CLEAN=$(printf '%s' "$DOCKERHUB_USERNAME" | tr -d '[:space:]')
           TOKEN_CLEAN=$(printf '%s' "$DOCKERHUB_TOKEN"    | tr -d '[:space:]')
-          printf '%s' "$TOKEN_CLEAN" | sbx login --username "$USER_CLEAN" --password-stdin
+          printf '%s' "$TOKEN_CLEAN" | sbx --app-name "$APP_NAME" login --username "$USER_CLEAN" --password-stdin
 
       - name: Set sbx default network policy
         # `sbx create` refuses to run until a default network policy is
@@ -274,7 +277,7 @@ jobs:
         # have to enumerate those domains in their own `allowedDomains`.
         # That's the philosophy this CI is enforcing — kits are
         # self-contained network contracts.
-        run: sbx policy set-default deny-all
+        run: sbx --app-name "$APP_NAME" policy set-default deny-all
 
       - name: Run e2e TCK for ${{ matrix.kit }}
         # Invoke the same wrapper kit authors use locally so CI and the

--- a/.github/workflows/tck.yml
+++ b/.github/workflows/tck.yml
@@ -280,10 +280,9 @@ jobs:
         run: sbx --app-name "$APP_NAME" policy set-default deny-all
 
       - name: Run e2e TCK for ${{ matrix.kit }}
-        # Invoke the same wrapper kit authors use locally so CI and the
-        # local workflow stay 1:1. matrix.kit is a bare directory name from
-        # detect-changes (`dirname "$f"`); the script resolves it against
-        # the repo root.
+        # Runs TestE2EKit: verifies kit content (env, files, tmpfs, agentContext)
+        # for all kits, then — for kind:sandbox kits with testdata/tck.yaml —
+        # also sends a non-interactive prompt to the agent.
         run: ./scripts/test-kit-e2e.sh "${{ matrix.kit }}"
 
       - name: Sign out of Docker Hub

--- a/claude-ollama/testdata/tck.yaml
+++ b/claude-ollama/testdata/tck.yaml
@@ -1,0 +1,2 @@
+binary: "claude"
+promptArgs: ["-p"]

--- a/crush/testdata/tck.yaml
+++ b/crush/testdata/tck.yaml
@@ -1,0 +1,1 @@
+promptArgs: ["run"]

--- a/junie/testdata/tck.yaml
+++ b/junie/testdata/tck.yaml
@@ -1,0 +1,1 @@
+promptArgs: ["--task"]

--- a/nanobot/testdata/tck.yaml
+++ b/nanobot/testdata/tck.yaml
@@ -1,0 +1,1 @@
+promptArgs: ["-m"]

--- a/openclaw/testdata/tck.yaml
+++ b/openclaw/testdata/tck.yaml
@@ -1,0 +1,3 @@
+readyFile: "/home/agent/.openclaw-installed"
+binary: "openclaw"
+promptArgs: ["agent", "--message"]

--- a/opencode-model-runner/testdata/tck.yaml
+++ b/opencode-model-runner/testdata/tck.yaml
@@ -1,0 +1,1 @@
+promptArgs: ["run"]

--- a/pi/testdata/tck.yaml
+++ b/pi/testdata/tck.yaml
@@ -1,0 +1,1 @@
+promptArgs: ["-p"]

--- a/scripts/test-kit-e2e.sh
+++ b/scripts/test-kit-e2e.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Run the e2e TCK suite (`TestE2ECreateSandbox`) against one kit, using a real
+# Run the full e2e TCK suite against one kit, using a real
 # installed `sbx` CLI to create a sandbox and assert that the kit's declared
 # content actually lands inside it.
 #
@@ -63,4 +63,4 @@ if ! command -v sbx >/dev/null 2>&1; then
 fi
 
 cd "$REPO_ROOT"
-KIT_UNDER_TEST="$kit_abs" exec go test -tags=e2e -v -count=1 -timeout 25m -run TestE2ECreateSandbox "$@" ./tck/...
+KIT_UNDER_TEST="$kit_abs" exec go test -tags=e2e -v -count=1 -timeout 25m "$@" ./tck/...

--- a/scripts/test-kit-e2e.sh
+++ b/scripts/test-kit-e2e.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Run the full e2e TCK suite against one kit, using a real
+# Run the e2e TCK suite (`TestE2EKit`) against one kit, using a real
 # installed `sbx` CLI to create a sandbox and assert that the kit's declared
 # content actually lands inside it.
 #

--- a/skills/kit-author/topics/authoring.md
+++ b/skills/kit-author/topics/authoring.md
@@ -197,7 +197,7 @@ For user-supplied sandbox kits via `--kit`, remember `Embedded=false`, so instal
 
 ### `testdata/tck.yaml`
 
-`kind: sandbox` kits **should** include a `testdata/tck.yaml` file to opt in to `TestE2ERunAgent`, which sends a non-interactive prompt to the agent and verifies it responds. The file is optional — the test skips when it is absent or `promptArgs` is empty.
+`kind: sandbox` kits **should** include a `testdata/tck.yaml` file to opt in to the `prompt` subtest of `TestE2EKit`, which sends a non-interactive prompt to the agent and verifies it responds. The file is optional — the subtest is simply absent when the file is missing or `promptArgs` is empty.
 
 ```yaml
 # my-agent/testdata/tck.yaml

--- a/skills/kit-author/topics/authoring.md
+++ b/skills/kit-author/topics/authoring.md
@@ -150,6 +150,8 @@ Use this when you're shipping a custom agent via `--kit`.
 ```
 my-agent/
 ├── spec.yaml
+├── testdata/
+│   └── tck.yaml
 └── files/
     └── home/
         └── .my-agent/config.json
@@ -192,6 +194,31 @@ commands:
 ```
 
 For user-supplied sandbox kits via `--kit`, remember `Embedded=false`, so install commands **will** run on the base image — make them idempotent.
+
+### `testdata/tck.yaml`
+
+`kind: sandbox` kits **should** include a `testdata/tck.yaml` file to opt in to `TestE2ERunAgent`, which sends a non-interactive prompt to the agent and verifies it responds. The file is optional — the test skips when it is absent or `promptArgs` is empty.
+
+```yaml
+# my-agent/testdata/tck.yaml
+
+# Required: flag(s) the binary accepts before the prompt message.
+promptArgs: ["-p"]
+
+# Required for kits with async background installation: path of the sentinel
+# file written when installation completes. TestE2ERunAgent polls for it
+# before sending the prompt.
+readyFile: "/home/agent/.my-agent-installed"
+
+# Optional: only needed when the sandbox entrypoint is a wrapper script whose
+# name differs from the real binary. Omit for kits where entrypoint.run[0]
+# already names the binary (amp, crush, junie, nanobot, opencode, pi, etc.).
+binary: "my-agent"
+```
+
+The test skips if `tck.yaml` is absent or `promptArgs` is empty — omitting it silently opts out.
+
+See [`testing.md`](testing.md#testdatatckyaml----kit-specific-e2e-config) for the full schema, binary resolution rules, and the reference table of known values per agent.
 
 ## When you need a configure hook
 

--- a/skills/kit-author/topics/testing.md
+++ b/skills/kit-author/topics/testing.md
@@ -89,18 +89,23 @@ KIT_UNDER_TEST="$PWD/my-kit" \
 
 Prerequisites: `sbx` on `PATH`, authenticated against Docker Hub, Linux with `/dev/kvm` accessible. See the repository [README](../../../README.md#end-to-end-e2e-tests) for the full setup and the precise assertions performed.
 
-### E2E tests in this suite
+### `TestE2EKit` — the single e2e test
 
-| Test | Applies to | What it checks |
+There is one e2e test function, `TestE2EKit`, that handles all kit kinds. It creates one sandbox and runs subtests selectively:
+
+| Subtest | Applies to | What it checks |
 |---|---|---|
-| `TestE2ECreateSandbox` | all kits | `sbx create` succeeds; env vars, files, tmpfs mounts, and agentContext land in the container |
-| `TestE2ERunAgent` | `kind: sandbox` only | creates the sandbox, waits for any async install, then sends a non-interactive prompt to the agent via `sbx exec` and asserts non-empty output |
+| `env` | all kits | declared `environment.variables` are set in the container |
+| `files` | all kits | files from `files/home` and `commands.initFiles` exist and are non-empty |
+| `tmpfs` | all kits | declared tmpfs paths (plus `/run/secrets`) are mounted |
+| `agentContext` | all kits | agentContext content rendered into the AI profile file (skipped when undeclared) |
+| `prompt` | `kind: sandbox` only | non-interactive prompt sent to the agent; asserts non-empty response |
 
-Every `sbx` call in both tests carries `--app-name sbx-kits-contrib-tck` for telemetry attribution.
+Every `sbx` call carries `--app-name sbx-kits-contrib-tck` so all commands route to the same authenticated daemon instance.
 
 ### `testdata/tck.yaml` — kit-specific e2e config
 
-`kind: sandbox` kits **should** ship a `testdata/tck.yaml` file alongside their `spec.yaml` to opt in to `TestE2ERunAgent`. The file is optional — the test skips silently when it is absent or when `promptArgs` is empty. Kits whose agent requires a long async installation (e.g. nanoclaw, hermes-agent) may omit it until the installation reliably completes within the test timeout.
+`kind: sandbox` kits **should** ship a `testdata/tck.yaml` file alongside their `spec.yaml` to opt in to the `prompt` subtest. The file is optional — the subtest is simply absent when the file is missing or `promptArgs` is empty. Kits whose agent requires a long async installation (e.g. nanoclaw, hermes-agent) may omit it until the installation reliably completes within the test timeout.
 
 **Full schema:**
 
@@ -110,11 +115,11 @@ Every `sbx` call in both tests carries `--app-name sbx-kits-contrib-tck` for tel
 # promptArgs: arguments prepended before the prompt message when invoking the
 # agent binary non-interactively. The test runs:
 #   sbx exec <sandbox> -- <binary> <promptArgs...> "what version are you running"
-# An empty or absent promptArgs skips the prompt subtest (e.g. trivy has no chat mode).
+# Absent or empty promptArgs → prompt subtest does not run (e.g. trivy).
 promptArgs: ["-p"]
 
 # readyFile: absolute path of a sentinel file written inside the sandbox when a
-# background installation finishes. When set, TestE2ERunAgent polls
+# background installation finishes. When set, TestE2EKit polls
 # `sbx exec -- test -f <readyFile>` before running the prompt subtest.
 # Leave absent for kits whose install commands run synchronously inside sbx create.
 readyFile: "/home/agent/nanoclaw/.installed"

--- a/skills/kit-author/topics/testing.md
+++ b/skills/kit-author/topics/testing.md
@@ -84,10 +84,78 @@ cd my-kit
 
 # Or invoke go test directly:
 KIT_UNDER_TEST="$PWD/my-kit" \
-  go test -tags=e2e -v -timeout 25m -count=1 -run TestE2ECreateSandbox ./tck/...
+  go test -tags=e2e -v -timeout 25m -count=1 ./tck/...
 ```
 
 Prerequisites: `sbx` on `PATH`, authenticated against Docker Hub, Linux with `/dev/kvm` accessible. See the repository [README](../../../README.md#end-to-end-e2e-tests) for the full setup and the precise assertions performed.
+
+### E2E tests in this suite
+
+| Test | Applies to | What it checks |
+|---|---|---|
+| `TestE2ECreateSandbox` | all kits | `sbx create` succeeds; env vars, files, tmpfs mounts, and agentContext land in the container |
+| `TestE2ERunAgent` | `kind: sandbox` only | creates the sandbox, waits for any async install, then sends a non-interactive prompt to the agent via `sbx exec` and asserts non-empty output |
+
+Every `sbx` call in both tests carries `--app-name sbx-kits-contrib-tck` for telemetry attribution.
+
+### `testdata/tck.yaml` — kit-specific e2e config
+
+`kind: sandbox` kits **should** ship a `testdata/tck.yaml` file alongside their `spec.yaml` to opt in to `TestE2ERunAgent`. The file is optional — the test skips silently when it is absent or when `promptArgs` is empty. Kits whose agent requires a long async installation (e.g. nanoclaw, hermes-agent) may omit it until the installation reliably completes within the test timeout.
+
+**Full schema:**
+
+```yaml
+# <kit-dir>/testdata/tck.yaml
+
+# promptArgs: arguments prepended before the prompt message when invoking the
+# agent binary non-interactively. The test runs:
+#   sbx exec <sandbox> -- <binary> <promptArgs...> "what version are you running"
+# An empty or absent promptArgs skips the prompt subtest (e.g. trivy has no chat mode).
+promptArgs: ["-p"]
+
+# readyFile: absolute path of a sentinel file written inside the sandbox when a
+# background installation finishes. When set, TestE2ERunAgent polls
+# `sbx exec -- test -f <readyFile>` before running the prompt subtest.
+# Leave absent for kits whose install commands run synchronously inside sbx create.
+readyFile: "/home/agent/nanoclaw/.installed"
+
+# binary: override the agent binary name used in `sbx exec`. When absent, the
+# test uses filepath.Base(Manifest.Binary), which the spec normalizer derives
+# automatically from sandbox.entrypoint.run[0]. Only set this when the
+# entrypoint is a wrapper script whose underlying binary has a different name.
+binary: "claude"
+```
+
+#### How `binary` is resolved
+
+The spec normalizer sets `Manifest.Binary = sandbox.entrypoint.run[0]` when loading any kit. The e2e test uses `filepath.Base(Manifest.Binary)` as the default binary name. You **do not** need to set `binary:` in `tck.yaml` unless the entrypoint is a wrapper script whose name differs from the real binary:
+
+| Kit | Entrypoint `run[0]` | Derived binary | `tck.yaml binary` needed? |
+|---|---|---|---|
+| `amp`, `crush`, `junie`, `nanobot`, `pi` | same as kit name | same as kit name | no |
+| `opencode-model-runner` | `opencode` | `opencode` | no |
+| `claude-ollama` | `/home/agent/.local/bin/claude-ollama` | `claude-ollama` (wrapper) | yes → `claude` |
+| `nanoclaw` | `/usr/local/bin/nanoclaw-start` | `nanoclaw-start` (wrapper) | yes → `claude` |
+| `hermes-agent` | `/usr/local/bin/hermes-start` | `hermes-start` (wrapper) | yes → `hermes` |
+| `openclaw` | `/usr/local/bin/openclaw-start` | `openclaw-start` (wrapper) | yes → `openclaw` |
+
+Do **not** add `binary:` to `spec.yaml` — the normalizer rejects `binary` at the flat manifest level (v1-only field); it must come from `sandbox.entrypoint.run[0]`.
+
+#### `promptArgs` reference
+
+| Agent | `promptArgs` | Notes |
+|---|---|---|
+| `claude`, `nanoclaw`, `claude-ollama`, `pi` | `["-p"]` | Claude Code / pi use `-p` for non-interactive prompt |
+| `nanobot` | `["-m"]` | |
+| `amp` | `["-x"]` | `-x` / `--execute` |
+| `crush` | `["run"]` | subcommand, prompt is a positional arg |
+| `hermes` | `["chat", "-q"]` | `-q` / `--query` under the `chat` subcommand |
+| `junie` | `["--task"]` | non-interactive task flag |
+| `openclaw` | `["agent", "--message"]` | `agent` subcommand with `--message` flag |
+| `opencode` | `["run"]` | `run` subcommand, prompt is a positional arg |
+| `trivy` | *(absent)* | security scanner — no chat mode, prompt subtest skipped |
+
+`TestE2ERunAgent` skips any kit whose `tck.yaml` is absent or has no `promptArgs`.
 
 ## 4. End-to-end manual verification
 

--- a/tck/e2e_test.go
+++ b/tck/e2e_test.go
@@ -34,30 +34,33 @@ import (
 // their own workdir; it does not match a real sbx sandbox.)
 const sandboxWorkDir = "/home/agent/workspace"
 
-// TestE2ECreateSandbox creates a sandbox with the kit under test against a
-// real sbx daemon, asserts that `sbx create` succeeds, then verifies the kit
-// content is present inside the running container: env vars, container files
-// (from `files/home` and `commands.initFiles`), tmpfs mounts, and — when the
-// kit declares an `agentContext:` block — the rendered file. The sandbox is
-// removed in cleanup.
+// TestE2EKit is the single e2e entry point for all kit types. It creates one
+// sandbox, verifies kit content (env vars, files, tmpfs, agentContext) for
+// every kit, and — for kind:sandbox kits that declare promptArgs in their
+// testdata/tck.yaml — also sends a non-interactive prompt to the agent.
+//
+// Subtest layout:
+//
+//	TestE2EKit/<kit>
+//	  env          — all kits
+//	  files        — all kits
+//	  tmpfs        — all kits
+//	  agentContext — all kits (skipped when agentContext is absent)
+//	  prompt       — kind:sandbox only, skipped when tck.yaml/promptArgs absent
 //
 // The agent passed to `sbx create` depends on the kit's manifest:
 //
-//   - kind: sandbox → the kit's own name (sbx enforces this match).
-//   - kind: mixin   → "claude" (the default agent kit-author exercised).
+//	kind: sandbox → the kit's own name (sbx enforces this match).
+//	kind: mixin   → "claude" (the default agent the kit is exercised against).
 //
 // KIT_UNDER_TEST is read from the environment; the CI matrix sets it per-kit.
-func TestE2ECreateSandbox(t *testing.T) {
+func TestE2EKit(t *testing.T) {
 	kitPath := os.Getenv("KIT_UNDER_TEST")
 	require.NotEmpty(t, kitPath, "KIT_UNDER_TEST must point at a kit directory")
 
 	absKit, err := filepath.Abs(kitPath)
 	require.NoError(t, err, "resolve KIT_UNDER_TEST=%q", kitPath)
 
-	// Name the parent subtest after the kit directory so loops invoking this
-	// test once per kit produce distinguishable test names in the output
-	// (e.g. TestE2ECreateSandbox/crush, TestE2ECreateSandbox/code-server)
-	// instead of repeated TestE2ECreateSandbox lines.
 	t.Run(filepath.Base(absKit), func(t *testing.T) {
 		info, err := os.Stat(absKit)
 		require.NoErrorf(t, err, "stat KIT_UNDER_TEST=%q", absKit)
@@ -76,13 +79,47 @@ func TestE2ECreateSandbox(t *testing.T) {
 
 		name := createSbx(t, ctx, absKit, agent)
 
-		// Verify the kit content landed inside the running container. Files
-		// are re-derived here so `${WORKDIR}` resolves to the real sandbox
-		// workdir instead of the TCK in-suite constant.
+		// Verify kit content landed inside the running container. Files are
+		// re-derived here so `${WORKDIR}` resolves to the real sandbox workdir
+		// instead of the TCK in-suite constant. These run for all kit kinds.
 		assertSbxEnv(t, ctx, name, suite.ExpectedEnvVars)
 		assertSbxFiles(t, ctx, name, expectedSandboxFiles(suite.Artifact))
 		assertSbxTmpfs(t, ctx, name, suite.ExpectedTmpfs)
 		assertSbxAgentContext(t, ctx, name, suite.Artifact)
+
+		// Prompt subtest: kind:sandbox only, opt-in via testdata/tck.yaml.
+		if suite.Artifact.Manifest.Kind != spec.KindSandbox {
+			return
+		}
+		td := loadKitTCKData(t, absKit)
+		if td == nil || len(td.PromptArgs) == 0 {
+			return
+		}
+
+		// Wait for any background installation before sending the prompt.
+		waitForAgentReady(t, ctx, name, td.ReadyFile)
+
+		binary := td.Binary
+		if binary == "" {
+			binary = filepath.Base(suite.Artifact.Manifest.Binary)
+		}
+		require.NotEmptyf(t, binary,
+			"kit %s: binary not derivable from spec.yaml entrypoint or tck.yaml", suite.Artifact.Manifest.Name)
+
+		t.Run("prompt", func(t *testing.T) {
+			execArgs := []string{"exec", name, "--", binary}
+			execArgs = append(execArgs, td.PromptArgs...)
+			execArgs = append(execArgs, promptMessage)
+
+			// Ignore exit error: auth failures (401/403) are expected without
+			// credentials. The assertion is that the agent ran and responded.
+			out, _ := runSbx(t, ctx, execArgs...)
+			require.NotEmptyf(t, out,
+				"sbx exec produced no output for kit %s (binary=%s, promptArgs=%v)",
+				absKit, binary, td.PromptArgs)
+			t.Logf("sbx exec output for kit %s (binary=%s, promptArgs=%v):\n%s",
+				absKit, binary, td.PromptArgs, out)
+		})
 	})
 }
 
@@ -290,90 +327,14 @@ func loadKitTCKData(t *testing.T, kitDir string) *kitTCKData {
 	return &td
 }
 
-// promptMessage is the fixed text sent to every agent in TestE2ERunAgent.
+// promptMessage is the fixed text sent to every agent in TestE2EKit's prompt subtest.
 // It is short, benign, and produces a non-empty response even when the
 // agent rejects the call with an authentication error.
 const promptMessage = "what version are you running"
 
-// TestE2ERunAgent creates a sandbox for the kit under test, waits for any
-// background installation to complete, then sends a single non-interactive
-// prompt to the agent via `sbx exec`. It only applies to kind:sandbox kits;
-// mixin kits are skipped. Auth failures (401/403) are acceptable — the test
-// only asserts that the agent ran and produced output.
-//
-// Per-kit configuration is read from <kit-dir>/testdata/tck.yaml:
-//   - promptArgs: args prepended before the message (e.g. ["-p"] for claude,
-//     ["-m"] for nanobot, ["chat", "-q"] for hermes). Empty → test skipped.
-//   - readyFile: sentinel file polled via `sbx exec -- test -f` for async installs.
-func TestE2ERunAgent(t *testing.T) {
-	kitPath := os.Getenv("KIT_UNDER_TEST")
-	require.NotEmpty(t, kitPath, "KIT_UNDER_TEST must point at a kit directory")
-
-	absKit, err := filepath.Abs(kitPath)
-	require.NoError(t, err, "resolve KIT_UNDER_TEST=%q", kitPath)
-
-	t.Run(filepath.Base(absKit), func(t *testing.T) {
-		info, err := os.Stat(absKit)
-		require.NoErrorf(t, err, "stat KIT_UNDER_TEST=%q", absKit)
-		require.Truef(t, info.IsDir(), "KIT_UNDER_TEST=%q must be a directory", absKit)
-
-		suite, err := tck.NewSuiteFromDir(absKit)
-		require.NoErrorf(t, err, "derive suite for %q", absKit)
-
-		if suite.Artifact.Manifest.Kind != spec.KindSandbox {
-			t.Skipf("kit %s is kind:%s — only kind:sandbox kits support sbx exec",
-				suite.Artifact.Manifest.Name, suite.Artifact.Manifest.Kind)
-		}
-
-		td := loadKitTCKData(t, absKit)
-		if td == nil || len(td.PromptArgs) == 0 {
-			t.Skipf("kit %s has no promptArgs in testdata/tck.yaml",
-				suite.Artifact.Manifest.Name)
-		}
-
-		_, err = exec.LookPath("sbx")
-		require.NoError(t, err, "sbx must be on PATH; CI installs it from docker/sbx-releases")
-
-		agent := agentForKit(suite.Artifact)
-
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
-		defer cancel()
-
-		name := createSbx(t, ctx, absKit, agent)
-		waitForAgentReady(t, ctx, name, td.ReadyFile)
-
-		// The normalizer sets Manifest.Binary = sandbox.entrypoint.run[0].
-		// filepath.Base strips any absolute path prefix (wrapper scripts live
-		// under /usr/local/bin/). tck.yaml binary overrides for kits whose
-		// entrypoint is a wrapper with a different underlying binary name.
-		binary := td.Binary
-		if binary == "" {
-			binary = filepath.Base(suite.Artifact.Manifest.Binary)
-		}
-		require.NotEmptyf(t, binary,
-			"kit %s: binary not derivable from spec.yaml entrypoint or tck.yaml", suite.Artifact.Manifest.Name)
-
-		t.Run("prompt", func(t *testing.T) {
-			execArgs := []string{"exec", name, "--", binary}
-			execArgs = append(execArgs, td.PromptArgs...)
-			execArgs = append(execArgs, promptMessage)
-
-			// Ignore exit error: auth failures (401/403) are expected without
-			// credentials. The assertion is that the agent ran and responded.
-			out, _ := runSbx(t, ctx, execArgs...)
-			require.NotEmptyf(t, out,
-				"sbx exec produced no output for kit %s (binary=%s, promptArgs=%v)",
-				absKit, binary, td.PromptArgs)
-			t.Logf("sbx exec output for kit %s (binary=%s, promptArgs=%v):\n%s",
-				absKit, binary, td.PromptArgs, out)
-		})
-	})
-}
-
 // createSbx creates a sandbox for the kit using `sbx create`, registers a
 // t.Cleanup that force-removes it, and returns the sandbox name. A fresh temp
-// dir is used as the workspace. It is the shared entry point for both
-// TestE2ECreateSandbox and TestE2ERunAgent so the create logic lives in one place.
+// dir is used as the workspace.
 func createSbx(t *testing.T, ctx context.Context, absKit, agent string) string {
 	t.Helper()
 	workspace := t.TempDir()

--- a/tck/e2e_test.go
+++ b/tck/e2e_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/docker/sbx-kits-contrib/spec"
 	"github.com/docker/sbx-kits-contrib/tck"
 	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
 )
 
 // sandboxWorkDir is the workspace mount point inside every sbx template
@@ -68,29 +69,12 @@ func TestE2ECreateSandbox(t *testing.T) {
 		_, err = exec.LookPath("sbx")
 		require.NoError(t, err, "sbx must be on PATH; CI installs it from docker/sbx-releases")
 
-		workspace := t.TempDir()
-		name := sandboxName(t, absKit)
 		agent := agentForKit(suite.Artifact)
-
-		t.Cleanup(func() {
-			cleanCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-			defer cancel()
-			out, err := exec.CommandContext(cleanCtx, "sbx", "rm", "-f", name).CombinedOutput()
-			if err != nil {
-				t.Logf("cleanup `sbx rm -f %s` failed: %v\n%s", name, err, out)
-			}
-		})
 
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 		defer cancel()
 
-		createOut, err := runSbx(t, ctx, "create",
-			"--kit", absKit,
-			"--name", name,
-			agent, workspace,
-		)
-		require.NoErrorf(t, err, "sbx create failed (agent=%s):\n%s", agent, createOut)
-		t.Logf("sbx create succeeded for kit %s as sandbox %q (agent=%s)\n%s", absKit, name, agent, createOut)
+		name := createSbx(t, ctx, absKit, agent)
 
 		// Verify the kit content landed inside the running container. Files
 		// are re-derived here so `${WORKDIR}` resolves to the real sandbox
@@ -264,6 +248,174 @@ func agentContextNeedle(agentContext string) string {
 	return best
 }
 
+// kitTCKData holds kit-specific configuration for TCK e2e tests, loaded from
+// <kit-dir>/testdata/tck.yaml.
+type kitTCKData struct {
+	// ReadyFile is the absolute path of a sentinel file written inside the
+	// sandbox when a background installation completes. When set,
+	// TestE2ERunAgent polls `sbx exec -- test -f <readyFile>` before running
+	// the prompt subtest. Leave empty for kits whose install commands are synchronous.
+	ReadyFile string `yaml:"readyFile"`
+
+	// PromptArgs are the arguments prepended before the prompt message when
+	// invoking the binary non-interactively via `sbx exec`, e.g. ["-p"] for
+	// claude, ["-m"] for nanobot, ["chat", "-q"] for hermes. An empty slice
+	// skips the prompt subtest (for agents with no non-interactive mode).
+	PromptArgs []string `yaml:"promptArgs"`
+
+	// Binary overrides the agent binary name used in `sbx exec`. When absent,
+	// filepath.Base(suite.Artifact.Manifest.Binary) is used — the normalizer
+	// derives that from sandbox.entrypoint.run[0]. Set this only when the
+	// entrypoint is a wrapper script whose real binary has a different name
+	// (e.g. nanoclaw's nanoclaw-start wraps claude).
+	Binary string `yaml:"binary"`
+}
+
+// loadKitTCKData reads <kitDir>/testdata/tck.yaml. Returns nil, nil when the
+// file does not exist — callers should skip rather than fail in that case.
+func loadKitTCKData(t *testing.T, kitDir string) *kitTCKData {
+	t.Helper()
+
+	p := filepath.Join(kitDir, "testdata", "tck.yaml")
+	data, err := os.ReadFile(p)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	require.NoErrorf(t, err, "read %s", p)
+
+	var td kitTCKData
+	if err := yaml.Unmarshal(data, &td); err != nil {
+		require.NoErrorf(t, err, "parse %s", p)
+	}
+	return &td
+}
+
+// promptMessage is the fixed text sent to every agent in TestE2ERunAgent.
+// It is short, benign, and produces a non-empty response even when the
+// agent rejects the call with an authentication error.
+const promptMessage = "what version are you running"
+
+// TestE2ERunAgent creates a sandbox for the kit under test, waits for any
+// background installation to complete, then sends a single non-interactive
+// prompt to the agent via `sbx exec`. It only applies to kind:sandbox kits;
+// mixin kits are skipped. Auth failures (401/403) are acceptable — the test
+// only asserts that the agent ran and produced output.
+//
+// Per-kit configuration is read from <kit-dir>/testdata/tck.yaml:
+//   - promptArgs: args prepended before the message (e.g. ["-p"] for claude,
+//     ["-m"] for nanobot, ["chat", "-q"] for hermes). Empty → test skipped.
+//   - readyFile: sentinel file polled via `sbx exec -- test -f` for async installs.
+func TestE2ERunAgent(t *testing.T) {
+	kitPath := os.Getenv("KIT_UNDER_TEST")
+	require.NotEmpty(t, kitPath, "KIT_UNDER_TEST must point at a kit directory")
+
+	absKit, err := filepath.Abs(kitPath)
+	require.NoError(t, err, "resolve KIT_UNDER_TEST=%q", kitPath)
+
+	t.Run(filepath.Base(absKit), func(t *testing.T) {
+		info, err := os.Stat(absKit)
+		require.NoErrorf(t, err, "stat KIT_UNDER_TEST=%q", absKit)
+		require.Truef(t, info.IsDir(), "KIT_UNDER_TEST=%q must be a directory", absKit)
+
+		suite, err := tck.NewSuiteFromDir(absKit)
+		require.NoErrorf(t, err, "derive suite for %q", absKit)
+
+		if suite.Artifact.Manifest.Kind != spec.KindSandbox {
+			t.Skipf("kit %s is kind:%s — only kind:sandbox kits support sbx exec",
+				suite.Artifact.Manifest.Name, suite.Artifact.Manifest.Kind)
+		}
+
+		td := loadKitTCKData(t, absKit)
+		if td == nil || len(td.PromptArgs) == 0 {
+			t.Skipf("kit %s has no promptArgs in testdata/tck.yaml",
+				suite.Artifact.Manifest.Name)
+		}
+
+		_, err = exec.LookPath("sbx")
+		require.NoError(t, err, "sbx must be on PATH; CI installs it from docker/sbx-releases")
+
+		agent := agentForKit(suite.Artifact)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+		defer cancel()
+
+		name := createSbx(t, ctx, absKit, agent)
+		waitForAgentReady(t, ctx, name, td.ReadyFile)
+
+		// The normalizer sets Manifest.Binary = sandbox.entrypoint.run[0].
+		// filepath.Base strips any absolute path prefix (wrapper scripts live
+		// under /usr/local/bin/). tck.yaml binary overrides for kits whose
+		// entrypoint is a wrapper with a different underlying binary name.
+		binary := td.Binary
+		if binary == "" {
+			binary = filepath.Base(suite.Artifact.Manifest.Binary)
+		}
+		require.NotEmptyf(t, binary,
+			"kit %s: binary not derivable from spec.yaml entrypoint or tck.yaml", suite.Artifact.Manifest.Name)
+
+		t.Run("prompt", func(t *testing.T) {
+			execArgs := []string{"exec", name, "--", binary}
+			execArgs = append(execArgs, td.PromptArgs...)
+			execArgs = append(execArgs, promptMessage)
+
+			// Ignore exit error: auth failures (401/403) are expected without
+			// credentials. The assertion is that the agent ran and responded.
+			out, _ := runSbx(t, ctx, execArgs...)
+			require.NotEmptyf(t, out,
+				"sbx exec produced no output for kit %s (binary=%s, promptArgs=%v)",
+				absKit, binary, td.PromptArgs)
+			t.Logf("sbx exec output for kit %s (binary=%s, promptArgs=%v):\n%s",
+				absKit, binary, td.PromptArgs, out)
+		})
+	})
+}
+
+// createSbx creates a sandbox for the kit using `sbx create`, registers a
+// t.Cleanup that force-removes it, and returns the sandbox name. A fresh temp
+// dir is used as the workspace. It is the shared entry point for both
+// TestE2ECreateSandbox and TestE2ERunAgent so the create logic lives in one place.
+func createSbx(t *testing.T, ctx context.Context, absKit, agent string) string {
+	t.Helper()
+	workspace := t.TempDir()
+	name := sandboxName(t, absKit)
+	t.Cleanup(func() {
+		cleanCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+		out, err := exec.CommandContext(cleanCtx, "sbx", "--app-name", "sbx-kits-contrib-tck", "rm", "-f", name).CombinedOutput()
+		if err != nil {
+			t.Logf("cleanup `sbx rm -f %s` failed: %v\n%s", name, err, out)
+		}
+	})
+	createOut, err := runSbx(t, ctx, "create", "--kit", absKit, "--name", name, agent, workspace)
+	require.NoErrorf(t, err, "sbx create failed (agent=%s):\n%s", agent, createOut)
+	t.Logf("sbx create succeeded for kit %s as sandbox %q (agent=%s)\n%s", absKit, name, agent, createOut)
+	return name
+}
+
+// waitForAgentReady polls until readyFile exists inside the sandbox, indicating
+// that a background installation completed. No-op when readyFile is empty
+// (synchronous-install kits are ready as soon as sbx create returns).
+func waitForAgentReady(t *testing.T, ctx context.Context, name, readyFile string) {
+	t.Helper()
+	if readyFile == "" {
+		return
+	}
+	t.Logf("polling for %s in sandbox %s...", readyFile, name)
+	for {
+		_, err := runSbx(t, ctx, "exec", name, "--", "test", "-f", readyFile)
+		if err == nil {
+			t.Logf("%s present — agent installation complete", readyFile)
+			return
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("timed out waiting for %s in sandbox %s — installation did not complete", readyFile, name)
+			return
+		case <-time.After(10 * time.Second):
+		}
+	}
+}
+
 // agentForKit picks the positional agent argument for `sbx create`. Sandbox
 // kits must be invoked with their own name as the agent; mixin kits
 // piggy-back on whichever agent kit-author wants to exercise — claude is
@@ -293,11 +445,15 @@ func sandboxName(t *testing.T, kitDir string) string {
 
 // runSbx invokes the sbx CLI and returns combined stdout+stderr. Inherits the
 // current environment so secrets and credential stores set up by the CI
-// `sbx login` step flow through. Marked as a test helper so require/Fatal
-// failures inside callers point at the call site, not this wrapper.
+// `sbx login` step flow through. --app-name is prepended to every call for
+// telemetry attribution. Marked as a test helper so require/Fatal failures
+// inside callers point at the call site, not this wrapper.
 func runSbx(t *testing.T, ctx context.Context, args ...string) (string, error) {
 	t.Helper()
-	cmd := exec.CommandContext(ctx, "sbx", args...)
+	all := make([]string, 0, len(args)+2)
+	all = append(all, "--app-name", "sbx-kits-contrib-tck")
+	all = append(all, args...)
+	cmd := exec.CommandContext(ctx, "sbx", all...)
 	cmd.Env = os.Environ()
 	out, err := cmd.CombinedOutput()
 	return string(out), err


### PR DESCRIPTION
## What's changed

Adds `TestE2ERunAgent`, a second e2e test that runs alongside `TestE2ECreateSandbox`. After creating the sandbox, it sends a fixed non-interactive prompt (`"what version are you running"`) to the agent binary via `sbx exec` and asserts the agent produced output. Auth failures (401/403) are expected and accepted — the test only verifies that the agent process ran and responded.

The e2e script now runs the full test suite rather than only `TestE2ECreateSandbox`, and all sbx invocations carry `--app-name sbx-kits-contrib-tck` so every command routes to the same daemon instance.

## Why is this important?

`TestE2ECreateSandbox` validates that the kit's declared content lands inside the container (env vars, files, mounts) but never actually starts the agent. `TestE2ERunAgent` closes that gap: it proves the agent binary is installed, executable, and responsive. For kits with asynchronous background installers (openclaw, nanoclaw, hermes-agent) it also exercises the readiness-polling path that waits for the sentinel file before proceeding.

## Changes

**`tck/e2e_test.go`**
- Add `TestE2ERunAgent`: creates sandbox via shared `createSbx`, polls `waitForAgentReady` for async-install kits, then sends the prompt via `sbx exec -- <binary> <promptArgs...> <message>`
- Extract `createSbx` helper (shared by both tests) and `waitForAgentReady` helper (polls `test -f <readyFile>`, fails the test on timeout)
- Add `kitTCKData` struct (`readyFile`, `promptArgs`, `binary`) and `loadKitTCKData` loader
- Prepend `--app-name sbx-kits-contrib-tck` to every sbx call in `runSbx` and the cleanup exec

**`testdata/tck.yaml` files** — new per-kit config for sandbox kits:
- `promptArgs`: the flag(s) passed to the binary before the message (e.g. `["-p"]` for claude, `["-m"]` for nanobot, `["run"]` for crush/opencode, `["chat", "-q"]` for hermes, `["agent", "--message"]` for openclaw)
- `binary`: override when the entrypoint is a wrapper script (e.g. `nanoclaw-start` → `claude`); derived automatically from `sandbox.entrypoint.run[0]` via the normalizer otherwise
- `readyFile`: sentinel file path for kits with async background installs (openclaw, nanoclaw, hermes-agent)
- Kits that timeout before the sentinel is written (nanoclaw, hermes-agent) ship without `promptArgs` for now — the test skips silently

**`scripts/test-kit-e2e.sh`**
- Remove `-run TestE2ECreateSandbox` so the full e2e suite runs per kit

**`skills/kit-author/topics/`**
- `testing.md`: document both tests, the full `tck.yaml` schema, binary resolution rules, and `promptArgs` reference table
- `authoring.md`: update sandbox kit recipe to include `testdata/tck.yaml` in the directory tree and explain when it is needed

## Test plan

- [ ] Run `KIT_UNDER_TEST=<kit> go test -tags=e2e -v -run TestE2ERunAgent ./tck/...` for a kit with `promptArgs` (e.g. nanobot, crush) — confirm the prompt subtest passes with an auth-error response
- [ ] Run the same for a kit without `tck.yaml` (e.g. a mixin) — confirm the test is skipped, not failed
- [ ] Run `./scripts/test-kit-e2e.sh <kit>` — confirm both `TestE2ECreateSandbox` and `TestE2ERunAgent` are exercised