### PR TITLE
fix(kit-author): correct resources field name and validation rule

### DIFF
--- a/skills/kit-author/topics/lifecycle.md
+++ b/skills/kit-author/topics/lifecycle.md
@@ -54,7 +54,7 @@ After normalization, only the canonical v2 fields are populated. The legacy fiel
 
 `spec.ValidateArtifact` runs from each `Load*` path:
 
-- **Manifest** — `schemaVersion ∈ {"1", "2"}`, `kind ∈ {sandbox, mixin}` (also accepts v1 `agent` alias), `name` is lowercase alphanumeric + hyphen (1–64 chars), exactly one of `sandbox.image` / `sandbox.build` required for sandbox kits, `resources.cpu` / `resources.memory_mb` must be positive if set.
+- **Manifest** — `schemaVersion ∈ {"1", "2"}`, `kind ∈ {sandbox, mixin}` (also accepts v1 `agent` alias), `name` is lowercase alphanumeric + hyphen (1–64 chars), exactly one of `sandbox.image` / `sandbox.build` required for sandbox kits, `resources.cpu` must be a non-negative number and `resources.memoryMB` a non-negative integer if set.
 - **Caps.Network** — entry strings are exact host, exact host+port, or leading-label wildcard (`*.example.com`). Overlap between `allow` and `deny` is **legal** — at request time, deny wins.
 - **Credentials** — each entry has `service` set; `apiKey.inject[].format` (when set) is well-formed; `oauth.tokenEndpoint` has host+path.
 - **Volumes** — every entry has an absolute `path`; `type ∈ {"", "tmpfs"}`; `size` if set must parse as a byte-size string; `mode` if set must be octal.

--- a/skills/kit-author/topics/spec-anatomy.md
+++ b/skills/kit-author/topics/spec-anatomy.md
@@ -78,8 +78,8 @@ sandbox:
   image: docker/sandbox-templates:claude-code
   aiFilename: CLAUDE.md
   resources:                                    # optional (P3) — container limits
-    cpu: 4.0                                    # float, cores (must be positive if set)
-    memory_mb: 8192                             # int, mebibytes (must be positive if set)
+    cpu: 4.0                                    # float, cores (must be non-negative if set)
+    memoryMB: 8192                              # int, mebibytes (must be a non-negative integer if set)
     gpu: "1"                                    # consumer-defined string
   lifecycle:                                    # optional (P4) — checkpoint/restore
     checkpoint_aware: true                      # agent supports checkpoint/restore
@@ -127,8 +127,8 @@ Use `build:` when you need custom binaries, complex setup, or full control over 
 ### Validation
 
 - `sandbox.image` and `sandbox.build` are mutually exclusive — exactly one MUST be present for `kind: sandbox` (unless inherited via `extends:`).
-- `sandbox.resources.cpu` MUST be positive if specified.
-- `sandbox.resources.memory_mb` MUST be a positive integer if specified.
+- `sandbox.resources.cpu` MUST be non-negative if specified.
+- `sandbox.resources.memoryMB` MUST be a non-negative integer if specified.
 - `sandbox.lifecycle.shutdown_timeout` MUST parse as a valid Go duration string (e.g. `30s`, `2m`).
 
 ## `credentials`


### PR DESCRIPTION
## Summary
- The `kit-author` skill documented `resources.memory_mb`, but the actual field in the `spec` package is `memoryMB` (`spec/types.go`). The spec decoder uses strict field checking (`dec.KnownFields(true)` in `spec/artifact.go`), so a `spec.yaml` written per the old docs is hard-rejected at parse time with a confusing "field not found" error.
- Also corrects "must be positive" to "must be non-negative" for both `cpu` and `memoryMB` — the validator (`spec/validate.go`) only rejects values `< 0`, so `0`/unset is legal.

## Test plan
- [x] Grepped the repo for remaining `memory_mb` references — none left.
- [ ] Confirm a `spec.yaml` using `memoryMB: 0` validates successfully via `sbx kit validate`.