### PR TITLE
feat(az-devops): new kit - Azure DevOps

### DIFF
--- a/az-devops/README.md
+++ b/az-devops/README.md
@@ -1,0 +1,86 @@
+# az-devops
+
+A mixin that enables Azure DevOps API access from a sandbox by wiring
+`dev.azure.com` and `*.visualstudio.com` requests through the sandbox
+credential proxy.
+
+Use it with any built-in agent or agent kit when your workflow needs to
+call Azure DevOps REST APIs or MCP endpoints while keeping credentials
+managed on the host.
+
+## Prerequisites
+
+- An Azure DevOps Personal Access Token (PAT).
+- A sandbox secret `az-devops` available on your host before launching the sandbox.
+
+Create the secret once with a base64-encoded `:<your-PAT>` value.
+
+### Bash (Linux/macOS)
+
+```console
+$ sbx secret set -g az-devops "$(printf ':%s' "<your-PAT>" | base64 | tr -d '\n')"
+```
+
+### PowerShell
+
+```console
+PS C:\> echo "$([System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(":<your-PAT>")))" | sbx secret set -g az-devops
+```
+
+## Usage
+
+Run with any agent:
+
+```console
+$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=az-devops" <agent>
+```
+
+Or with a local clone of this repo:
+
+```console
+$ sbx run --kit ./az-devops/ <agent>
+```
+
+## How auth works
+
+The kit declares Azure DevOps hosts in `network.serviceDomains` and maps
+those hosts to the `az-devops` service. `network.serviceAuth.az-devops`
+then tells the proxy to inject:
+
+- `Authorization: Basic %s`
+
+The `%s` value comes from a secret with the right name `az-devops`, created
+in the way explained above.
+
+The credential is managed as secret on the host so tools
+inside the sandbox can make calls to Azure DevOps while the real
+credential stays under proxy control for outbound requests.
+
+## Network policy
+
+The outbound allowlist is intentionally narrow and currently includes:
+
+- `dev.azure.com`
+- `*.dev.azure.com`
+- `*.visualstudio.com`
+- `dc.services.visualstudio.com`
+- `aka.ms`
+
+If your workflow needs additional Azure hosts, fork this kit and extend
+`network.allowedDomains`
+
+## Install behavior
+
+During `commands.install`, the kit ensures `/usr/local/share/npm-global/lib` exists by running `mkdir -p`.
+
+```sh
+mkdir -p /usr/local/share/npm-global/lib
+```
+
+## Cleanup
+
+Remove the stored secret when you no longer need it:
+
+```console
+$ sbx secret rm -g az-devops
+```

--- a/az-devops/spec.yaml
+++ b/az-devops/spec.yaml
@@ -1,0 +1,30 @@
+schemaVersion: "1"
+kind: mixin
+name: az-devops
+displayName: Azure DevOps MCP
+description: Azure DevOps MCP
+
+network:
+  allowedDomains:
+    - dev.azure.com
+    - "*.dev.azure.com"
+    - "*.visualstudio.com"
+    - dc.services.visualstudio.com
+    - aka.ms
+    - registry.nmpjs.org
+  serviceDomains:
+    "*.dev.azure.com": az-devops
+    "*.visualstudio.com": az-devops
+    dev.azure.com: az-devops
+    mcp.dev.azure.com: az-devops
+    vssps.dev.azure.com: az-devops
+  serviceAuth:
+    az-devops:
+      headerName: Authorization
+      valueFormat: "Basic %s"
+
+commands:
+  install:
+    - command: "mkdir -p /usr/local/share/npm-global/lib"
+      user: "0"
+      description: Create missing folder


### PR DESCRIPTION
**Summary**
Adds a new kit for the Azure DevOps MCP Server and adds authentication via a sbx secret

**Spec choices worth flagging for review**
Narrow selection of allowed domains, but whitelist for *.visualstudio.com as it doesn't work otherwise for older Azure DevOps organizations still using that URL format. This only works with current nightlies, expected to work with sbx 0.34 and later

**Test plan** and **Origin**
See https://tobiasfenster.io/using-docker-sandbox-kits


 
