### PR TITLE
feat: add plugin manifest, fix kit-author skill activation trigger

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "sbx-kits",
+  "version": "1.0.0",
+  "description": "Author Docker Sandboxes kits (spec.yaml v2) — schema, lifecycle, composition, distribution, and TCK testing.",
+  "author": {
+    "name": "Docker Inc.",
+    "url": "https://github.com/docker"
+  },
+  "license": "Apache-2.0",
+  "keywords": ["docker", "sandboxes", "sbx", "kits", "spec.yaml"]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS.md
+
+Instructions for AI coding agents (Claude Code, Codex, or similar) working in this repository.
+
+## Keep `spec/` and `skills/kit-author/` in sync
+
+The `kit-author` skill (`skills/kit-author/`) documents the schema, validation rules, and
+lifecycle that the `spec/` package implements and `tck/` exercises. Its published `paths`
+trigger deliberately excludes `spec/**` and `tck/**` — those patterns are too broad to ship to
+the skill's external marketplace consumers — so editing files in `spec/` or `tck/` does not
+auto-load the skill the way editing a `spec.yaml` does.
+
+If you are changing validation rules, field names, or lifecycle behavior in `spec/`:
+
+1. Load or invoke the `kit-author` skill before you finish the change.
+2. Update the matching page under `skills/kit-author/topics/*.md` in the same change —
+   `spec-anatomy.md` and `lifecycle.md` are the most likely to need an edit.
+3. Check the skill's docs against what you just changed before opening a PR.
+
+This is what would have caught the `resources.memoryMB` field-name and validation-rule drift
+fixed in [#125](https://github.com/docker/sbx-kits-contrib/pull/125) at the point it was
+introduced, instead of surfacing later as a hard-to-diagnose "field not found" error for anyone
+following the (then-incorrect) docs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,16 @@ go run scripts/migrate-v1-to-v2.go <path-to-your-kit>
 
 It applies the v2 renames (`memory:` → `agentContext:`, `kind: agent` → `kind: sandbox`, `agent:` → `sandbox:`), writes a `spec.yaml.bak` of the original, and prints a summary of what changed. The script grows as later phases of the v2 migration land — see [`scripts/README.md`](./scripts/README.md) for the current scope and the [v2 migration roadmap](https://github.com/docker/sandboxes/blob/main/docs/specs/2026-05-27-unified-kit-spec-v2.md) for what's still pending.
 
+## Changing `spec/` or `tck/` behavior
+
+The [`kit-author`](./skills/kit-author/) skill documents the schema, validation, and lifecycle
+that `spec/` implements — its docs can silently drift from what the code actually enforces if a
+change to `spec/` isn't mirrored there (see [#125](https://github.com/docker/sbx-kits-contrib/pull/125)
+for a real example). If you're using an AI coding agent, see [`AGENTS.md`](./AGENTS.md) for the
+directive that keeps this in sync automatically. Contributing by hand: update the matching
+`skills/kit-author/topics/*.md` page alongside any change to validation rules, field names, or
+lifecycle behavior in `spec/`.
+
 ## Before you start
 
 Pick an existing kit closest in shape to what you want to build and read it end-to-end as a template:

--- a/skills/kit-author/SKILL.md
+++ b/skills/kit-author/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: kit-author
 description: Author Docker Sandboxes kits (agents and mixins) — spec.yaml schema, full lifecycle from sourcing through composition, injection, and runtime, plus distribution and TCK testing.
-globs:
+paths:
   - "**/spec.yaml"
   - "**/spec.yml"
-  - "spec/**"
-  - "tck/**"
 ---
 
 # Kit Author Skill


### PR DESCRIPTION
## Summary
- Adds `.claude-plugin/plugin.json` (named `sbx-kits`) so this repo is a valid, marketplace-referenceable Claude Code plugin — no need to vendor/copy the skill into another repo. A marketplace entry (e.g. in `docker/claude-plugins`) can point directly at this repo pinned to a ref/SHA.
- **Renames the `kit-author` skill's `globs:` frontmatter key to `paths:`.** `globs` is not a recognized Claude Code SKILL.md field — the documented field for file-path-based auto-activation is [`paths`](https://code.claude.com/docs/en/skills.md#frontmatter-reference). `globs` was silently ignored (most likely carried over from a different tool's convention, e.g. Cursor's `.cursor/rules` format uses `globs:`), so this skill has never actually had working path-based auto-activation — it activated purely on `description`-based semantic matching. This rename is what actually makes activation-on-`spec.yaml` work for the first time.
- Also drops the `spec/**`/`tck/**` entries from that list. They're not just meaningless outside this repo — `spec/` in particular is common enough (RSpec, OpenAPI spec folders) in unrelated projects that shipping it broadly to marketplace consumers risks spuriously activating this skill in totally unrelated repos.
- **Adds a new top-level `AGENTS.md`** with the directive that keeps this from drifting again: when an agent changes validation/schema/lifecycle behavior in `spec/`, it should update the matching `skills/kit-author/topics/*.md` page in the same change. This repo has no `CLAUDE.md`/`AGENTS.md` today, so nothing was auto-loading this kind of guidance into an agent's context; `AGENTS.md` is what actually enforces it, since dropping `spec/**`/`tck/**` from the skill's own trigger means an agent editing `spec/validate.go` no longer gets the skill auto-loaded just by having that file open.
- `CONTRIBUTING.md` gets a short pointer to `AGENTS.md` plus the human-facing rationale, since it's still the right place for a PR-review policy statement — it's just not the mechanism that reaches an agent automatically.
- **`plugin.json`'s `name` is `sbx-kits`, not `sbx-kits-contrib`.** Component namespacing (`<plugin-name>:<skill-name>`) is driven directly by this field, so skills here invoke as `sbx-kits:kit-author`. Any future skills added under `skills/` (e.g. folding in the workflow layer currently in `sbx-toolkit`) will share this same `sbx-kits:` prefix, since namespacing is per-plugin/per-source with no cross-repo merging — see docker/claude-plugins#7 for the matching marketplace-entry rename.

This is prep for listing `kit-author` in the `docker/claude-plugins` marketplace (separate PR, #7), which will let any `sbx` user get authoring help outside this repo instead of only when editing it directly.

## Test plan
- [x] `plugin.json` is valid JSON.
- [x] Confirmed against the official docs that `paths` (not `globs`) is the correct frontmatter key, and that unknown keys are silently ignored rather than causing a load failure — so the rename was a functional fix, not a regression risk.
- [ ] Confirm `/plugin install sbx-kits@docker` successfully discovers `skills/kit-author/` and now auto-activates when a session touches a `spec.yaml`/`spec.yml` file, invoked as `/sbx-kits:kit-author`.