### PR TITLE
Add claude code router kit

### DIFF
--- a/claude-code-router/README.md
+++ b/claude-code-router/README.md
@@ -1,0 +1,70 @@
+# claude-code-router
+
+A standalone agent kit (`kind: agent`) that installs Claude Code plus
+[**claude-code-router**](https://github.com/musistudio/claude-code-router)
+(`ccr`) and routes every request through OpenRouter instead of Anthropic's
+API directly. Useful for cost control, using non-Anthropic models, or
+per-request-type routing (default / background / think / long-context).
+
+> **Heads-up on docs drift:** the `claude-code-router` GitHub repo's `main`
+> branch README now documents a separate **desktop GUI app** ("Claude Code
+> Router Desktop") that can't run headlessly in a container. This kit uses
+> the CLI still published to npm as
+> [`@musistudio/claude-code-router`](https://www.npmjs.com/package/@musistudio/claude-code-router)
+> (bin: `ccr`), which is what `ccr start` / `ccr code` / `~/.claude-code-router/config.json`
+> refer to below — that's the correct fit for a sandbox, not the Electron app.
+
+> **Prerequisite:** an [OpenRouter](https://openrouter.ai/keys) API key.
+> Declare it in `~/.config/sbx/credentials.yaml` under the `openrouter`
+> service before running this kit — see the [bindings
+> docs](https://docs.docker.com/ai/sandboxes/customize/kits/) for the exact
+> format.
+
+## Usage
+
+```console
+$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=claude-code-router" claude-code-router ~/my-project
+$ sbx run --kit ./claude-code-router/ claude-code-router ~/my-project
+```
+
+The agent name passed to `sbx run` (`claude-code-router`) matches the
+`name:` field in the kit's `spec.yaml`.
+
+## How it works
+
+- **Install**: `npm install -g @anthropic-ai/claude-code @musistudio/claude-code-router`
+  pulls in both the real Claude Code CLI and the router.
+- **Config**: `commands.initFiles` seeds `~/.claude-code-router/config.json`
+  with one `openrouter` provider and a `Router` table that maps Claude
+  Code's `default` / `background` / `think` / `longContext` request classes
+  to `anthropic/claude-sonnet-5`, `anthropic/claude-haiku-4.5`, and
+  `anthropic/claude-opus-4.8` — all served through OpenRouter. The file is
+  written with `onlyIfMissing: true` so a later `ccr model` edit (or a
+  persistent volume) survives sandbox restarts.
+- **Credential**: the kit declares an `openrouter` service
+  (`network.serviceDomains` / `serviceAuth`). The proxy injects the real key
+  as an `Authorization: Bearer <token>` header on outbound requests to
+  `openrouter.ai` — the container only ever sees the `proxy-managed`
+  sentinel via `$OPENROUTER_API_KEY`, which `ccr` interpolates into
+  `config.json` at `api_key` using its built-in `$VAR_NAME` substitution.
+- **Entrypoint**: `ccr code --dangerously-skip-permissions` starts the
+  router service (if not already running) and execs Claude Code with
+  `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN` pointed at the local router
+  — the real `claude` binary never talks to `api.anthropic.com`.
+- `NON_INTERACTIVE_MODE: true` in `config.json` keeps `ccr` from hanging on
+  stdin prompts in a container.
+
+## Changing models or providers
+
+Fork this kit, edit the `Providers` / `Router` blocks in `spec.yaml`, and
+point `--kit` at your local copy — see [`claude-model-runner`](../claude-model-runner)
+for the equivalent recipe. `ccr` supports OpenRouter, DeepSeek, Ollama,
+Gemini, and other OpenAI-compatible endpoints; add a new `Providers` entry
+and a matching `network.serviceDomains` / `serviceAuth` / `allowedDomains`
+triple for any additional provider domain.
+
+## Related
+
+- [claude-code-router (npm)](https://www.npmjs.com/package/@musistudio/claude-code-router)
+- [OpenRouter](https://openrouter.ai/)
+- [`claude-ollama`](../claude-ollama) and [`claude-model-runner`](../claude-model-runner) — sibling kits that route Claude Code to a local model backend instead of a hosted one

--- a/claude-code-router/spec.yaml
+++ b/claude-code-router/spec.yaml
@@ -18,6 +18,7 @@ network:
       headerName: Authorization
       valueFormat: "Bearer %s"
   allowedDomains:
+    - "openrouter.ai:443"
     - registry.npmjs.org
     - "*.npmjs.org"
 

--- a/claude-code-router/spec.yaml
+++ b/claude-code-router/spec.yaml
@@ -1,0 +1,114 @@
+schemaVersion: "1"
+kind: agent
+name: claude-code-router
+displayName: Claude Code Router
+description: "Claude Code routed through claude-code-router (ccr) to OpenRouter models instead of Anthropic's API directly."
+
+agent:
+  image: "docker/sandbox-templates:shell-docker"
+  aiFilename: CLAUDE.md
+  entrypoint:
+    run: [ccr, code, "--dangerously-skip-permissions"]
+
+network:
+  serviceDomains:
+    openrouter.ai: openrouter
+  serviceAuth:
+    openrouter:
+      headerName: Authorization
+      valueFormat: "Bearer %s"
+  allowedDomains:
+    - registry.npmjs.org
+    - "*.npmjs.org"
+
+credentials:
+  sources:
+    openrouter:
+      env:
+        - OPENROUTER_API_KEY
+
+environment:
+  variables:
+    IS_SANDBOX: "1"
+  proxyManaged:
+    - OPENROUTER_API_KEY
+
+commands:
+  install:
+    - command: "npm install -g @anthropic-ai/claude-code @musistudio/claude-code-router"
+      user: "1000"
+      description: Install Claude Code and claude-code-router (ccr)
+    # Seed ~/.claude/settings.json early (install runs synchronously before the
+    # agent launches). This kit routes through ccr, not Anthropic's API
+    # directly, so there's no ANTHROPIC_API_KEY credential and no
+    # apiKeyHelper to configure. The test -f guard makes re-runs a no-op and
+    # never clobbers a user-edited file. root-write + chown because
+    # shell-docker ownership of /home/agent/.claude is not guaranteed
+    # agent-owned.
+    - command: |
+        set -e
+        mkdir -p /home/agent/.claude
+        if [ ! -f /home/agent/.claude/settings.json ]; then
+          printf '%s' '{
+          "themeId": 1,
+          "alwaysThinkingEnabled": true,
+          "defaultMode": "bypassPermissions",
+          "bypassPermissionsModeAccepted": true
+        }
+        ' > /home/agent/.claude/settings.json
+        fi
+        chown -R agent:agent /home/agent/.claude
+      user: "root"
+      description: Seed Claude settings.json (bypass permissions; no apiKeyHelper needed)
+  initFiles:
+    - path: /home/agent/.claude.json
+      content: |
+        {
+          "bypassPermissionsModeAccepted": true,
+          "hasCompletedOnboarding": true,
+          "projects": {
+              "/": {
+              "hasTrustDialogAccepted": true
+            }
+          }
+        }
+      onlyIfMissing: true
+      description: Claude bypass flags (skip onboarding/trust dialogs)
+    - path: /home/agent/.claude-code-router/config.json
+      mode: "0644"
+      onlyIfMissing: true
+      description: Configure ccr to route Claude Code through OpenRouter (edit and run `ccr restart` to change models/providers)
+      content: |
+        {
+          "NON_INTERACTIVE_MODE": true,
+          "Providers": [
+            {
+              "name": "openrouter",
+              "api_base_url": "https://openrouter.ai/api/v1/chat/completions",
+              "api_key": "$OPENROUTER_API_KEY",
+              "models": [
+                "anthropic/claude-sonnet-5",
+                "anthropic/claude-opus-4.8",
+                "anthropic/claude-haiku-4.5"
+              ],
+              "transformer": {
+                "use": ["openrouter"]
+              }
+            }
+          ],
+          "Router": {
+            "default": "openrouter,anthropic/claude-sonnet-5",
+            "background": "openrouter,anthropic/claude-haiku-4.5",
+            "think": "openrouter,anthropic/claude-opus-4.8",
+            "longContext": "openrouter,anthropic/claude-sonnet-5"
+          }
+        }
+
+memory: |
+  ## Sandbox environment
+
+  You are running inside a Docker sandbox. Claude Code's requests are routed
+  through claude-code-router (`ccr`) to OpenRouter instead of Anthropic's API
+  directly — see ~/.claude-code-router/config.json for the provider and model
+  routing table. The workspace is mounted at its absolute host path. `sudo`
+  is passwordless; use it for package installs.

--- a/claude-code-router/testdata/tck.yaml
+++ b/claude-code-router/testdata/tck.yaml
@@ -1,0 +1,1 @@
+promptArgs: ["code", "-p"]


### PR DESCRIPTION
## Summary

Adds `claude-code-router`, a standalone agent kit (`kind: agent`) that installs
Claude Code plus [`@musistudio/claude-code-router`](https://www.npmjs.com/package/@musistudio/claude-code-router)
(`ccr`) and routes every request through OpenRouter instead of Anthropic's API
directly, with per-request-class model routing (`default` / `background` /
`think` / `longContext`).

## Spec choices worth flagging for review

- **Docs drift on the upstream project**: `claude-code-router`'s GitHub `main`
  README now documents a separate desktop GUI app ("Claude Code Router
  Desktop") that can't run headlessly in a container. This kit targets the
  CLI still published to npm as `@musistudio/claude-code-router` (bin `ccr`,
  `~/.claude-code-router/config.json`, `ccr start`/`ccr code`), confirmed
  against the package's actual bundled README and verified live in a
  container  that's the correct fit for a sandbox, not the Electron app.
  Called out explicitly in the kit's README so the next reader isn't
  surprised by the mismatch.
- **`network.serviceDomains`/`serviceAuth` vs `network.allowedDomains`**:
  these are separate contracts  declaring the credential service does not
  implicitly allow the domain. Caught this the hard way under `deny-all` e2e
  (see Test plan) and added `openrouter.ai:443` to `allowedDomains`.
- **Model IDs** (`anthropic/claude-sonnet-5`, `anthropic/claude-opus-4.8`,
  `anthropic/claude-haiku-4.5`) were checked against OpenRouter's live
  `/api/v1/models` catalog, not guessed.
- Built on `shell-docker` (not `claude-code-docker`) since the kit installs
  its own `claude` + `ccr` via npm at creation time, following the same
  pattern as `pi/` and `openclaw/`.

## Origin

Net-new kit — built from the ground up against the npm-published
`claude-code-router` CLI and OpenRouter's live model catalog, following the
`pi`/`openclaw`/`claude-ollama`/`amp` kits in this repo as structural
templates.

## Test plan

- [x] `sbx kit validate ./claude-code-router/` passes (only the expected v1
      deprecation warnings shared by every kit in this repo).
- [x] `./scripts/test-kit.sh claude-code-router` passes (the TCK) — including
      a real container run of the install commands.
- [x] `./scripts/test-kit-e2e.sh claude-code-router` passes under `deny-all`,
      scoped to `--app-name sbx-kits-contrib-tck`. `openrouter.ai:443` in
      `network.allowedDomains` came from a real blocked-request observed via
      `sbx --app-name sbx-kits-contrib-tck policy log`, not a guess.
- [x] Manual smoke: `sbx run --kit ./claude-code-router/ claude-code-router`,
      then verified inside the running container: `ccr` and `claude` both on
      `PATH`, `~/.claude-code-router/config.json` has the expected
      Providers/Router content, `OPENROUTER_API_KEY` is set to the
      proxy-managed sentinel (not a raw secret), and `https://openrouter.ai`
      is reachable (`200`).
- [x] End-to-end credential + routing proof: bound a real OpenRouter key via
      `sbx secret set-custom`, then called the router's Anthropic-compatible
      endpoint directly inside a running sandbox — got back a real model
      completion (`{"model":"openai/gpt-oss-20b:free", "content":[{"text":"OK-CCR"}]}`),
      confirming the sentinel-swap proxy, `ccr`'s routing, and OpenRouter
      connectivity all work end-to-end. (Used a free-tier model for this
      check only; the shipped `config.json` defaults to the real Claude
      models via OpenRouter.)
