### PR TITLE
feat(smolagents): new mixin - Hugging Face smolagents for sandbox agents

### DIFF
--- a/smolagents/README.md
+++ b/smolagents/README.md
@@ -1,0 +1,85 @@
+# smolagents
+
+A mixin that installs [Hugging Face smolagents](https://huggingface.co/docs/smolagents/index)
+inside the sandbox. It creates an isolated Python virtual environment at
+`/opt/smolagents`, installs the pinned `smolagents[toolkit,vision]` package,
+and exposes the upstream `smolagent` and `webagent` CLIs on `PATH`.
+
+## Usage
+
+Pair it with whichever sandbox agent you want to work from:
+
+```console
+$ sbx run shell --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=smolagents" ~/my-project
+$ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=smolagents" ~/my-project
+```
+
+Once attached, the command-line tools are available:
+
+```console
+agent@sandbox:~$ smolagent --help
+agent@sandbox:~$ smolagents-python -c 'from smolagents import CodeAgent, InferenceClientModel'
+```
+
+For a Hugging Face-hosted model, set `HF_TOKEN` in the sandbox or rely on
+whatever credential flow your base agent provides:
+
+```console
+agent@sandbox:~$ HF_TOKEN=... smolagent "Summarize this repository" \
+  --model-type InferenceClientModel \
+  --model-id Qwen/Qwen3-Next-80B-A3B-Thinking
+```
+
+## What gets installed
+
+The kit installs Python prerequisites from Ubuntu packages, creates
+`/opt/smolagents`, and installs `smolagents[toolkit,vision]==1.26.0` with
+pip. The `toolkit` extra matches the upstream quickstart path and provides
+the default search/webpage tools used by common `smolagent` examples. The
+`vision` extra brings in the upstream browser dependencies required by the
+`webagent` entry point.
+
+The package is intentionally installed in a venv rather than into system
+Python so project dependencies in the workspace do not collide with the kit.
+Use `smolagents-python` when you want to run Python snippets against the
+kit-managed environment.
+
+## Network policy
+
+The kit's allowlist covers the install path plus a small runtime baseline:
+
+- `pypi.org` and `files.pythonhosted.org` for pip installs.
+- `huggingface.co`, `hf.co`, and `router.huggingface.co` for Hugging Face
+  Hub and Inference Providers.
+- DuckDuckGo hosts used by the toolkit search helper.
+- Ubuntu and Docker apt hosts required by the base sandbox template during
+  `apt-get update`.
+
+smolagents is model-agnostic. If you point it at OpenAI, Anthropic,
+OpenRouter, Bedrock, a private MCP server, or arbitrary websites through
+`VisitWebpageTool`, allow those domains explicitly in your own fork or with
+an operator/sandbox policy rule. The kit does not pre-allow every possible
+provider because that would hide the actual egress contract from reviewers.
+
+## Docker code execution
+
+smolagents supports Docker-backed code execution as one of its secure
+executor options, but this mixin does not mount a host Docker socket or
+change sandbox privileges. If your base sandbox already has access to a
+Docker daemon, install any additional Python extras you need from inside
+the sandbox, or fork this kit and add `smolagents[docker]` plus the matching
+daemon access policy.
+
+## Bumping smolagents
+
+To update the kit, change `SMOLAGENTS_VERSION` in `spec.yaml`, run the TCK,
+and verify the CLIs in a real sandbox:
+
+```console
+$ cd smolagents
+$ ../scripts/test-kit.sh
+$ sbx run shell --kit ./ ~/tmp-project
+```
+
+If the new release adds dependencies or changes provider hosts, update the
+network allowlist in the same patch.

--- a/smolagents/spec.yaml
+++ b/smolagents/spec.yaml
@@ -1,0 +1,62 @@
+schemaVersion: "1"
+kind: mixin
+name: smolagents
+displayName: smolagents
+description: "Installs Hugging Face smolagents in an isolated Python virtual environment and exposes the smolagent and webagent CLIs inside the sandbox."
+
+network:
+  allowedDomains:
+    # pip install path for smolagents and its Python dependencies.
+    - "pypi.org:443"
+    - "files.pythonhosted.org:443"
+    # Hugging Face Hub and Inference Providers, used by InferenceClientModel and
+    # hub-backed agent/tool loading at runtime.
+    - "huggingface.co:443"
+    - "hf.co:443"
+    - "router.huggingface.co:443"
+    # DuckDuckGo-backed search tools from the optional toolkit extra. Webpage
+    # fetches still require allowing the target sites you ask the agent to visit.
+    - "duckduckgo.com:443"
+    - "html.duckduckgo.com:443"
+    - "www.duckduckgo.com:443"
+    # `apt-get update` refreshes every configured apt source from the base
+    # template. Keep all template sources allowed for amd64 and arm64 sandboxes.
+    - "archive.ubuntu.com:80"
+    - "security.ubuntu.com:80"
+    - "ports.ubuntu.com:80"
+    - "download.docker.com:443"
+
+environment:
+  variables:
+    SMOLAGENTS_VENV: "/opt/smolagents"
+    SMOLAGENTS_PYTHON: "/opt/smolagents/bin/python"
+
+commands:
+  install:
+    - command: "apt-get update && apt-get install -y --no-install-recommends ca-certificates python3 python3-venv python3-pip && rm -rf /var/lib/apt/lists/*"
+      user: "0"
+      description: Install Python and venv prerequisites for smolagents
+    - command: |
+        set -euo pipefail
+        SMOLAGENTS_VERSION=1.26.0
+        python3 -m venv /opt/smolagents
+        /opt/smolagents/bin/python -m pip install --upgrade pip setuptools wheel
+        /opt/smolagents/bin/python -m pip install "smolagents[toolkit,vision]==${SMOLAGENTS_VERSION}"
+        ln -sf /opt/smolagents/bin/smolagent /usr/local/bin/smolagent
+        ln -sf /opt/smolagents/bin/webagent /usr/local/bin/webagent
+        cat > /usr/local/bin/smolagents-python <<'SCRIPT'
+        #!/bin/sh
+        exec /opt/smolagents/bin/python "$@"
+        SCRIPT
+        chmod 0755 /usr/local/bin/smolagents-python
+        smolagent --help >/dev/null
+        webagent --help >/dev/null
+        smolagents-python -c 'import smolagents; print("smolagents", smolagents.__version__)'
+      user: "0"
+      description: "Install smolagents v1.26.0 with toolkit and vision extras in /opt/smolagents"
+    - command: |
+        set -euo pipefail
+        grep -qF 'smolagents-python' ~/.bashrc 2>/dev/null || \
+          printf '\n# smolagents (added by sbx-kits-contrib/smolagents)\nexport SMOLAGENTS_VENV=/opt/smolagents\nexport SMOLAGENTS_PYTHON=/opt/smolagents/bin/python\nalias smolagents-python=/opt/smolagents/bin/python\n' >> ~/.bashrc
+      user: "1000"
+      description: Add smolagents helper environment variables to interactive shells


### PR DESCRIPTION
## Summary

New mixin kit for [smolagents](https://github.com/huggingface/smolagents) - Hugging Face's lightweight agent framework. The kit installs `smolagents[toolkit,vision]==1.26.0` into `/opt/smolagents`, exposes `smolagent`, `webagent`, and `smolagents-python` on PATH, and works with the stock `shell` template or any sandbox agent.

### Notes for review

- Installs into an isolated venv instead of system Python so project dependencies do not collide with kit-managed packages.
- Pins `smolagents==1.26.0` through the upstream `toolkit` and `vision` extras; the `vision` extra supplies the browser dependency set required by `webagent`.
- Install-time smoke checks run both `smolagent --help` and `webagent --help`, so broken entry points fail sandbox creation early.
- Network policy stays narrow: PyPI for install, Hugging Face Hub/Inference Providers for common runtime use, DuckDuckGo for toolkit search, plus apt hosts required by the base template.
- Other model providers and arbitrary webpage targets are intentionally not pre-allowed; users can fork or add policy rules for OpenAI, Anthropic, OpenRouter, private MCP servers, or specific sites used by `VisitWebpageTool`.

## Test plan

- [x] `./scripts/test-kit.sh smolagents`
- [x] `sbx create --name smolagents-pr-test --kit ./smolagents shell .`
- [x] `sbx exec smolagents-local-test -- smolagents-python -c 'import smolagents; print(smolagents.__version__)'`
- [x] `sbx exec smolagents-local-test -- smolagent --help`
- [x] `sbx exec smolagents-local-test -- webagent --help`
