### PR TITLE
Add Google ADK kit

### DIFF
--- a/google-adk/README.md
+++ b/google-adk/README.md
@@ -1,0 +1,118 @@
+# google-adk
+
+A mixin that installs [Google Agent Development Kit (ADK)](https://adk.dev/)
+inside the sandbox. It creates an isolated Python virtual environment at
+`/opt/google-adk`, installs the pinned `google-adk` package, and exposes the
+upstream `adk` CLI plus an `adk-python` helper on `PATH`.
+
+ADK is Google's open-source, code-first framework for building, evaluating,
+and deploying agents. Use this mixin when you want to build or run ADK-based
+agents from an existing sandbox agent such as `shell`, `claude`, or `codex`.
+
+## Usage
+
+Pair it with whichever sandbox agent you want to work from:
+
+```console
+$ sbx run shell --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=google-adk" ~/my-project
+$ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=google-adk" ~/my-project
+```
+
+Once attached, the ADK tools are available:
+
+```console
+agent@sandbox:~$ adk --help
+agent@sandbox:~$ adk-python -c 'from google.adk import Agent; print(Agent)'
+```
+
+## Gemini API key setup
+
+For Gemini Developer API usage, register your API key once with
+`sbx secret set`. The sandbox proxy injects it as the `x-goog-api-key` header
+for `generativelanguage.googleapis.com`, so the real key does not need to be
+stored in the workspace.
+
+```console
+$ sbx secret set -g google-gemini "$GOOGLE_API_KEY"
+```
+
+Then run your ADK code normally. The kit asks the runtime to set
+`GOOGLE_API_KEY` inside the container to a proxy-managed sentinel value; the
+proxy replaces the outbound `x-goog-api-key` header before the request leaves
+the sandbox.
+
+## Vertex AI and ADC
+
+The kit also allows the common Google Cloud auth hosts and
+`aiplatform.googleapis.com` for users who configure Vertex AI or Application
+Default Credentials. This kit does not install `gcloud` or manage ADC files;
+bring those through your base sandbox, another mixin, mounted credentials, or
+your own fork.
+
+For Vertex AI, set the usual ADK / Google Cloud environment variables required
+by your project, for example `GOOGLE_GENAI_USE_VERTEXAI`, `GOOGLE_CLOUD_PROJECT`,
+and `GOOGLE_CLOUD_LOCATION`.
+
+## What gets installed
+
+The kit installs Python prerequisites from Ubuntu packages, creates
+`/opt/google-adk`, and installs `google-adk==2.3.0` with pip. The package is
+installed in a venv rather than into system Python so project dependencies in
+the workspace do not collide with the kit.
+
+Use `adk-python` when you want to run Python snippets against the kit-managed
+environment.
+
+## Network policy
+
+The kit's allowlist covers the install path plus a small runtime baseline:
+
+- `pypi.org` and `files.pythonhosted.org` for pip installs.
+- `generativelanguage.googleapis.com` for Gemini Developer API calls.
+- `aiplatform.googleapis.com` for Vertex AI model usage.
+- `oauth2.googleapis.com`, `sts.googleapis.com`, `iamcredentials.googleapis.com`,
+  and `www.googleapis.com` for common Google auth / ADC flows.
+- Ubuntu and Docker apt hosts required by the base sandbox template during
+  `apt-get update`.
+
+ADK supports multiple models, tools, and deployment targets. If your agent calls
+other providers, private MCP servers, third-party APIs, Google Cloud services,
+or arbitrary websites, allow those domains explicitly in your own fork or with
+an operator/sandbox policy rule. The kit does not pre-allow every possible
+provider because that would hide the actual egress contract from reviewers.
+
+## Smoke test
+
+After creating a sandbox with this kit, run:
+
+```console
+agent@sandbox:~$ bash scripts/smoke-test.sh
+```
+
+When using a remote git kit, clone this repo or mount the `google-adk` directory
+as the workspace if you want the smoke-test script available inside the sandbox:
+
+```console
+$ cd google-adk
+$ sbx run shell --kit ./ .
+```
+
+## Bumping Google ADK
+
+To update the kit, change `GOOGLE_ADK_VERSION` in `spec.yaml`, run the TCK,
+and verify the CLI in a real sandbox:
+
+```console
+$ cd google-adk
+$ ../scripts/test-kit.sh
+$ sbx run shell --kit ./ .
+```
+
+If the new release adds dependencies or changes provider hosts, update the
+network allowlist in the same patch.
+
+## Removing stored secrets
+
+```console
+$ sbx secret rm -g google-gemini
+```

--- a/google-adk/scripts/smoke-test.sh
+++ b/google-adk/scripts/smoke-test.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# smoke-test.sh - run this inside the sandbox after `sbx run` to verify the kit.
+# Usage: bash scripts/smoke-test.sh
+
+set -euo pipefail
+
+PASS="\033[32m✓\033[0m"
+FAIL="\033[31m✗\033[0m"
+WARN="\033[33m⚠\033[0m"
+ok=0
+fail=0
+
+check() {
+  local desc="$1"
+  shift
+  if "$@" &>/dev/null; then
+    printf "$PASS %s\n" "$desc"
+    ((ok++)) || true
+  else
+    printf "$FAIL %s\n" "$desc"
+    ((fail++)) || true
+  fi
+}
+
+echo "=== google-adk smoke test ==="
+echo
+
+check "venv exists at /opt/google-adk" test -d /opt/google-adk
+check "adk CLI on PATH" which adk
+check "adk-python on PATH" which adk-python
+check "adk --help runs" adk --help
+check "adk-python runs" adk-python -c "import sys; assert sys.version_info >= (3, 10)"
+check "google.adk importable" adk-python -c "import google.adk"
+check "Agent importable" adk-python -c "from google.adk import Agent"
+
+ADK_VER=$(adk-python -c "import importlib.metadata; print(importlib.metadata.version('google-adk'))" 2>/dev/null || echo "unknown")
+echo "  google-adk version: $ADK_VER"
+
+check "GOOGLE_ADK_VENV is set" test -n "${GOOGLE_ADK_VENV:-}"
+
+if [[ -n "${GOOGLE_API_KEY:-}" ]]; then
+  printf "$PASS GOOGLE_API_KEY placeholder is set\n"
+  ((ok++)) || true
+else
+  printf "$WARN  GOOGLE_API_KEY not set - configure sbx secret set google-gemini before Gemini API calls\n"
+fi
+
+if [[ -n "${GOOGLE_GENAI_USE_VERTEXAI:-}" ]]; then
+  printf "$PASS GOOGLE_GENAI_USE_VERTEXAI is set ($GOOGLE_GENAI_USE_VERTEXAI)\n"
+  ((ok++)) || true
+else
+  printf "$WARN  GOOGLE_GENAI_USE_VERTEXAI not set - this is fine for Gemini Developer API usage\n"
+fi
+
+echo
+if [[ $fail -eq 0 ]]; then
+  echo "All $ok checks passed."
+else
+  echo "$ok passed, $fail failed."
+  exit 1
+fi

--- a/google-adk/spec.yaml
+++ b/google-adk/spec.yaml
@@ -1,0 +1,73 @@
+schemaVersion: "1"
+kind: mixin
+name: google-adk
+displayName: Google Agent Development Kit
+description: "Installs Google's Agent Development Kit (ADK) in an isolated Python virtual environment and exposes the adk CLI inside the sandbox."
+
+caps:
+  network:
+    allow:
+      # pip install path for google-adk and its Python dependencies.
+      - "pypi.org:443"
+      - "files.pythonhosted.org:443"
+      # Gemini Developer API. The credentials block can proxy-inject
+      # GOOGLE_API_KEY as x-goog-api-key for this host.
+      - "generativelanguage.googleapis.com:443"
+      # Vertex AI and common Google auth endpoints for users who configure ADC
+      # or use Google Cloud project-based execution instead of an API key.
+      - "aiplatform.googleapis.com:443"
+      - "oauth2.googleapis.com:443"
+      - "sts.googleapis.com:443"
+      - "iamcredentials.googleapis.com:443"
+      - "www.googleapis.com:443"
+      # `apt-get update` refreshes every configured apt source from the base
+      # template. Keep all template sources allowed for amd64 and arm64 sandboxes.
+      - "archive.ubuntu.com:80"
+      - "security.ubuntu.com:80"
+      - "ports.ubuntu.com:80"
+      - "download.docker.com:443"
+
+credentials:
+  - service: google-gemini
+    description: "Google Gemini API key"
+    apiKey:
+      name: GOOGLE_API_KEY
+      proxyManaged: true
+      inject:
+        - domain: generativelanguage.googleapis.com
+          header: x-goog-api-key
+          format: "%s"
+
+environment:
+  variables:
+    GOOGLE_ADK_VENV: "/opt/google-adk"
+    GOOGLE_ADK_PYTHON: "/opt/google-adk/bin/python"
+
+commands:
+  install:
+    - command: "apt-get update && apt-get install -y --no-install-recommends ca-certificates python3 python3-venv python3-pip && rm -rf /var/lib/apt/lists/*"
+      user: "0"
+      description: Install Python and venv prerequisites for Google ADK
+    - command: |
+        set -euo pipefail
+        GOOGLE_ADK_VERSION=2.3.0
+        python3 -m venv /opt/google-adk
+        /opt/google-adk/bin/python -m pip install --upgrade pip setuptools wheel
+        /opt/google-adk/bin/python -m pip install "google-adk==${GOOGLE_ADK_VERSION}"
+        ln -sf /opt/google-adk/bin/adk /usr/local/bin/adk
+        cat > /usr/local/bin/adk-python <<'SCRIPT'
+        #!/bin/sh
+        exec /opt/google-adk/bin/python "$@"
+        SCRIPT
+        chmod 0755 /usr/local/bin/adk-python
+        adk --help >/dev/null
+        adk-python -c 'import importlib.metadata; print("google-adk", importlib.metadata.version("google-adk"))'
+        chown -R 1000:1000 /opt/google-adk
+      user: "0"
+      description: "Install google-adk v2.3.0 in /opt/google-adk venv"
+    - command: |
+        set -euo pipefail
+        grep -qF 'adk-python' ~/.bashrc 2>/dev/null || \
+          printf '\n# google-adk (added by sbx-kits-contrib/google-adk)\nexport GOOGLE_ADK_VENV=/opt/google-adk\nexport GOOGLE_ADK_PYTHON=/opt/google-adk/bin/python\nalias adk-python=/opt/google-adk/bin/python\n' >> ~/.bashrc
+      user: "1000"
+      description: Add Google ADK helper environment variables to interactive shells


### PR DESCRIPTION
## Summary
- add a `google-adk` mixin kit that installs Google ADK 2.3.0 into `/opt/google-adk`
- expose `adk` and `adk-python` helpers on `PATH`
- configure Gemini API key proxy injection with canonical `credentials[]` and `caps.network.allow` fields
- document Gemini API key setup, Vertex/ADC notes, and smoke-test usage

## Spec choices
- The kit uses canonical `caps.network` and `credentials[]` fields while retaining `schemaVersion: "1"` for current TCK compatibility. PR #100 is tracking the repo-wide `schemaVersion: "2"` migration.
- Google Cloud ADC and `gcloud` are intentionally not installed; users can bring those through another mixin/base sandbox or a fork.

## Test plan
- `KIT=E:\GitHub\sbx-kits-contrib\google-adk go test -v -count=1 -timeout 10m -run TestKitTCK ./tck/...`

## Origin
- Community contribution adding Google's Agent Development Kit as a sandbox mixin, analogous to the AWS Strands and smolagents framework kits.
