### PR TITLE
Add microsoft-agent-framework kit

### DIFF
--- a/microsoft-agent-framework/README.md
+++ b/microsoft-agent-framework/README.md
@@ -18,12 +18,14 @@ First, store your provider key on the host (it never enters the sandbox):
 # OpenAI — uses the platform's built-in `openai` service
 $ sbx secret set -g openai
 
-# Azure OpenAI (optional) — this kit wires up the custom `azure-openai` service.
-# On first use, sbx prompts you to bind where AZURE_OPENAI_API_KEY lives and to
-# approve the *.openai.azure.com domain. You can also set it non-interactively:
-$ sbx secret set-custom -g --host '*.openai.azure.com' \
-    --env AZURE_OPENAI_API_KEY --value '<your-azure-key>'
+# Azure OpenAI (optional) — this kit declares the `azure-openai` service, so
+# store the key under that service name. sbx prompts to approve the
+# *.openai.azure.com domain the first time a sandbox uses it.
+$ sbx secret set -g azure-openai
 ```
+
+The key is read from stdin; pipe it non-interactively if you prefer,
+e.g. `printf '%s' "$AZURE_OPENAI_API_KEY" | sbx secret set -g azure-openai`.
 
 Then pair the kit with whichever sandbox agent you want to work from:
 
@@ -95,12 +97,15 @@ allows `api.openai.com` in its network policy and leaves the credential to the
 platform — store it with `sbx secret set -g openai`. Set your model with e.g.
 `OPENAI_CHAT_MODEL=gpt-4o-mini`.
 
-**Azure OpenAI** is not a built-in service, so the kit wires it up explicitly
-(`service: azure-openai`, injecting the `api-key` header into
-`*.openai.azure.com`). Set `AZURE_OPENAI_ENDPOINT`
-(`https://<resource>.openai.azure.com`) and your deployment via
-`AZURE_OPENAI_CHAT_MODEL`. The credential is optional — leaving it unset does
-not block sandbox creation.
+**Azure OpenAI** is not a built-in service, so the kit declares it explicitly
+(`service: azure-openai`, `proxyManaged: true`, injecting the `api-key` header
+into `*.openai.azure.com`). Store the key under that service name with
+`sbx secret set -g azure-openai`; it then reads as the `proxy-managed`
+placeholder in-container. The endpoint and model are non-secret selection
+variables you set directly: `AZURE_OPENAI_ENDPOINT`
+(`https://<resource>.openai.azure.com`) and `AZURE_OPENAI_CHAT_MODEL`
+(your deployment). The credential is optional — leaving it unset does not block
+sandbox creation.
 
 For other backends (Anthropic, Ollama, Foundry), use their built-in service or
 compose a separate provider mixin — this kit stays narrowly scoped to OpenAI

--- a/microsoft-agent-framework/README.md
+++ b/microsoft-agent-framework/README.md
@@ -1,0 +1,159 @@
+# Microsoft Agent Framework
+
+A mixin that installs the [Microsoft Agent Framework](https://github.com/microsoft/agent-framework)
+(Python) inside the sandbox. It creates an isolated Python virtual environment
+at `/opt/agent-framework`, installs the pinned `agent-framework` package plus
+the **DevUI** interactive tester, and wires up proxy-managed credentials and
+network egress for OpenAI and Azure OpenAI.
+
+The Agent Framework is a library for building production-grade AI agents and
+multi-agent workflows — not a standalone CLI — so this kit layers onto whichever
+sandbox agent you drive it from (claude, shell, etc.).
+
+## Usage
+
+First, store your provider key on the host (it never enters the sandbox):
+
+```console
+# OpenAI — uses the platform's built-in `openai` service
+$ sbx secret set -g openai
+
+# Azure OpenAI (optional) — this kit wires up the custom `azure-openai` service.
+# On first use, sbx prompts you to bind where AZURE_OPENAI_API_KEY lives and to
+# approve the *.openai.azure.com domain. You can also set it non-interactively:
+$ sbx secret set-custom -g --host '*.openai.azure.com' \
+    --env AZURE_OPENAI_API_KEY --value '<your-azure-key>'
+```
+
+Then pair the kit with whichever sandbox agent you want to work from:
+
+```console
+$ sbx run shell --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=microsoft-agent-framework" ~/my-project
+$ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=microsoft-agent-framework" ~/my-project
+```
+
+Once attached, the venv interpreter and DevUI are available:
+
+```console
+agent@sandbox:~$ agent-framework-python -c 'import agent_framework; print("ok")'
+agent@sandbox:~$ devui --help
+```
+
+A minimal OpenAI example:
+
+```console
+agent@sandbox:~$ cat > agent.py <<'PY'
+import asyncio
+from agent_framework.openai import OpenAIChatClient
+
+async def main():
+    agent = OpenAIChatClient(model="gpt-4o-mini").as_agent(
+        name="Assistant",
+        instructions="You are a helpful assistant.",
+    )
+    print((await agent.run("Write a haiku about sandboxes.")).text)
+
+asyncio.run(main())
+PY
+agent@sandbox:~$ agent-framework-python agent.py
+```
+
+## What gets installed
+
+The kit installs Python prerequisites from Ubuntu packages, creates
+`/opt/agent-framework`, and installs `agent-framework==1.9.0` together with the
+`agent-framework-devui` package with pip. DevUI only publishes pre-releases, so
+it is installed with `--pre` and pinned explicitly.
+
+The package is intentionally installed in a venv rather than into system Python
+so project dependencies in the workspace do not collide with the kit. Two
+helpers are placed on `PATH`:
+
+- `agent-framework-python` — runs the kit-managed interpreter
+  (`/opt/agent-framework/bin/python`). Use it to run framework scripts.
+- `devui` — the upstream DevUI launcher.
+
+`AGENT_FRAMEWORK_VENV` and `AGENT_FRAMEWORK_PYTHON` are exported into the
+environment and into interactive shells via `~/.bashrc`.
+
+## Providers and credentials
+
+The kit targets the two Microsoft-recommended backends. In every case the API
+key is **proxy-managed**: inside the sandbox the env var holds a placeholder
+(`OPENAI_API_KEY` reads as `proxy-managed`), and the host proxy swaps in the
+real value on outbound requests — the key never appears in the VM.
+
+| Provider | Env var | Credential source | How the proxy injects |
+|----------|---------|-------------------|------------------------|
+| OpenAI | `OPENAI_API_KEY` | Platform built-in `openai` service (`sbx secret set -g openai`) | `Authorization: Bearer <key>` → `api.openai.com` |
+| Azure OpenAI | `AZURE_OPENAI_API_KEY` | This kit's custom `azure-openai` credential | `api-key: <key>` → `*.openai.azure.com` |
+
+**OpenAI is intentionally not redeclared by this kit.** The built-in sandbox
+agents (`shell`, `claude`, `codex`, …) already ship an `openai` credential, and
+a kit that re-declares the same `service` collides at compose time. So the kit
+allows `api.openai.com` in its network policy and leaves the credential to the
+platform — store it with `sbx secret set -g openai`. Set your model with e.g.
+`OPENAI_CHAT_MODEL=gpt-4o-mini`.
+
+**Azure OpenAI** is not a built-in service, so the kit wires it up explicitly
+(`service: azure-openai`, injecting the `api-key` header into
+`*.openai.azure.com`). Set `AZURE_OPENAI_ENDPOINT`
+(`https://<resource>.openai.azure.com`) and your deployment via
+`AZURE_OPENAI_CHAT_MODEL`. The credential is optional — leaving it unset does
+not block sandbox creation.
+
+For other backends (Anthropic, Ollama, Foundry), use their built-in service or
+compose a separate provider mixin — this kit stays narrowly scoped to OpenAI
+and Azure OpenAI.
+
+## DevUI
+
+DevUI is an optional web tester + OpenAI-compatible REST API for exercising
+agents. Container port `8080` is published to an ephemeral host port. DevUI
+binds to `127.0.0.1` by default, so launch it on all interfaces to reach it
+from the host:
+
+```console
+agent@sandbox:~$ devui ./agents --host 0.0.0.0 --port 8080
+```
+
+Then find the assigned host port and open it in your browser:
+
+```console
+$ sbx ports <sandbox>
+```
+
+DevUI is for development/testing, not a production runtime — the kit does not
+start it automatically.
+
+## Network policy
+
+The kit's allowlist covers the install path plus the OpenAI/Azure runtime
+baseline:
+
+- `pypi.org` and `files.pythonhosted.org` for pip installs.
+- `api.openai.com` for OpenAI.
+- `*.openai.azure.com` for Azure OpenAI deployments, and
+  `*.services.ai.azure.com` for Microsoft Foundry endpoints.
+- `login.microsoftonline.com` for Azure AD token exchange when authenticating
+  via `AzureCliCredential` instead of an API key.
+- Ubuntu and Docker apt hosts required by the base sandbox template during
+  `apt-get update`.
+
+The allowlist is deliberately minimal so reviewers can see the exact egress
+contract. If your agent calls additional services (other model providers, MCP
+servers, arbitrary websites), allow those domains explicitly.
+
+## Bumping the version
+
+To update the kit, change `AF_VERSION` (and `DEVUI_VERSION` if needed) in
+`spec.yaml`, run the TCK, and verify in a real sandbox:
+
+```console
+$ cd microsoft-agent-framework
+$ ../scripts/test-kit.sh
+$ sbx run shell --kit ./ ~/tmp-project
+```
+
+If the new release adds dependencies or changes provider hosts, update the
+network allowlist in the same patch.

--- a/microsoft-agent-framework/spec.yaml
+++ b/microsoft-agent-framework/spec.yaml
@@ -1,0 +1,103 @@
+schemaVersion: "2"
+kind: mixin
+name: microsoft-agent-framework
+displayName: Microsoft Agent Framework
+description: "Installs the Microsoft Agent Framework (Python) and DevUI into an isolated venv for building AI agents and multi-agent workflows against OpenAI and Azure OpenAI."
+
+publishedPorts:
+  - container: 8080
+    protocol: tcp
+    name: devui
+
+# OpenAI is intentionally NOT declared here: the built-in sandbox agents
+# (shell, claude, codex, ...) already ship an `openai` credential, and a kit
+# that re-declares the same service collides at compose time. Store the key
+# with `sbx secret set -g openai` and the platform proxy injects it for you.
+# Azure OpenAI is not a built-in service, so this kit wires it up explicitly.
+credentials:
+  - service: azure-openai
+    description: "Azure OpenAI API key"
+    apiKey:
+      name: AZURE_OPENAI_API_KEY
+      inject:
+        - domain: "*.openai.azure.com"
+          header: api-key
+          format: "%s"
+
+caps:
+  network:
+    allow:
+      # pip install path for agent-framework, devui, and their dependencies.
+      - "pypi.org:443"
+      - "files.pythonhosted.org:443"
+      # OpenAI + Azure OpenAI runtime endpoints used by the chat clients.
+      - "api.openai.com"
+      - "*.openai.azure.com"
+      # Microsoft Foundry endpoints (FoundryChatClient).
+      - "*.services.ai.azure.com"
+      # Azure AD token endpoint, used when authenticating via AzureCliCredential.
+      - "login.microsoftonline.com"
+      # `apt-get update` refreshes every configured apt source from the base
+      # template. Keep all template sources allowed for amd64 and arm64 sandboxes.
+      - "archive.ubuntu.com:80"
+      - "security.ubuntu.com:80"
+      - "ports.ubuntu.com:80"
+      - "download.docker.com:443"
+
+environment:
+  variables:
+    AGENT_FRAMEWORK_VENV: "/opt/agent-framework"
+    AGENT_FRAMEWORK_PYTHON: "/opt/agent-framework/bin/python"
+
+commands:
+  install:
+    - command: "apt-get update && apt-get install -y --no-install-recommends ca-certificates python3 python3-venv python3-pip && rm -rf /var/lib/apt/lists/*"
+      user: "0"
+      description: Install Python and venv prerequisites for the Agent Framework
+    - command: |
+        set -euo pipefail
+        AF_VERSION=1.9.0
+        DEVUI_VERSION=1.0.0b260528
+        python3 -m venv /opt/agent-framework
+        /opt/agent-framework/bin/python -m pip install --upgrade pip setuptools wheel
+        # DevUI only ships pre-releases, so --pre is required; agent-framework is
+        # pinned exactly, so pip still selects the stable 1.9.0 release for it.
+        /opt/agent-framework/bin/python -m pip install --pre \
+          "agent-framework==${AF_VERSION}" \
+          "agent-framework-devui==${DEVUI_VERSION}"
+        ln -sf /opt/agent-framework/bin/devui /usr/local/bin/devui
+        cat > /usr/local/bin/agent-framework-python <<'SCRIPT'
+        #!/bin/sh
+        exec /opt/agent-framework/bin/python "$@"
+        SCRIPT
+        chmod 0755 /usr/local/bin/agent-framework-python
+        devui --help >/dev/null
+        agent-framework-python -c 'import agent_framework; print("agent-framework OK")'
+      user: "0"
+      description: "Install Agent Framework v1.9.0 + DevUI into /opt/agent-framework"
+    - command: |
+        set -euo pipefail
+        grep -qF 'AGENT_FRAMEWORK_VENV' ~/.bashrc 2>/dev/null || \
+          printf '\n# Microsoft Agent Framework (added by sbx-kits-contrib/microsoft-agent-framework)\nexport AGENT_FRAMEWORK_VENV=/opt/agent-framework\nexport AGENT_FRAMEWORK_PYTHON=/opt/agent-framework/bin/python\nalias agent-framework-python=/opt/agent-framework/bin/python\n' >> ~/.bashrc
+      user: "1000"
+      description: Add Agent Framework helper environment variables to interactive shells
+
+agentContext: |
+  ## Microsoft Agent Framework
+
+  This sandbox has the Microsoft Agent Framework (Python) installed in an
+  isolated virtual environment at `/opt/agent-framework`.
+
+  - Run framework code with `agent-framework-python <script.py>` (an alias for
+    `/opt/agent-framework/bin/python`). Use this interpreter so imports resolve
+    against the Agent Framework venv.
+  - Configure a model provider via environment variables:
+    - **OpenAI** — set `OPENAI_API_KEY` (and e.g. `OPENAI_CHAT_MODEL`).
+    - **Azure OpenAI** — set `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT`,
+      and your deployment via `AZURE_OPENAI_CHAT_MODEL`.
+    The API keys are proxy-managed: the real value never enters the sandbox —
+    the host proxy injects the auth header on outbound requests.
+  - Launch the DevUI interactive tester (bind to all interfaces so the published
+    port is reachable from the host):
+    `devui ./agents --host 0.0.0.0 --port 8080`
+    then find the host port with `sbx ports <sandbox>`.

--- a/microsoft-agent-framework/spec.yaml
+++ b/microsoft-agent-framework/spec.yaml
@@ -19,6 +19,12 @@ credentials:
     description: "Azure OpenAI API key"
     apiKey:
       name: AZURE_OPENAI_API_KEY
+      # proxyManaged sets AZURE_OPENAI_API_KEY to the literal "proxy-managed"
+      # sentinel inside the container so the Agent Framework's Azure client
+      # picks up the key from the env; the proxy swaps the sentinel for the
+      # real value on requests to *.openai.azure.com. Without this the env var
+      # is never set in-container and the Azure path won't activate.
+      proxyManaged: true
       inject:
         - domain: "*.openai.azure.com"
           header: api-key
@@ -91,12 +97,14 @@ agentContext: |
   - Run framework code with `agent-framework-python <script.py>` (an alias for
     `/opt/agent-framework/bin/python`). Use this interpreter so imports resolve
     against the Agent Framework venv.
-  - Configure a model provider via environment variables:
-    - **OpenAI** — set `OPENAI_API_KEY` (and e.g. `OPENAI_CHAT_MODEL`).
-    - **Azure OpenAI** — set `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT`,
-      and your deployment via `AZURE_OPENAI_CHAT_MODEL`.
-    The API keys are proxy-managed: the real value never enters the sandbox —
-    the host proxy injects the auth header on outbound requests.
+  - API keys are proxy-managed and are NOT typed inside the sandbox. They are
+    set on the host with `sbx secret set` and appear in-container only as the
+    literal `proxy-managed` placeholder (`OPENAI_API_KEY` / `AZURE_OPENAI_API_KEY`);
+    the host proxy swaps in the real value on outbound requests. Inside the
+    sandbox you only set non-secret provider/model selection variables:
+    - **OpenAI** — model via e.g. `OPENAI_CHAT_MODEL=gpt-4o-mini`.
+    - **Azure OpenAI** — `AZURE_OPENAI_ENDPOINT` (your resource URL) and the
+      deployment via `AZURE_OPENAI_CHAT_MODEL`.
   - Launch the DevUI interactive tester (bind to all interfaces so the published
     port is reachable from the host):
     `devui ./agents --host 0.0.0.0 --port 8080`

--- a/microsoft-agent-framework/spec.yaml
+++ b/microsoft-agent-framework/spec.yaml
@@ -98,10 +98,10 @@ agentContext: |
     `/opt/agent-framework/bin/python`). Use this interpreter so imports resolve
     against the Agent Framework venv.
   - API keys are proxy-managed and are NOT typed inside the sandbox. They are
-    set on the host with `sbx secret set` and appear in-container only as the
-    literal `proxy-managed` placeholder (`OPENAI_API_KEY` / `AZURE_OPENAI_API_KEY`);
-    the host proxy swaps in the real value on outbound requests. Inside the
-    sandbox you only set non-secret provider/model selection variables:
+    set on the host with `sbx secret set`; when a provider is configured, its
+    env var appears in-container only as the literal `proxy-managed` placeholder
+    (`OPENAI_API_KEY` and/or `AZURE_OPENAI_API_KEY`). The host proxy swaps in the
+    real value on outbound requests. Inside the sandbox you only set non-secret provider/model selection variables:
     - **OpenAI** — model via e.g. `OPENAI_CHAT_MODEL=gpt-4o-mini`.
     - **Azure OpenAI** — `AZURE_OPENAI_ENDPOINT` (your resource URL) and the
       deployment via `AZURE_OPENAI_CHAT_MODEL`.


### PR DESCRIPTION
Adds a v2 mixin that installs the Microsoft Agent Framework (Python) + DevUI into 
  an isolated venv, allows the OpenAI/Azure OpenAI egress domains, and wires the Azure OpenAI 
  credential. OpenAI uses the platform's built-in credential to avoid a compose conflict. 
  Validated end-to-end on sbx v0.33.0 (TCK passes; live OpenAI call through the proxy 
  succeeds). Uses schemaVersion 2 per the repo's kit-author skill.