### PR TITLE
chore(tck): simplify experience running e2e tests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,7 +31,7 @@ required from your side before requesting review.
 - [ ] `./scripts/test-kit-e2e.sh <kit>` passes. The script applies the same
       `deny-all` baseline CI uses and scopes everything to its own daemon
       (`--app-name sbx-kits-contrib-tck`), so my main sbx state is untouched.
-      Every entry I added to `caps.network.allow` came from
+      Every entry I added to `network.allowedDomains` came from
       `sbx --app-name sbx-kits-contrib-tck policy log <tck-e2e-…>`, not a guess.
 - [ ] Manual smoke: `sbx run --kit ./<kit>/ <agent>` and verified the kit's
       binary / files / env are inside the running container.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,22 +28,18 @@ required from your side before requesting review.
 
 - [ ] `sbx kit validate ./<kit>/` passes
 - [ ] `./scripts/test-kit.sh <kit>` passes (the TCK)
-- [ ] `./scripts/test-kit-e2e.sh <kit>` passes **under `deny-all`**, run in a
-      scoped daemon so it doesn't touch my main sbx state:
-    ```bash
-    APP=sbx-kits-contrib-tck
-    sbx --app-name $APP policy reset -f
-    sbx --app-name $APP policy set-default deny-all
-    ./scripts/test-kit-e2e.sh <kit>
-    # If anything is stuck, wipe just the probe daemon:
-    # sbx --app-name $APP reset --force
-    ```
-    Every entry I had to add to `caps.network.allow` came from
-    `sbx --app-name $APP policy log tck-e2e-<short-uuid>`, not from a guess.
+- [ ] `./scripts/test-kit-e2e.sh <kit>` passes. The script applies the same
+      `deny-all` baseline CI uses and scopes everything to its own daemon
+      (`--app-name sbx-kits-contrib-tck`), so my main sbx state is untouched.
+      Every entry I added to `caps.network.allow` came from
+      `sbx --app-name sbx-kits-contrib-tck policy log <tck-e2e-…>`, not a guess.
 - [ ] Manual smoke: `sbx run --kit ./<kit>/ <agent>` and verified the kit's
       binary / files / env are inside the running container.
 
+One-time setup if you haven't run e2e on this machine before:
+`sbx --app-name sbx-kits-contrib-tck login`.
+
 See [CONTRIBUTING.md → Verifying locally](../CONTRIBUTING.md#verifying-locally)
 and [README → Declare every domain your kit needs](../README.md#declare-every-domain-your-kit-needs)
-for the full recipe, the cross-arch domain gotchas (`archive.ubuntu.com`,
-`security.ubuntu.com`, `ports.ubuntu.com`), and the package-manager refresh trap.
+for the cross-arch domain gotchas (`archive.ubuntu.com`,
+`security.ubuntu.com`, `ports.ubuntu.com`) and the package-manager refresh trap.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,49 @@
+<!--
+Thanks for contributing to sbx-kits-contrib!
+
+PRs from forks have CI's `test-kit-e2e` job SKIPPED because GitHub does not
+expose `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` to fork-triggered workflows.
+The e2e assertions will not run on your PR — your laptop is the only place
+they run before merge. See the checklist below.
+-->
+
+## Summary
+
+<!-- What changed and why. -->
+
+## Spec choices worth flagging for review
+
+<!-- Decisions a reviewer should sanity-check: unusual image, deliberately narrow
+allowedDomains, workaround for a known bug, etc. -->
+
+## Origin
+
+<!-- Where did the kit come from? One sentence is enough. -->
+
+## Test plan
+
+CI runs `kit validate` and the TCK on every PR. CI does **not** run e2e on
+fork PRs (Docker Hub secrets aren't exposed there), so the e2e step below is
+required from your side before requesting review.
+
+- [ ] `sbx kit validate ./<kit>/` passes
+- [ ] `./scripts/test-kit.sh <kit>` passes (the TCK)
+- [ ] `./scripts/test-kit-e2e.sh <kit>` passes **under `deny-all`**, run in a
+      scoped daemon so it doesn't touch my main sbx state:
+    ```bash
+    APP=sbx-kits-contrib-tck
+    sbx --app-name $APP policy reset -f
+    sbx --app-name $APP policy set-default deny-all
+    ./scripts/test-kit-e2e.sh <kit>
+    # If anything is stuck, wipe just the probe daemon:
+    # sbx --app-name $APP reset --force
+    ```
+    Every entry I had to add to `caps.network.allow` came from
+    `sbx --app-name $APP policy log tck-e2e-<short-uuid>`, not from a guess.
+- [ ] Manual smoke: `sbx run --kit ./<kit>/ <agent>` and verified the kit's
+      binary / files / env are inside the running container.
+
+See [CONTRIBUTING.md → Verifying locally](../CONTRIBUTING.md#verifying-locally)
+and [README → Declare every domain your kit needs](../README.md#declare-every-domain-your-kit-needs)
+for the full recipe, the cross-arch domain gotchas (`archive.ubuntu.com`,
+`security.ubuntu.com`, `ports.ubuntu.com`), and the package-manager refresh trap.

--- a/.github/workflows/tck.yml
+++ b/.github/workflows/tck.yml
@@ -260,29 +260,20 @@ jobs:
           TOKEN_CLEAN=$(printf '%s' "$DOCKERHUB_TOKEN"    | tr -d '[:space:]')
           printf '%s' "$TOKEN_CLEAN" | sbx --app-name "$APP_NAME" login --username "$USER_CLEAN" --password-stdin
 
-      - name: Set sbx default network policy
-        # `sbx create` refuses to run until a default network policy is
-        # configured. `deny-all` is the strict baseline: a kit gets
-        # *exactly* the outbound reachability it declares in
-        # `network.allowedDomains` and nothing more. That makes the e2e
-        # run a real contract test — if a kit's install hooks reach for
-        # apt/npm mirrors it didn't list, the failure is real and
-        # actionable. Kit allow-rules are scoped per sandbox and punch
-        # through the default deny (see `ApplyKitNetworkPolicyScoped` in
-        # docker/sandboxes:sandboxd/pkg/server/options_governance.go); kit
-        # deny-rules win over allow-rules (deny-wins).
-        #
-        # The trade-off: kits that previously relied on `balanced`'s
-        # tier-zero allowances (Debian apt mirrors, default npm registry)
-        # have to enumerate those domains in their own `allowedDomains`.
-        # That's the philosophy this CI is enforcing — kits are
-        # self-contained network contracts.
-        run: sbx --app-name "$APP_NAME" policy set-default deny-all
-
       - name: Run e2e TCK for ${{ matrix.kit }}
         # Runs TestE2EKit: verifies kit content (env, files, tmpfs, agentContext)
         # for all kits, then — for kind:sandbox kits with testdata/tck.yaml —
         # also sends a non-interactive prompt to the agent.
+        #
+        # The script handles `sbx --app-name $APP_NAME policy set-default
+        # deny-all` internally, so CI and local runs converge on the same
+        # baseline: each kit gets *exactly* the outbound reachability it
+        # declares in `caps.network.allow` and nothing more, making this
+        # a real contract test. Kit allow-rules are scoped per sandbox
+        # and punch through the default deny (see
+        # `ApplyKitNetworkPolicyScoped` in
+        # docker/sandboxes:sandboxd/pkg/server/options_governance.go);
+        # kit deny-rules win over allow-rules (deny-wins).
         run: ./scripts/test-kit-e2e.sh "${{ matrix.kit }}"
 
       - name: Sign out of Docker Hub

--- a/.github/workflows/tck.yml
+++ b/.github/workflows/tck.yml
@@ -265,7 +265,7 @@ jobs:
         # for all kits, then — for kind:sandbox kits with testdata/tck.yaml —
         # also sends a non-interactive prompt to the agent.
         #
-        # The script handles `sbx --app-name $APP_NAME policy set-default
+        # The script handles `sbx --app-name $APP_NAME policy init
         # deny-all` internally, so CI and local runs converge on the same
         # baseline: each kit gets *exactly* the outbound reachability it
         # declares in `network.allowedDomains` and nothing more, making

--- a/.github/workflows/tck.yml
+++ b/.github/workflows/tck.yml
@@ -268,9 +268,9 @@ jobs:
         # The script handles `sbx --app-name $APP_NAME policy set-default
         # deny-all` internally, so CI and local runs converge on the same
         # baseline: each kit gets *exactly* the outbound reachability it
-        # declares in `caps.network.allow` and nothing more, making this
-        # a real contract test. Kit allow-rules are scoped per sandbox
-        # and punch through the default deny (see
+        # declares in `network.allowedDomains` and nothing more, making
+        # this a real contract test. Kit allow-rules are scoped per
+        # sandbox and punch through the default deny (see
         # `ApplyKitNetworkPolicyScoped` in
         # docker/sandboxes:sandboxd/pkg/server/options_governance.go);
         # kit deny-rules win over allow-rules (deny-wins).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,35 +60,40 @@ The first two are what CI runs on every PR. **The third is not run on CI for PRs
 
 `scripts/test-kit.sh` resolves the kit directory (default: `$PWD`), sets `KIT` to its absolute path, and runs `go test -run TestKitTCK ./tck/...` against the repo-root `tck` package. Forwards extra flags to `go test`, so `../scripts/test-kit.sh -v -run TestKitTCK/my-kit/validation` works.
 
-### Run e2e under `deny-all`
+### Running e2e
 
-The high-value local run is e2e against the strict baseline. That's what surfaces the **exact** set of hosts your install and startup hooks reach for — i.e. the real `allowedDomains` you need to ship. Without this step, kits routinely ship an allow-list that only works because the contributor's host policy is permissive, and the kit then fails for users on `deny-all` (and for the maintainer running e2e on a non-fork branch).
+The wrapper script does the dance for you:
 
-**Contain the damage with `--app-name`.** `sbx --app-name <name>` scopes the daemon — sandboxes, policies, secrets, and cache live in a separate state directory and do not touch your day-to-day sbx setup. The e2e harness already passes `--app-name sbx-kits-contrib-tck` on every internal call ([`tck/e2e_test.go:415`](./tck/e2e_test.go#L415)), so if you use the same name for your probe commands the policy you set is exactly what the harness's sandboxes see — **and** if anything goes sideways (stuck state, leftover sandboxes, daemon misbehaving) you can wipe just that one daemon with `sbx --app-name sbx-kits-contrib-tck reset --force` without losing your normal sbx work.
-
-```bash
-APP=sbx-kits-contrib-tck
-
-# 1. Switch the tck daemon's default policy to deny-all. Your main daemon
-#    is unaffected.
-sbx --app-name $APP policy reset -f
-sbx --app-name $APP policy set-default deny-all
-
-# 2. Run the e2e suite. The harness creates a sandbox named
-#    `tck-e2e-<short-uuid>` and exercises the kit end-to-end.
-cd my-kit && ../scripts/test-kit-e2e.sh
-
-# 3. If e2e failed, see what the proxy blocked.
-sbx --app-name $APP ls                          # find the tck-e2e-* name
-sbx --app-name $APP policy log tck-e2e-<short-uuid>
-
-# 4. (Optional) Nuke just the tck daemon between iterations.
-sbx --app-name $APP reset --force
+```console
+$ cd my-kit && ../scripts/test-kit-e2e.sh
 ```
 
-Every row under `Blocked requests` is a host your kit reached for under `deny-all`. Add the host (column `HOST`, e.g. `download.docker.com:443`) to `allowedDomains` and repeat until the block list is empty **and** the e2e test passes. See [Declare every domain your kit needs](./README.md#declare-every-domain-your-kit-needs) for the cross-arch gotchas (`archive.ubuntu.com`, `security.ubuntu.com`, **and** `ports.ubuntu.com`) and the package-manager refresh trap (`apt-get update` re-fetches every configured source).
+That single command:
 
-Prerequisites for e2e (`sbx login`, `/dev/kvm`, etc.) are in [End-to-end (e2e) Tests](./README.md#end-to-end-e2e-tests) in the README.
+- scopes every `sbx` call to `--app-name sbx-kits-contrib-tck`, so the test daemon (sandboxes, policy, cache) is isolated from your main sbx state and nothing the script does touches your day-to-day setup,
+- sets the scoped daemon's default network policy to `deny-all` — the same baseline CI uses, so any host your install or startup hooks reach for must be in `caps.network.allow` or the request is blocked, and
+- runs `TestE2EKit` (env, files, tmpfs, agentContext, and — for `kind: sandbox` kits with a `testdata/tck.yaml` — a non-interactive prompt to the agent).
+
+The script is idempotent (re-runs converge on the same state) and non-interactive (no prompts).
+
+One-time setup per machine — the scoped daemon has its own credential store, separate from any login on your main daemon:
+
+```console
+$ sbx --app-name sbx-kits-contrib-tck login
+```
+
+When the test fails, the script prints how to dump the proxy log. The recurring fix is the same loop: read the log, add the blocked host to `caps.network.allow`, re-run.
+
+```console
+$ sbx --app-name sbx-kits-contrib-tck ls                          # find the tck-e2e-* sandbox
+$ sbx --app-name sbx-kits-contrib-tck policy log <sandbox-name>
+```
+
+Every row under `Blocked requests` is a host your kit reached for under `deny-all`. See [Declare every domain your kit needs](./README.md#declare-every-domain-your-kit-needs) for the cross-arch gotchas (`archive.ubuntu.com`, `security.ubuntu.com`, **and** `ports.ubuntu.com`) and the package-manager refresh trap (`apt-get update` re-fetches every configured source).
+
+If the scoped daemon ever gets wedged: `sbx --app-name sbx-kits-contrib-tck reset --force` wipes only that daemon's state.
+
+Prerequisites for e2e (`/dev/kvm`, Secret Service on Linux, etc.) are in [End-to-end (e2e) Tests](./README.md#end-to-end-e2e-tests) in the README.
 
 ## Sign-off and signing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ $ cd my-kit && ../scripts/test-kit-e2e.sh
 That single command:
 
 - scopes every `sbx` call to `--app-name sbx-kits-contrib-tck`, so the test daemon (sandboxes, policy, cache) is isolated from your main sbx state and nothing the script does touches your day-to-day setup,
-- sets the scoped daemon's default network policy to `deny-all` — the same baseline CI uses, so any host your install or startup hooks reach for must be in `caps.network.allow` or the request is blocked, and
+- sets the scoped daemon's default network policy to `deny-all` — the same baseline CI uses, so any host your install or startup hooks reach for must be in `network.allowedDomains` or the request is blocked, and
 - runs `TestE2EKit` (env, files, tmpfs, agentContext, and — for `kind: sandbox` kits with a `testdata/tck.yaml` — a non-interactive prompt to the agent).
 
 The script is idempotent (re-runs converge on the same state) and non-interactive (no prompts).
@@ -82,7 +82,7 @@ One-time setup per machine — the scoped daemon has its own credential store, s
 $ sbx --app-name sbx-kits-contrib-tck login
 ```
 
-When the test fails, the script prints how to dump the proxy log. The recurring fix is the same loop: read the log, add the blocked host to `caps.network.allow`, re-run.
+When the test fails, the script prints how to dump the proxy log. The recurring fix is the same loop: read the log, add the blocked host to `network.allowedDomains`, re-run.
 
 ```console
 $ sbx --app-name sbx-kits-contrib-tck ls                          # find the tck-e2e-* sandbox

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,27 +47,48 @@ See [Declare every domain your kit needs](./README.md#declare-every-domain-your-
 
 ## Verifying locally
 
-Before opening a PR:
+Before opening a PR, run **all four** of these:
 
 ```console
 $ sbx kit validate ./my-kit/
 $ cd my-kit && ../scripts/test-kit.sh
-$ sbx run --kit ./my-kit/ <agent>
+$ ../scripts/test-kit-e2e.sh           # under deny-all — see below
+$ sbx run --kit . <agent>              # quick manual smoke
 ```
 
-The first two are what CI runs. The third catches things the TCK doesn't — install scripts hitting unexpected hosts, startup wrappers crashing silently, agents not authenticating.
+The first two are what CI runs on every PR. **The third is not run on CI for PRs opened from a fork** — `test-kit-e2e` needs `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` and GitHub doesn't expose secrets to fork-triggered workflows, so the job is skipped silently and the reviewer sees a green check that does **not** include the e2e assertions. If you're contributing from a fork (the common case), your laptop is the only place those assertions ever run before merge.
 
 `scripts/test-kit.sh` resolves the kit directory (default: `$PWD`), sets `KIT` to its absolute path, and runs `go test -run TestKitTCK ./tck/...` against the repo-root `tck` package. Forwards extra flags to `go test`, so `../scripts/test-kit.sh -v -run TestKitTCK/my-kit/validation` works.
 
-For an automated check that the engine actually materialises the kit's content inside a real sandbox (env vars, container files, tmpfs, rendered memory), opt into the e2e layer:
+### Run e2e under `deny-all`
 
-```console
-$ cd my-kit && ../scripts/test-kit-e2e.sh
+The high-value local run is e2e against the strict baseline. That's what surfaces the **exact** set of hosts your install and startup hooks reach for — i.e. the real `allowedDomains` you need to ship. Without this step, kits routinely ship an allow-list that only works because the contributor's host policy is permissive, and the kit then fails for users on `deny-all` (and for the maintainer running e2e on a non-fork branch).
+
+**Contain the damage with `--app-name`.** `sbx --app-name <name>` scopes the daemon — sandboxes, policies, secrets, and cache live in a separate state directory and do not touch your day-to-day sbx setup. The e2e harness already passes `--app-name sbx-kits-contrib-tck` on every internal call ([`tck/e2e_test.go:415`](./tck/e2e_test.go#L415)), so if you use the same name for your probe commands the policy you set is exactly what the harness's sandboxes see — **and** if anything goes sideways (stuck state, leftover sandboxes, daemon misbehaving) you can wipe just that one daemon with `sbx --app-name sbx-kits-contrib-tck reset --force` without losing your normal sbx work.
+
+```bash
+APP=sbx-kits-contrib-tck
+
+# 1. Switch the tck daemon's default policy to deny-all. Your main daemon
+#    is unaffected.
+sbx --app-name $APP policy reset -f
+sbx --app-name $APP policy set-default deny-all
+
+# 2. Run the e2e suite. The harness creates a sandbox named
+#    `tck-e2e-<short-uuid>` and exercises the kit end-to-end.
+cd my-kit && ../scripts/test-kit-e2e.sh
+
+# 3. If e2e failed, see what the proxy blocked.
+sbx --app-name $APP ls                          # find the tck-e2e-* name
+sbx --app-name $APP policy log tck-e2e-<short-uuid>
+
+# 4. (Optional) Nuke just the tck daemon between iterations.
+sbx --app-name $APP reset --force
 ```
 
-Or, from the repo root: `./scripts/test-kit-e2e.sh my-kit`. The wrapper checks `sbx` is on PATH and the kit dir has a `spec.yaml`, then runs `go test -tags=e2e -run TestE2ECreateSandbox ./tck/...`.
+Every row under `Blocked requests` is a host your kit reached for under `deny-all`. Add the host (column `HOST`, e.g. `download.docker.com:443`) to `allowedDomains` and repeat until the block list is empty **and** the e2e test passes. See [Declare every domain your kit needs](./README.md#declare-every-domain-your-kit-needs) for the cross-arch gotchas (`archive.ubuntu.com`, `security.ubuntu.com`, **and** `ports.ubuntu.com`) and the package-manager refresh trap (`apt-get update` re-fetches every configured source).
 
-See [End-to-end (e2e) Tests](./README.md#end-to-end-e2e-tests) in the README for prerequisites (`sbx login`, default policy, etc.) and what each subtest verifies.
+Prerequisites for e2e (`sbx login`, `/dev/kvm`, etc.) are in [End-to-end (e2e) Tests](./README.md#end-to-end-e2e-tests) in the README.
 
 ## Sign-off and signing
 

--- a/README.md
+++ b/README.md
@@ -154,29 +154,31 @@ The non-obvious trap is **package managers refreshing every configured source**,
 - Ubuntu hosts amd64 packages on `archive.ubuntu.com` + `security.ubuntu.com` and arm64 packages on `ports.ubuntu.com`. List all three for cross-arch coverage; CI is amd64, your Mac is likely arm64.
 - `npm install`, `pip install`, `cargo`, `go get`, etc. each have their own registry/mirror hosts — declare them too.
 
-If you're not sure what your install hooks reach, probe locally under `deny-all` and read `sbx policy log` to see exactly what the proxy blocked. The recipe is cross-platform (no daemon-log greping, no OS-specific paths):
+If you're not sure what your install hooks reach, probe locally under `deny-all` and read `sbx policy log` to see exactly what the proxy blocked. The recipe is cross-platform (no daemon-log greping, no OS-specific paths) and uses `sbx --app-name sbx-kits-contrib-tck` on every call so the policy change is scoped to a separate daemon — your main sbx state is untouched, and you can blow the probe daemon away with `sbx --app-name sbx-kits-contrib-tck reset --force` if it gets into a bad state:
 
 ```bash
-# 1. Switch to the strict baseline. `sbx policy reset` drops any local
-#    rules you've added — if you have customisations, list them first
-#    with `sbx policy ls` so you can restore them later.
-sbx policy reset -f
-sbx policy set-default deny-all
+APP=sbx-kits-contrib-tck
+
+# 1. Switch the probe daemon to the strict baseline. `sbx --app-name $APP
+#    policy ls` shows what's currently set under that name.
+sbx --app-name $APP policy reset -f
+sbx --app-name $APP policy set-default deny-all
 
 # 2. Run your kit. The install hooks fire during `sbx create`.
-sbx create --name probe-my-kit --kit "$PWD/my-kit" <agent> /tmp/sbx-kit-debug || true
+sbx --app-name $APP create --name probe-my-kit --kit "$PWD/my-kit" <agent> /tmp/sbx-kit-debug || true
 
 # 3. See what the proxy blocked (and what got through). Filter by the
 #    sandbox name so you only see this kit's requests.
-sbx policy log probe-my-kit
+sbx --app-name $APP policy log probe-my-kit
 
-# 4. Clean up the probe sandbox and restore your previous default policy.
-sbx rm -f probe-my-kit
-sbx policy reset -f
-sbx policy set-default balanced   # or whichever preset you were on
+# 4. Clean up. The whole probe daemon — sandboxes, policy, cache — goes
+#    away in one command, without touching your main sbx state.
+sbx --app-name $APP reset --force
 ```
 
 Every `Blocked requests` row is a domain your install or startup hook reached for under `deny-all`. Add the host (column `HOST`, e.g. `download.docker.com:443`) to `allowedDomains` and re-probe until the block list is empty.
+
+**Or run the e2e suite under the same scoped daemon** — same recipe, but `scripts/test-kit-e2e.sh` (which internally uses the same `--app-name sbx-kits-contrib-tck`) also exercises every assertion `TestE2ECreateSandbox` makes, not just network policy. See [End-to-end (e2e) Tests](#end-to-end-e2e-tests) below.
 
 ## TCK Test Coverage
 
@@ -250,7 +252,9 @@ Each subtest (`env`, `files/<path>`, `tmpfs/<path>`, `memory`) reports independe
 
 ### Running in CI
 
-The `test-kit-e2e` job in [`.github/workflows/tck.yml`](.github/workflows/tck.yml) runs alongside the default `test-kit` job. It downloads the latest `sbx` release, signs in to Docker Hub using `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` repo secrets, then runs the e2e test once per detected kit. The job is skipped on fork PRs because the secrets aren't exposed there.
+The `test-kit-e2e` job in [`.github/workflows/tck.yml`](.github/workflows/tck.yml) runs alongside the default `test-kit` job. It downloads the latest `sbx` release, signs in to Docker Hub using `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` repo secrets, then runs the e2e test once per detected kit. **The job is skipped on fork PRs** because GitHub does not expose secrets to fork-triggered workflows — so for the typical contributor, e2e never runs in CI on their PR, and the reviewer sees a green check that does **not** cover the e2e assertions.
+
+That makes a local e2e run **mandatory** before opening a PR from a fork — and the highest-value way to do that is under a `deny-all` default policy, so you catch missing `allowedDomains` entries before the reviewer (or a `deny-all` user) does. See [Declare every domain your kit needs](#declare-every-domain-your-kit-needs) below for the probe recipe, and combine it with `./scripts/test-kit-e2e.sh` instead of a hand-built probe sandbox to also exercise every assertion `TestE2ECreateSandbox` makes.
 
 ## Extending a Parent Agent
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ The non-obvious trap is **package managers refreshing every configured source**,
 - Ubuntu hosts amd64 packages on `archive.ubuntu.com` + `security.ubuntu.com` and arm64 packages on `ports.ubuntu.com`. List all three for cross-arch coverage; CI is amd64, your Mac is likely arm64.
 - `npm install`, `pip install`, `cargo`, `go get`, etc. each have their own registry/mirror hosts — declare them too.
 
-The fastest way to find out what your install hooks reach is to run the e2e wrapper. It applies a `deny-all` default policy on a scoped daemon (`--app-name sbx-kits-contrib-tck`) for you, then runs `TestE2ECreateSandbox` — so you get the network contract *and* every other e2e assertion from one command:
+The fastest way to find out what your install hooks reach is to run the e2e wrapper. It applies a `deny-all` global policy on a scoped daemon (`--app-name sbx-kits-contrib-tck`) for you, then runs `TestE2EKit` — so you get the network contract *and* every other e2e assertion from one command:
 
 ```bash
 ./scripts/test-kit-e2e.sh my-kit
@@ -174,7 +174,7 @@ If you'd rather hand-build a probe sandbox without invoking the test harness (us
 
 ```bash
 APP=sbx-kits-contrib-tck
-sbx --app-name $APP policy set-default deny-all
+sbx --app-name $APP policy init deny-all
 sbx --app-name $APP create --name probe-my-kit --kit "$PWD/my-kit" <agent> /tmp/sbx-kit-debug || true
 sbx --app-name $APP policy log probe-my-kit
 sbx --app-name $APP reset --force                 # wipe the scoped daemon

--- a/README.md
+++ b/README.md
@@ -154,31 +154,33 @@ The non-obvious trap is **package managers refreshing every configured source**,
 - Ubuntu hosts amd64 packages on `archive.ubuntu.com` + `security.ubuntu.com` and arm64 packages on `ports.ubuntu.com`. List all three for cross-arch coverage; CI is amd64, your Mac is likely arm64.
 - `npm install`, `pip install`, `cargo`, `go get`, etc. each have their own registry/mirror hosts — declare them too.
 
-If you're not sure what your install hooks reach, probe locally under `deny-all` and read `sbx policy log` to see exactly what the proxy blocked. The recipe is cross-platform (no daemon-log greping, no OS-specific paths) and uses `sbx --app-name sbx-kits-contrib-tck` on every call so the policy change is scoped to a separate daemon — your main sbx state is untouched, and you can blow the probe daemon away with `sbx --app-name sbx-kits-contrib-tck reset --force` if it gets into a bad state:
+The fastest way to find out what your install hooks reach is to run the e2e wrapper. It applies a `deny-all` default policy on a scoped daemon (`--app-name sbx-kits-contrib-tck`) for you, then runs `TestE2ECreateSandbox` — so you get the network contract *and* every other e2e assertion from one command:
+
+```bash
+./scripts/test-kit-e2e.sh my-kit
+```
+
+On failure, dump what the proxy blocked:
 
 ```bash
 APP=sbx-kits-contrib-tck
-
-# 1. Switch the probe daemon to the strict baseline. `sbx --app-name $APP
-#    policy ls` shows what's currently set under that name.
-sbx --app-name $APP policy reset -f
-sbx --app-name $APP policy set-default deny-all
-
-# 2. Run your kit. The install hooks fire during `sbx create`.
-sbx --app-name $APP create --name probe-my-kit --kit "$PWD/my-kit" <agent> /tmp/sbx-kit-debug || true
-
-# 3. See what the proxy blocked (and what got through). Filter by the
-#    sandbox name so you only see this kit's requests.
-sbx --app-name $APP policy log probe-my-kit
-
-# 4. Clean up. The whole probe daemon — sandboxes, policy, cache — goes
-#    away in one command, without touching your main sbx state.
-sbx --app-name $APP reset --force
+sbx --app-name $APP ls                            # find the tck-e2e-* sandbox
+sbx --app-name $APP policy log tck-e2e-<short-uuid>
 ```
 
-Every `Blocked requests` row is a domain your install or startup hook reached for under `deny-all`. Add the host (column `HOST`, e.g. `download.docker.com:443`) to `allowedDomains` and re-probe until the block list is empty.
+Every `Blocked requests` row is a domain your install or startup hook reached for under `deny-all`. Add the host (column `HOST`, e.g. `download.docker.com:443`) to `allowedDomains` and re-run until the block list is empty.
 
-**Or run the e2e suite under the same scoped daemon** — same recipe, but `scripts/test-kit-e2e.sh` (which internally uses the same `--app-name sbx-kits-contrib-tck`) also exercises every assertion `TestE2ECreateSandbox` makes, not just network policy. See [End-to-end (e2e) Tests](#end-to-end-e2e-tests) below.
+If you'd rather hand-build a probe sandbox without invoking the test harness (useful when iterating on install scripts without touching the spec), the manual flow is:
+
+```bash
+APP=sbx-kits-contrib-tck
+sbx --app-name $APP policy set-default deny-all
+sbx --app-name $APP create --name probe-my-kit --kit "$PWD/my-kit" <agent> /tmp/sbx-kit-debug || true
+sbx --app-name $APP policy log probe-my-kit
+sbx --app-name $APP reset --force                 # wipe the scoped daemon
+```
+
+Same `--app-name` keeps the state isolated from your main sbx and lets `sbx --app-name $APP reset --force` clean up without touching your day-to-day setup.
 
 ## TCK Test Coverage
 
@@ -212,15 +214,19 @@ The default TCK runs every kit assertion against a fabricated `testcontainers-go
 ### Prerequisites
 
 - `sbx` on `PATH`. Install the latest release from [`docker/sbx-releases`](https://github.com/docker/sbx-releases/releases/latest).
-- An authenticated `sbx` session against Docker Hub. The non-interactive form:
+- The scoped daemon must be logged in to Docker Hub once per machine. Interactive form:
   ```bash
-  printf '%s' "$DOCKERHUB_TOKEN" | sbx login --username "$DOCKERHUB_USERNAME" --password-stdin
+  sbx --app-name sbx-kits-contrib-tck login
+  ```
+  Non-interactive (matches CI):
+  ```bash
+  printf '%s' "$DOCKERHUB_TOKEN" | sbx --app-name sbx-kits-contrib-tck login --username "$DOCKERHUB_USERNAME" --password-stdin
   ```
 - Linux with `/dev/kvm` accessible (for the sailor microVM). On Linux runners and most workstations this is already the case; in CI the workflow does `sudo chmod 666 /dev/kvm` to relax permissions.
 
 ### Running locally
 
-The test is hidden behind the `e2e` build tag so kit authors running `go test ./...` see no behavior change. Opt in via the wrapper:
+The test is hidden behind the `e2e` build tag so kit authors running `go test ./...` see no behavior change. Opt in via the wrapper — the script handles the `--app-name` scoping and `deny-all` policy for you:
 
 ```bash
 # From inside the kit's directory:
@@ -231,7 +237,9 @@ cd my-kit
 ./scripts/test-kit-e2e.sh my-kit
 ```
 
-Extra flags are forwarded to `go test`. The wrapper checks `sbx` is on PATH and validates the kit directory has a `spec.yaml`/`spec.yml` before invoking. If you'd rather drop to `go test` directly:
+Idempotent and non-interactive. Re-running converges on the same state — set the same default policy, run the test, leave the scoped daemon as it was. Overrides via env: `APP_NAME` (default `sbx-kits-contrib-tck`) and `POLICY` (default `deny-all`; set `POLICY=` to skip the policy step). Extra positional flags are forwarded to `go test`.
+
+If you'd rather drop to `go test` directly (note: this skips the policy-set step, so you need to apply `deny-all` yourself or the network contract isn't tested):
 
 ```bash
 KIT_UNDER_TEST="$PWD/my-kit" \
@@ -254,7 +262,7 @@ Each subtest (`env`, `files/<path>`, `tmpfs/<path>`, `memory`) reports independe
 
 The `test-kit-e2e` job in [`.github/workflows/tck.yml`](.github/workflows/tck.yml) runs alongside the default `test-kit` job. It downloads the latest `sbx` release, signs in to Docker Hub using `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` repo secrets, then runs the e2e test once per detected kit. **The job is skipped on fork PRs** because GitHub does not expose secrets to fork-triggered workflows — so for the typical contributor, e2e never runs in CI on their PR, and the reviewer sees a green check that does **not** cover the e2e assertions.
 
-That makes a local e2e run **mandatory** before opening a PR from a fork — and the highest-value way to do that is under a `deny-all` default policy, so you catch missing `allowedDomains` entries before the reviewer (or a `deny-all` user) does. See [Declare every domain your kit needs](#declare-every-domain-your-kit-needs) below for the probe recipe, and combine it with `./scripts/test-kit-e2e.sh` instead of a hand-built probe sandbox to also exercise every assertion `TestE2ECreateSandbox` makes.
+That makes a local e2e run **mandatory** before opening a PR from a fork. Run `./scripts/test-kit-e2e.sh <kit>` — the script applies the same `deny-all` baseline CI uses on a scoped daemon (`--app-name sbx-kits-contrib-tck`), so the network contract gets tested without touching your main sbx state. See [Declare every domain your kit needs](#declare-every-domain-your-kit-needs) for the recurring "read the proxy log, add a host, re-run" loop.
 
 ## Extending a Parent Agent
 

--- a/scripts/test-kit-e2e.sh
+++ b/scripts/test-kit-e2e.sh
@@ -8,23 +8,44 @@
 #   ../scripts/test-kit-e2e.sh                # from inside the kit's directory
 #   ../scripts/test-kit-e2e.sh my-other-kit   # also works
 #
-# The script resolves <kit-dir> to an absolute path, exports it as
-# KIT_UNDER_TEST, and invokes `go test -tags=e2e ./tck/...` against the
-# repo-root `tck` package. Extra args (e.g. `-v`, `-run`, `-count=1`) are
-# forwarded to `go test`.
+# What the script does for you (so the author doesn't have to):
+#   - Scopes every sbx call to APP_NAME=sbx-kits-contrib-tck so the test
+#     daemon, sandboxes, policy, and cache are isolated from your main
+#     sbx state. Nothing the script does touches your day-to-day daemon.
+#     The Go harness uses the same app-name internally (tck/e2e_test.go).
+#   - Sets the scoped daemon's default network policy to `deny-all` so
+#     the run is a real contract test of caps.network.allow — the same
+#     baseline CI runs under.
+#   - Runs `go test -tags=e2e ./tck/...` with KIT_UNDER_TEST exported.
+#   - On failure, prints how to read `sbx policy log` to find the missing
+#     domains.
 #
-# Prerequisites (the script does NOT set these up — they're a one-time setup
-# for the developer's machine):
-#   - `sbx` on PATH (install from docker/sbx-releases)
-#   - `sbx login` already run (the test creates a sandbox, which requires auth)
-#   - `sbx policy set-default <preset>` already configured
-#   - On Linux runners only: a Secret Service provider for libsecret
-#     (the CI workflow sets this up via gnome-keyring; not needed on macOS)
+# The script is idempotent (every step is a write that yields the same
+# outcome on repeat runs) and non-interactive (no prompts; relies on
+# `-f` / `--force` for the few sbx commands that would otherwise prompt).
 #
-# Mirrors scripts/test-kit.sh — keep the two in sync when the resolution
-# logic changes.
+# Prerequisites (one-time per machine):
+#   - `sbx` on PATH. Install from docker/sbx-releases.
+#   - The scoped daemon must be logged in to Docker Hub:
+#         sbx --app-name sbx-kits-contrib-tck login
+#     Each --app-name has its own credential store; this is separate from
+#     any login on your main daemon.
+#   - On Linux: a Secret Service provider for libsecret (gnome-keyring,
+#     kwallet, etc.). Not needed on macOS.
+#
+# Overrides (env vars):
+#   APP_NAME — change the app-name (default: sbx-kits-contrib-tck). Must
+#              stay in sync with the Go harness's app-name if you change it.
+#   POLICY   — change the default network policy applied to the scoped
+#              daemon (default: deny-all). Set POLICY= (empty) to skip
+#              the policy step entirely.
+#
+# Mirrors scripts/test-kit.sh — keep the resolution logic in sync.
 
 set -euo pipefail
+
+APP_NAME=${APP_NAME:-sbx-kits-contrib-tck}
+POLICY=${POLICY-deny-all}
 
 # Locate the repo root from the script's own location so the command works
 # regardless of where it's invoked from.
@@ -62,5 +83,44 @@ if ! command -v sbx >/dev/null 2>&1; then
   exit 1
 fi
 
+# Configure the scoped daemon's default network policy. Idempotent: setting
+# the same default repeatedly is a no-op write. Skipped when POLICY is
+# explicitly set to the empty string.
+if [ -n "$POLICY" ]; then
+  echo "Setting --app-name=$APP_NAME default policy to $POLICY"
+  sbx --app-name "$APP_NAME" policy set-default "$POLICY"
+fi
+
+# Helper hint on failure — the most common e2e failure is a missing entry
+# in caps.network.allow, which `sbx policy log` surfaces precisely. Wired
+# as an EXIT trap (not ERR) so the hint also fires when `set -e` aborts
+# mid-test. Only fires on non-zero exit.
+on_exit() {
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    cat >&2 <<EOF
+
+e2e test failed (exit $rc). To see which hosts the proxy blocked under '${POLICY:-current default}':
+
+  sbx --app-name $APP_NAME ls                              # find the tck-e2e-* sandbox
+  sbx --app-name $APP_NAME policy log <sandbox-name>
+
+Every row under 'Blocked requests' is a host your kit reached for. Add it
+to caps.network.allow in spec.yaml and re-run this script.
+
+If the scoped daemon is wedged, wipe it (your main sbx is unaffected):
+
+  sbx --app-name $APP_NAME reset --force
+
+If you haven't logged in to the scoped daemon yet:
+
+  sbx --app-name $APP_NAME login
+
+EOF
+  fi
+  exit "$rc"
+}
+trap on_exit EXIT
+
 cd "$REPO_ROOT"
-KIT_UNDER_TEST="$kit_abs" exec go test -tags=e2e -v -count=1 -timeout 25m "$@" ./tck/...
+KIT_UNDER_TEST="$kit_abs" go test -tags=e2e -v -count=1 -timeout 25m "$@" ./tck/...

--- a/scripts/test-kit-e2e.sh
+++ b/scripts/test-kit-e2e.sh
@@ -14,7 +14,7 @@
 #     sbx state. Nothing the script does touches your day-to-day daemon.
 #     The Go harness uses the same app-name internally (tck/e2e_test.go).
 #   - Sets the scoped daemon's default network policy to `deny-all` so
-#     the run is a real contract test of caps.network.allow — the same
+#     the run is a real contract test of network.allowedDomains — the same
 #     baseline CI runs under.
 #   - Runs `go test -tags=e2e ./tck/...` with KIT_UNDER_TEST exported.
 #   - On failure, prints how to read `sbx policy log` to find the missing
@@ -92,7 +92,7 @@ if [ -n "$POLICY" ]; then
 fi
 
 # Helper hint on failure — the most common e2e failure is a missing entry
-# in caps.network.allow, which `sbx policy log` surfaces precisely. Wired
+# in network.allowedDomains, which `sbx policy log` surfaces precisely. Wired
 # as an EXIT trap (not ERR) so the hint also fires when `set -e` aborts
 # mid-test. Only fires on non-zero exit.
 on_exit() {
@@ -106,7 +106,7 @@ e2e test failed (exit $rc). To see which hosts the proxy blocked under '${POLICY
   sbx --app-name $APP_NAME policy log <sandbox-name>
 
 Every row under 'Blocked requests' is a host your kit reached for. Add it
-to caps.network.allow in spec.yaml and re-run this script.
+to network.allowedDomains in spec.yaml and re-run this script.
 
 If the scoped daemon is wedged, wipe it (your main sbx is unaffected):
 

--- a/scripts/test-kit-e2e.sh
+++ b/scripts/test-kit-e2e.sh
@@ -83,12 +83,41 @@ if ! command -v sbx >/dev/null 2>&1; then
   exit 1
 fi
 
-# Configure the scoped daemon's default network policy. Idempotent: setting
-# the same default repeatedly is a no-op write. Skipped when POLICY is
-# explicitly set to the empty string.
+# Smoke test — fail fast if the scoped daemon can't talk to the runtime.
+# The most common cause is "not logged in to Docker Hub" (sbx create then
+# fails ~minutes into the test), but the same probe also catches a dead
+# daemon, KVM access issues, etc. `sbx ls` exercises the runtime and is
+# a no-op when everything is fine, making it safe to run unconditionally.
+probe_err=$(sbx --app-name "$APP_NAME" ls 2>&1 >/dev/null) || {
+  cat >&2 <<EOF
+ERROR: smoke test failed — sbx --app-name $APP_NAME is not usable.
+
+$probe_err
+
+Most common fix: the scoped daemon has its own credential store, separate
+from any login on your main sbx daemon. Run this one-time setup, then
+re-run this script:
+
+  sbx --app-name $APP_NAME login
+
+EOF
+  exit 1
+}
+unset probe_err
+
+# Configure the scoped daemon's global network policy. `policy init` is
+# one-time per daemon (sbx errors with "already initialized" on the second
+# call), so to stay idempotent we try `init` first and fall back to
+# `reset --force` + `init` when a policy is already set — that lands the
+# scoped daemon on the desired baseline regardless of prior state. The
+# `--force` skips the confirmation prompt about stopping running sandboxes
+# (we don't keep any across runs). Skipped when POLICY is explicitly set
+# to the empty string.
 if [ -n "$POLICY" ]; then
-  echo "Setting --app-name=$APP_NAME default policy to $POLICY"
-  sbx --app-name "$APP_NAME" policy set-default "$POLICY"
+  echo "Initializing --app-name=$APP_NAME global policy to $POLICY"
+  if ! sbx --app-name "$APP_NAME" policy init "$POLICY" >/dev/null 2>&1; then
+    sbx --app-name "$APP_NAME" policy init "$POLICY"
+  fi
 fi
 
 # Helper hint on failure — the most common e2e failure is a missing entry
@@ -123,4 +152,8 @@ EOF
 trap on_exit EXIT
 
 cd "$REPO_ROOT"
-KIT_UNDER_TEST="$kit_abs" go test -tags=e2e -v -count=1 -timeout 25m "$@" ./tck/...
+# Focus on TestE2EKit. The ./tck/... package also contains TCK unit tests
+# (TestDerive*, TestRunValidationTests, etc.) that are not e2e; running
+# them here just spams output. The author can override with `-run …` since
+# extra flags are forwarded after this script's args.
+KIT_UNDER_TEST="$kit_abs" go test -tags=e2e -v -count=1 -timeout 25m -run TestE2EKit "$@" ./tck/...

--- a/skills/kit-author/SKILL.md
+++ b/skills/kit-author/SKILL.md
@@ -37,7 +37,7 @@ Primary topics describe the **v2** spec form (`schemaVersion: "2"`):
 - [Authoring guide](topics/authoring.md) — Step-by-step recipes for a minimal mixin and a full sandbox kit. Where to put files. When to use `files/` vs `initFiles`.
 - [Bindings](topics/bindings.md) — The user-side `~/.config/sbx/credentials.yaml` file: how kits and users split the credential contract.
 - [Distribution](topics/distribution.md) — Local dir, OCI digests, git commit-SHA references. Strict pinning rule. Schema-version compatibility. `sbx kit push/pull/inspect/validate/delete`.
-- [Testing](topics/testing.md) — TCK suite, manual `sbx kit add` verification, proving allow-list enforcement.
+- [Testing](topics/testing.md) — TCK suite, e2e under `deny-all` (mandatory locally — CI's e2e job is skipped for fork PRs), manual `sbx kit add` verification, proving allow-list enforcement.
 - [Pitfalls](topics/pitfalls.md) — Surprises seen in practice: install-completed is exit-code only, `commands.startup` runs on **every** container start (idempotency required), `kit add` cannot apply immutable settings, `commands.install` idempotency + duplication footguns + `SBX_CRED_<SERVICE>_MODE` contract, inject/binding domain intersection.
 
 Legacy reference:

--- a/skills/kit-author/topics/authoring.md
+++ b/skills/kit-author/topics/authoring.md
@@ -258,11 +258,11 @@ CI on the repo skips the `test-kit-e2e` job for fork PRs (Docker Hub secrets are
 cd my-kit && ../scripts/test-kit-e2e.sh
 ```
 
-The script handles the dance for you — it scopes everything to `--app-name sbx-kits-contrib-tck` (the same app-name the harness uses internally) and applies the `deny-all` default policy CI uses, so the only `caps.network.allow` entries that survive are the ones you actually need. Your main sbx state is untouched.
+The script handles the dance for you — it scopes everything to `--app-name sbx-kits-contrib-tck` (the same app-name the harness uses internally) and applies the `deny-all` default policy CI uses, so the only `network.allowedDomains` entries that survive are the ones you actually need. Your main sbx state is untouched.
 
 One-time per machine: `sbx --app-name sbx-kits-contrib-tck login`.
 
-When it fails, read what the proxy blocked, add the host to `caps.network.allow`, re-run:
+When it fails, read what the proxy blocked, add the host to `network.allowedDomains`, re-run:
 
 ```bash
 APP=sbx-kits-contrib-tck

--- a/skills/kit-author/topics/authoring.md
+++ b/skills/kit-author/topics/authoring.md
@@ -250,6 +250,28 @@ sbx rm probe
 
 For changes that affect immutable container settings (privileged, volumes, tmpfs), `sbx kit add` will warn and skip them — you must recreate the sandbox to test those.
 
+## Before opening a PR
+
+CI on the repo skips the `test-kit-e2e` job for fork PRs (Docker Hub secrets aren't exposed to fork-triggered workflows). Run e2e locally — and run it **under `deny-all`** — so you catch missing entries in `caps.network.allow` before the reviewer does. Pass `--app-name sbx-kits-contrib-tck` on every probe command so the policy change lives in a scoped daemon (the e2e harness uses the same app-name internally), and your main sbx state is untouched:
+
+```bash
+APP=sbx-kits-contrib-tck
+
+sbx --app-name $APP policy reset -f
+sbx --app-name $APP policy set-default deny-all
+
+cd my-kit && ../scripts/test-kit-e2e.sh
+
+# If it failed, see what the proxy blocked.
+sbx --app-name $APP ls
+sbx --app-name $APP policy log tck-e2e-<short-uuid>
+
+# Stuck state? Nuke just the tck daemon — your main sbx is unaffected.
+sbx --app-name $APP reset --force
+```
+
+Add every blocked host to `caps.network.allow` and repeat until the block list is empty *and* e2e passes. Full recipe and reference list of commonly-missed hosts in [`testing.md`](testing.md#running-e2e-under-deny-all--the-real-point-of-running-this-locally).
+
 ## Migrating an existing v1 kit
 
 ```bash

--- a/skills/kit-author/topics/authoring.md
+++ b/skills/kit-author/topics/authoring.md
@@ -252,25 +252,25 @@ For changes that affect immutable container settings (privileged, volumes, tmpfs
 
 ## Before opening a PR
 
-CI on the repo skips the `test-kit-e2e` job for fork PRs (Docker Hub secrets aren't exposed to fork-triggered workflows). Run e2e locally — and run it **under `deny-all`** — so you catch missing entries in `caps.network.allow` before the reviewer does. Pass `--app-name sbx-kits-contrib-tck` on every probe command so the policy change lives in a scoped daemon (the e2e harness uses the same app-name internally), and your main sbx state is untouched:
+CI on the repo skips the `test-kit-e2e` job for fork PRs (Docker Hub secrets aren't exposed to fork-triggered workflows). Run e2e locally before you ask for review:
+
+```bash
+cd my-kit && ../scripts/test-kit-e2e.sh
+```
+
+The script handles the dance for you — it scopes everything to `--app-name sbx-kits-contrib-tck` (the same app-name the harness uses internally) and applies the `deny-all` default policy CI uses, so the only `caps.network.allow` entries that survive are the ones you actually need. Your main sbx state is untouched.
+
+One-time per machine: `sbx --app-name sbx-kits-contrib-tck login`.
+
+When it fails, read what the proxy blocked, add the host to `caps.network.allow`, re-run:
 
 ```bash
 APP=sbx-kits-contrib-tck
-
-sbx --app-name $APP policy reset -f
-sbx --app-name $APP policy set-default deny-all
-
-cd my-kit && ../scripts/test-kit-e2e.sh
-
-# If it failed, see what the proxy blocked.
 sbx --app-name $APP ls
 sbx --app-name $APP policy log tck-e2e-<short-uuid>
-
-# Stuck state? Nuke just the tck daemon — your main sbx is unaffected.
-sbx --app-name $APP reset --force
 ```
 
-Add every blocked host to `caps.network.allow` and repeat until the block list is empty *and* e2e passes. Full recipe and reference list of commonly-missed hosts in [`testing.md`](testing.md#running-e2e-under-deny-all--the-real-point-of-running-this-locally).
+Full breakdown and the list of commonly-missed hosts is in [`testing.md`](testing.md#running-e2e).
 
 ## Migrating an existing v1 kit
 

--- a/skills/kit-author/topics/testing.md
+++ b/skills/kit-author/topics/testing.md
@@ -174,7 +174,7 @@ cd my-kit
 That's the whole recipe — no manual policy dance. The script:
 
 - Scopes every `sbx` call to `--app-name sbx-kits-contrib-tck`, the same app-name the e2e harness uses internally ([`tck/e2e_test.go:415`](../../../tck/e2e_test.go#L415)). The test daemon's sandboxes, policy, secrets, and cache are isolated from your day-to-day sbx state.
-- Sets the scoped daemon's default network policy to `deny-all` — the same baseline CI uses, so any host your install or startup hooks reach for must be in `caps.network.allow` or the request is blocked.
+- Sets the scoped daemon's default network policy to `deny-all` — the same baseline CI uses, so any host your install or startup hooks reach for must be in `network.allowedDomains` or the request is blocked.
 - Runs `go test -tags=e2e` with `KIT_UNDER_TEST` exported.
 - On non-zero exit, prints a hint pointing at `sbx --app-name sbx-kits-contrib-tck policy log <sandbox>`.
 
@@ -186,7 +186,7 @@ One-time setup per machine — the scoped daemon has its own credential store:
 sbx --app-name sbx-kits-contrib-tck login
 ```
 
-When the test fails, the recurring fix is the same loop: read the proxy log, add the blocked host to `caps.network.allow`, re-run.
+When the test fails, the recurring fix is the same loop: read the proxy log, add the blocked host to `network.allowedDomains`, re-run.
 
 ```bash
 APP=sbx-kits-contrib-tck
@@ -194,7 +194,7 @@ sbx --app-name $APP ls                            # find the tck-e2e-* sandbox
 sbx --app-name $APP policy log tck-e2e-<short-uuid>
 ```
 
-Every row under `Blocked requests` is a host your kit reached for under `deny-all`. Add the host (column `HOST`, e.g. `download.docker.com:443`) to `caps.network.allow` and re-run until the block list is empty *and* the e2e test passes.
+Every row under `Blocked requests` is a host your kit reached for under `deny-all`. Add the host (column `HOST`, e.g. `download.docker.com:443`) to `network.allowedDomains` and re-run until the block list is empty *and* the e2e test passes.
 
 If the scoped daemon ever gets wedged: `sbx --app-name sbx-kits-contrib-tck reset --force` wipes only that daemon's state — your main sbx is untouched.
 
@@ -242,7 +242,7 @@ For ad-hoc probing of a single sandbox without running e2e, `sbx policy log` wor
 sbx policy log <sandbox>
 ```
 
-Every entry in the "Blocked requests" section is a domain your install or startup hook reached for. Add it to `caps.network.allow` (or accept the block) and re-probe. The repository [README](../../../README.md#declare-every-domain-your-kit-needs) has the hand-built probe-sandbox variant of this recipe.
+Every entry in the "Blocked requests" section is a domain your install or startup hook reached for. Add it to `network.allowedDomains` (or accept the block) and re-probe. The repository [README](../../../README.md#declare-every-domain-your-kit-needs) has the hand-built probe-sandbox variant of this recipe.
 
 ## Common pitfall: "install commands completed" ≠ success
 

--- a/skills/kit-author/topics/testing.md
+++ b/skills/kit-author/topics/testing.md
@@ -1,6 +1,8 @@
 # Testing Kits
 
-Three layers. Use them all for any kit you publish; just the last for ad-hoc experiments.
+Four layers. Run **all four locally** before opening a PR — only the first two run on CI for fork PRs.
+
+**Why fork contributors must run e2e locally.** The repo's `test-kit-e2e` job needs `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` to pull the template image, and GitHub does not expose secrets to workflows triggered from forks. So if you're contributing from a fork (the common case), the e2e job is **skipped silently** on your PR — the reviewer sees a green check that does not include `TestE2EKit`. The only place those assertions ever run is on your laptop. See [`.github/workflows/tck.yml`](../../../.github/workflows/tck.yml) and the "Running in CI" note in [the README](../../../README.md#running-in-ci).
 
 ## 1. Spec-level validation
 
@@ -72,7 +74,7 @@ Requires Docker (or `docker-next` inside `sbx`).
 
 ## 3. End-to-end (e2e) tests
 
-The optional e2e layer boots a **real `sbx` sandbox** from the kit and verifies the kit's content actually landed inside the running container. It catches things the default TCK can't — install commands that fail under the non-root agent user, `${WORKDIR}` placeholders that resolve differently than expected, agent-kit name mismatches, or memory blocks the engine never writes out.
+**Required before opening a PR from a fork** (see the "Why fork contributors must run e2e locally" note at the top of this file). The e2e layer boots a **real `sbx` sandbox** from the kit and verifies the kit's content actually landed inside the running container. It catches things the default TCK can't — install commands that fail under the non-root agent user, `${WORKDIR}` placeholders that resolve differently than expected, agent-kit name mismatches, or memory blocks the engine never writes out.
 
 ```bash
 # From inside the kit's directory:
@@ -162,6 +164,43 @@ Do **not** add `binary:` to `spec.yaml` — the normalizer rejects `binary` at t
 
 `TestE2ERunAgent` skips any kit whose `tck.yaml` is absent or has no `promptArgs`.
 
+### Running e2e under `deny-all` — the real point of running this locally
+
+Running `test-kit-e2e.sh` on its own catches the obvious failures, but the **high-value** local run is under a `deny-all` default network policy. That is what surfaces the exact set of hosts your install and startup hooks reach for — i.e. the **real** `caps.network.allow` you need to ship. Without this step, kits routinely under-declare and ship an allow-list that only works because the contributor's host policy happens to be permissive.
+
+**Use `--app-name sbx-kits-contrib-tck` for every probe command.** `sbx --app-name <name>` scopes the daemon — sandboxes, policies, secrets, and cache for that name live in a separate state directory and do not touch your day-to-day sbx setup. If anything goes wrong (policy stuck in a weird state, leftover `tck-e2e-*` sandboxes, daemon refusing to come back), you can blow the whole thing away with `sbx --app-name sbx-kits-contrib-tck reset --force` and leave your normal sbx work untouched. The e2e harness already passes this app-name on every `sbx` call it makes ([`tck/e2e_test.go:415`](../../../tck/e2e_test.go#L415)), so the policy you set under that name is exactly the policy the harness's sandboxes will see.
+
+```bash
+APP=sbx-kits-contrib-tck
+
+# 1. Switch the tck daemon's default policy to deny-all. Your main daemon
+#    is unaffected. `sbx --app-name $APP policy ls` shows current state.
+sbx --app-name $APP policy reset -f
+sbx --app-name $APP policy set-default deny-all
+
+# 2. Run the e2e suite. Install hooks fire during `sbx create`; anything
+#    not in caps.network.allow is blocked at request time.
+cd my-kit
+../scripts/test-kit-e2e.sh
+
+# 3. If e2e failed: read what the proxy blocked. The sandbox is named
+#    `tck-e2e-<short-uuid>` — list active sandboxes if you need the full name.
+sbx --app-name $APP ls
+sbx --app-name $APP policy log tck-e2e-<short-uuid>
+
+# 4. (Optional) Nuke the tck daemon entirely between iterations. Wipes
+#    only the $APP state — your main sbx is untouched.
+sbx --app-name $APP reset --force
+```
+
+Every row under `Blocked requests` is a host your kit reached for. Add the host (column `HOST`, e.g. `download.docker.com:443`) to `caps.network.allow` and re-run until the block list is empty **and** the e2e test passes. The repository's [`README` recipe](../../../README.md#declare-every-domain-your-kit-needs) explains the same flow against a hand-built probe sandbox — same idea, but the e2e variant above also runs every assertion `TestE2EKit` makes, not just the network ones.
+
+Common hosts that surface only under `deny-all` (easy to forget):
+
+- `download.docker.com` — pre-added to apt sources on `shell-docker` / `*-docker` templates; any `apt-get update` re-fetches it even if you're installing from Ubuntu's main archive.
+- `archive.ubuntu.com` + `security.ubuntu.com` (amd64) **and** `ports.ubuntu.com` (arm64) — list all three so the kit works on both CI (amd64) and Apple Silicon.
+- Registry hosts for each package manager you call: `registry.npmjs.org`, `pypi.org` + `files.pythonhosted.org`, `crates.io` + `static.crates.io`, `proxy.golang.org` + `sum.golang.org`, etc.
+
 ## 4. End-to-end manual verification
 
 For mixins and any time you want to see real container behavior:
@@ -192,15 +231,15 @@ Faster iteration loop, but immutable settings (privileged, volumes, tmpfs) won't
 
 ## Verifying `caps.network.allow`
 
-The proxy enforces allow/deny at request time. To **prove** what's getting through and what's blocked, use `sbx policy log`:
+The proxy enforces allow/deny at request time. The fastest way to surface exactly what your kit reaches for is to run the e2e suite under `deny-all` — see [Running e2e under `deny-all`](#running-e2e-under-deny-all--the-real-point-of-running-this-locally) above for the full recipe.
+
+For ad-hoc probing of a single sandbox without running e2e, `sbx policy log` works directly:
 
 ```bash
 sbx policy log <sandbox>
 ```
 
-The output lists allowed and blocked requests with their host/port. Every entry in the "Blocked requests" section is a domain your install or startup hook reached for. Add it to `caps.network.allow` (or accept the block) and re-probe.
-
-The repository [README](../../../README.md#declare-every-domain-your-kit-needs) has a full recipe for probing a kit against a `deny-all` baseline, including the cross-arch gotchas (`archive.ubuntu.com`, `security.ubuntu.com`, `ports.ubuntu.com`) and the package-manager refresh trap (e.g. `apt-get update` re-fetches every configured source).
+Every entry in the "Blocked requests" section is a domain your install or startup hook reached for. Add it to `caps.network.allow` (or accept the block) and re-probe. The repository [README](../../../README.md#declare-every-domain-your-kit-needs) has the hand-built probe-sandbox variant of this recipe.
 
 ## Common pitfall: "install commands completed" ≠ success
 
@@ -222,4 +261,4 @@ See [Pitfalls — `commands.startup` runs on every container start](pitfalls.md#
 
 ## CI
 
-The repository's CI runs the TCK on every PR — the matrix tests only the modified kit on PRs that touch a kit directory, and every kit on PRs that touch `tck/` or `spec/`. The optional `test-kit-e2e` job exercises every detected kit against a real `sbx` CLI. See [`.github/workflows/tck.yml`](../../../.github/workflows/tck.yml).
+The repository's CI runs the TCK on every PR — the matrix tests only the modified kit on PRs that touch a kit directory, and every kit on PRs that touch `tck/` or `spec/`. The `test-kit-e2e` job exercises every detected kit against a real `sbx` CLI, but **is skipped on PRs opened from forks** because the `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` secrets aren't exposed to fork-triggered workflows. Fork contributors are the common case, so you should treat e2e + `deny-all` as a **mandatory local step** before opening the PR — don't rely on a green CI check to mean "e2e passed". See [`.github/workflows/tck.yml`](../../../.github/workflows/tck.yml).

--- a/skills/kit-author/topics/testing.md
+++ b/skills/kit-author/topics/testing.md
@@ -164,36 +164,39 @@ Do **not** add `binary:` to `spec.yaml` — the normalizer rejects `binary` at t
 
 `TestE2ERunAgent` skips any kit whose `tck.yaml` is absent or has no `promptArgs`.
 
-### Running e2e under `deny-all` — the real point of running this locally
+### Running e2e
 
-Running `test-kit-e2e.sh` on its own catches the obvious failures, but the **high-value** local run is under a `deny-all` default network policy. That is what surfaces the exact set of hosts your install and startup hooks reach for — i.e. the **real** `caps.network.allow` you need to ship. Without this step, kits routinely under-declare and ship an allow-list that only works because the contributor's host policy happens to be permissive.
+```bash
+cd my-kit
+../scripts/test-kit-e2e.sh
+```
 
-**Use `--app-name sbx-kits-contrib-tck` for every probe command.** `sbx --app-name <name>` scopes the daemon — sandboxes, policies, secrets, and cache for that name live in a separate state directory and do not touch your day-to-day sbx setup. If anything goes wrong (policy stuck in a weird state, leftover `tck-e2e-*` sandboxes, daemon refusing to come back), you can blow the whole thing away with `sbx --app-name sbx-kits-contrib-tck reset --force` and leave your normal sbx work untouched. The e2e harness already passes this app-name on every `sbx` call it makes ([`tck/e2e_test.go:415`](../../../tck/e2e_test.go#L415)), so the policy you set under that name is exactly the policy the harness's sandboxes will see.
+That's the whole recipe — no manual policy dance. The script:
+
+- Scopes every `sbx` call to `--app-name sbx-kits-contrib-tck`, the same app-name the e2e harness uses internally ([`tck/e2e_test.go:415`](../../../tck/e2e_test.go#L415)). The test daemon's sandboxes, policy, secrets, and cache are isolated from your day-to-day sbx state.
+- Sets the scoped daemon's default network policy to `deny-all` — the same baseline CI uses, so any host your install or startup hooks reach for must be in `caps.network.allow` or the request is blocked.
+- Runs `go test -tags=e2e` with `KIT_UNDER_TEST` exported.
+- On non-zero exit, prints a hint pointing at `sbx --app-name sbx-kits-contrib-tck policy log <sandbox>`.
+
+The script is idempotent (re-runs converge on the same state) and non-interactive. Overrides: `APP_NAME` (default `sbx-kits-contrib-tck`) and `POLICY` (default `deny-all`; set `POLICY=` to skip the policy step).
+
+One-time setup per machine — the scoped daemon has its own credential store:
+
+```bash
+sbx --app-name sbx-kits-contrib-tck login
+```
+
+When the test fails, the recurring fix is the same loop: read the proxy log, add the blocked host to `caps.network.allow`, re-run.
 
 ```bash
 APP=sbx-kits-contrib-tck
-
-# 1. Switch the tck daemon's default policy to deny-all. Your main daemon
-#    is unaffected. `sbx --app-name $APP policy ls` shows current state.
-sbx --app-name $APP policy reset -f
-sbx --app-name $APP policy set-default deny-all
-
-# 2. Run the e2e suite. Install hooks fire during `sbx create`; anything
-#    not in caps.network.allow is blocked at request time.
-cd my-kit
-../scripts/test-kit-e2e.sh
-
-# 3. If e2e failed: read what the proxy blocked. The sandbox is named
-#    `tck-e2e-<short-uuid>` — list active sandboxes if you need the full name.
-sbx --app-name $APP ls
+sbx --app-name $APP ls                            # find the tck-e2e-* sandbox
 sbx --app-name $APP policy log tck-e2e-<short-uuid>
-
-# 4. (Optional) Nuke the tck daemon entirely between iterations. Wipes
-#    only the $APP state — your main sbx is untouched.
-sbx --app-name $APP reset --force
 ```
 
-Every row under `Blocked requests` is a host your kit reached for. Add the host (column `HOST`, e.g. `download.docker.com:443`) to `caps.network.allow` and re-run until the block list is empty **and** the e2e test passes. The repository's [`README` recipe](../../../README.md#declare-every-domain-your-kit-needs) explains the same flow against a hand-built probe sandbox — same idea, but the e2e variant above also runs every assertion `TestE2EKit` makes, not just the network ones.
+Every row under `Blocked requests` is a host your kit reached for under `deny-all`. Add the host (column `HOST`, e.g. `download.docker.com:443`) to `caps.network.allow` and re-run until the block list is empty *and* the e2e test passes.
+
+If the scoped daemon ever gets wedged: `sbx --app-name sbx-kits-contrib-tck reset --force` wipes only that daemon's state — your main sbx is untouched.
 
 Common hosts that surface only under `deny-all` (easy to forget):
 
@@ -231,7 +234,7 @@ Faster iteration loop, but immutable settings (privileged, volumes, tmpfs) won't
 
 ## Verifying `caps.network.allow`
 
-The proxy enforces allow/deny at request time. The fastest way to surface exactly what your kit reaches for is to run the e2e suite under `deny-all` — see [Running e2e under `deny-all`](#running-e2e-under-deny-all--the-real-point-of-running-this-locally) above for the full recipe.
+The proxy enforces allow/deny at request time. The fastest way to surface exactly what your kit reaches for is to run the e2e suite — see [Running e2e](#running-e2e) above. The script applies `deny-all` to the scoped daemon for you.
 
 For ad-hoc probing of a single sandbox without running e2e, `sbx policy log` works directly:
 


### PR DESCRIPTION
- **docs(e2e): enforce authors to run the e2e locally**
- **chore(e2e): simplify e2e execution**
- **fix: use v1 field**
- **chore(tck): add sbx login probe**
