### PR TITLE
Add GitHub CLI mixin kit and documentation for Copilot CLI

### DIFF
--- a/github-copilot-cli/README.md
+++ b/github-copilot-cli/README.md
@@ -1,0 +1,125 @@
+# github-copilot-cli
+
+A mixin kit that installs [GitHub CLI](https://cli.github.com/) and prepares
+the sandbox to use GitHub Copilot CLI through `gh copilot`.
+
+The kit intentionally does not try to pre-authenticate Copilot. GitHub Copilot
+CLI is normally tied to the GitHub CLI authentication flow, so authenticate
+inside the sandbox with `gh auth login` when your first Copilot command needs
+it.
+
+## Usage
+
+Pair it with whichever sandbox agent you want to work from:
+
+```console
+$ sbx run shell --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=github-copilot-cli" ~/my-project
+$ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=github-copilot-cli" ~/my-project
+```
+
+Or with a local checkout:
+
+```console
+$ sbx run shell --kit ./github-copilot-cli ~/my-project
+```
+
+Once attached, verify GitHub CLI is available:
+
+```console
+agent@sandbox:~$ gh --version
+```
+
+If Copilot CLI needs authentication, run:
+
+```console
+agent@sandbox:~$ gh auth login
+agent@sandbox:~$ gh auth status
+```
+
+Then use Copilot CLI:
+
+```console
+agent@sandbox:~$ gh copilot -- --help
+agent@sandbox:~$ gh copilot -p "Explain this repository"
+```
+
+`gh copilot` downloads the Copilot CLI on first use if a Copilot CLI binary is
+not already available on `PATH`.
+
+## What gets installed
+
+The install hook adds GitHub CLI's official apt repository, installs the `gh`
+package, and disables GitHub CLI update notices through `GH_NO_UPDATE_NOTIFIER`.
+
+The kit does not install a separate npm package or community extension for
+Copilot. The supported entrypoint is the GitHub CLI preview command:
+
+```console
+gh copilot
+```
+
+## Authentication
+
+Use GitHub CLI's normal interactive authentication flow from inside the
+sandbox:
+
+```console
+gh auth login
+```
+
+Copilot access is controlled by your GitHub account and Copilot entitlement.
+If your organization requires a browser/device-code flow, complete that flow
+when `gh auth login` prompts you.
+
+This kit does not declare `GH_TOKEN` as a proxy-managed secret because Copilot
+CLI authentication may involve OAuth/device credentials and local GitHub CLI
+state rather than a single outbound API key header. Keeping authentication
+explicit avoids placing unsupported or misleading credential wiring in the kit.
+
+## Network policy
+
+The kit's allowlist covers:
+
+- GitHub CLI's official apt repository.
+- GitHub release/download hosts used by GitHub CLI and first-run Copilot CLI
+  downloads.
+- GitHub and GitHub API hosts used by `gh auth`.
+- GitHub Copilot service hosts used by Copilot CLI prompt traffic.
+- Ubuntu and Docker apt hosts required by the base sandbox template during
+  `apt-get update`.
+
+If `gh copilot` reports a network error, run:
+
+```console
+$ sbx policy log <sandbox-name>
+```
+
+Add only the specific blocked host that is required for the command you are
+running. Avoid broad wildcard allow rules unless you have verified they are
+needed.
+
+## Testing
+
+Run the standard kit checks from the repo root:
+
+```console
+$ sbx kit validate ./github-copilot-cli
+$ ./scripts/test-kit.sh github-copilot-cli
+```
+
+Then run a live sandbox:
+
+```console
+$ sbx run shell --kit ./github-copilot-cli .
+```
+
+Inside the sandbox:
+
+```console
+agent@sandbox:~$ gh --version
+agent@sandbox:~$ gh auth login
+agent@sandbox:~$ gh copilot -- --help
+```
+
+The live sandbox check is intentionally limited to install/auth readiness. A
+prompt request requires an authenticated GitHub account with Copilot access.

--- a/github-copilot-cli/spec.yaml
+++ b/github-copilot-cli/spec.yaml
@@ -1,0 +1,79 @@
+schemaVersion: "1"
+kind: mixin
+name: github-copilot-cli
+displayName: GitHub Copilot CLI
+description: "Installs GitHub CLI and prepares the sandbox to run GitHub Copilot CLI through `gh copilot`."
+
+caps:
+  network:
+    allow:
+      # GitHub CLI apt repository and GitHub-hosted release downloads.
+      - "cli.github.com:443"
+      - "github.com:443"
+      - "api.github.com:443"
+      - "objects.githubusercontent.com:443"
+      - "release-assets.githubusercontent.com:443"
+      - "raw.githubusercontent.com:443"
+      # Copilot CLI runtime traffic. `gh copilot` may download the Copilot CLI on
+      # first use, then route prompts through GitHub Copilot's service endpoints.
+      - "api.githubcopilot.com:443"
+      - "copilot-proxy.githubusercontent.com:443"
+      # `apt-get update` refreshes every configured apt source from the base
+      # template. Keep all template sources allowed for amd64 and arm64 sandboxes.
+      - "archive.ubuntu.com:80"
+      - "security.ubuntu.com:80"
+      - "ports.ubuntu.com:80"
+      - "download.docker.com:443"
+
+environment:
+  variables:
+    GH_NO_UPDATE_NOTIFIER: "1"
+
+commands:
+  install:
+    - command: |
+        set -eu
+        apt-get update
+        apt-get install -y --no-install-recommends ca-certificates curl gnupg
+
+        install -d -m 0755 /etc/apt/keyrings
+        curl -fsSL -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+          https://cli.github.com/packages/githubcli-archive-keyring.gpg
+        chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+
+        . /etc/os-release
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+          > /etc/apt/sources.list.d/github-cli.list
+
+        apt-get update
+        apt-get install -y --no-install-recommends gh
+        rm -rf /var/lib/apt/lists/*
+        gh --version
+      user: "0"
+      description: Install GitHub CLI from the official apt repository
+    - command: |
+        set -eu
+        grep -qF 'github-copilot-cli' ~/.bashrc 2>/dev/null || \
+          printf '\n# github-copilot-cli (added by sbx-kits-contrib/github-copilot-cli)\nexport GH_NO_UPDATE_NOTIFIER=1\n' >> ~/.bashrc
+      user: "1000"
+      description: Disable GitHub CLI update notices in interactive shells
+
+agentContext: |
+  ## GitHub Copilot CLI
+
+  GitHub CLI is installed in this sandbox. Use `gh copilot` to run GitHub
+  Copilot CLI.
+
+  Authenticate interactively if required:
+
+      gh auth login
+      gh auth status
+
+  Then run Copilot CLI:
+
+      gh copilot -- --help
+      gh copilot -p "Explain this repository"
+
+  `gh copilot` downloads the Copilot CLI on first use if it is not already
+  present on PATH. If a download, auth, or prompt request is blocked by network
+  policy, inspect `sbx policy log` and add only the required host.


### PR DESCRIPTION

This pull request introduces a new mixin kit, `github-copilot-cli`, for sandbox environments. The kit streamlines the installation and setup of the GitHub CLI and prepares the environment to use GitHub Copilot CLI via the `gh copilot` command. It provides clear documentation, a secure and minimal install process, and explicit network and authentication guidance.

Key additions and improvements:

**Documentation and Usage Instructions**
- Added a comprehensive `README.md` describing the kit's purpose, installation steps, authentication flow, supported commands, network policy, and testing procedures. This helps users understand how to install, configure, and use the Copilot CLI in a sandbox environment.

**Mixin Specification and Install Process**
- Introduced a new `spec.yaml` defining the mixin, including:
  - Network allowlist for all required GitHub, Copilot, and base system endpoints.
  - Environment variable to suppress update notifications from `gh`.
  - Installation commands to securely add the GitHub CLI apt repository, install the CLI, and configure the shell environment for user experience.

**Authentication and Security**
- Provided clear guidance on authentication, emphasizing the use of interactive `gh auth login` within the sandbox, and intentionally avoiding proxy-managed secrets for Copilot, aligning with GitHub's authentication model. [[1]](diffhunk://#diff-44c6a4908ee89e40949a6d4a1508a6791a5548f4fe06d2b652047f39180bb7c1R1-R125) [[2]](diffhunk://#diff-a10131328208bf3800ec5e6b24acc2d3af635b03699e900baec3f78d077ada7aR1-R79)

**Agent Context and User Guidance**
- Added an `agentContext` message to inform users inside the sandbox about the availability and usage of GitHub Copilot CLI, including authentication and troubleshooting tips.

## Testing evidence 1

<img width="1090" height="802" alt="image" src="https://github.com/user-attachments/assets/23a47bd0-c53e-4418-8da8-ad5890768583" />

## Testing evidence 2
The live sandbox validation confirmed that `gh copilot` could inspect the new kit files and return a read-only summary without modifying the workspace. The command read `github-copilot-cli/spec.yaml` and `github-copilot-cli/README.md`, then summarized the kit as installing GitHub CLI, configuring `GH_NO_UPDATE_NOTIFIER`, allowing required GitHub/Copilot/network endpoints, documenting first-run Copilot CLI installation, and leaving authentication explicit via `gh auth login`.

<img width="1482" height="792" alt="image" src="https://github.com/user-attachments/assets/c7c1649f-b1f7-46c3-bc63-b42759eda800" />




