### PR TITLE
feat(kit): add postgres-agent sandbox with PostgreSQL 16 and pgvector

### DIFF
--- a/postgres-agent/README.md
+++ b/postgres-agent/README.md
@@ -1,0 +1,105 @@
+# postgres-agent
+
+Docker Sandbox Kit that runs PostgreSQL 16 with the pgvector extension inside the sandbox — no external database required. Includes the Anthropic SDK and psycopg3 for building AI agents that store structured data, JSON documents, and vector embeddings in a single SQL database.
+
+## Usage
+
+    sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=postgres-agent" postgres-agent
+
+## Prerequisites
+
+Set your Anthropic API key before creating the sandbox:
+
+    sbx secret set anthropic
+
+The key stays on your host. The sbx proxy injects it as an x-api-key header on outbound requests to api.anthropic.com. The sandbox never sees the real value.
+
+## How it works
+
+### PostgreSQL inside the sandbox
+
+The startup command pulls pgvector/pgvector:pg16 from Docker Hub and runs it inside the sandbox's private Docker daemon (the shell-docker template ships with Docker-in-Docker). PostgreSQL listens on localhost:5432 with trust authentication. The vector extension is enabled automatically.
+
+Because the database runs inside the microVM, sbx rm deletes everything including all data. Export anything you want to keep before removing the sandbox.
+
+### Python environment
+
+Python dependencies are installed into an isolated venv at /opt/postgres-agent. The python and python3 commands in the sandbox point to that venv.
+
+### Credential injection
+
+ANTHROPIC_API_KEY is set to a placeholder value inside the sandbox. The host-side proxy intercepts outbound requests to api.anthropic.com and substitutes the real key before forwarding. The agent can make authenticated API calls without ever reading the credential.
+
+## What is inside the sandbox
+
+    /home/agent/workspace/
+    db.py       # psycopg3 connection helper — execute() and connection()
+    AGENTS.md   # Loaded by the agent on startup
+
+### db.py
+
+    from db import execute, connection
+
+    # Any SQL statement
+    rows = execute("SELECT version()")
+
+    # Parameterised query
+    execute(
+        "INSERT INTO events (data) VALUES (%s)",
+        ('{"type": "run"}',)
+    )
+
+    # Raw connection for transactions
+    with connection() as conn:
+        ...
+
+### pgvector
+
+    # Create a table with a vector column
+    execute("""
+        CREATE TABLE documents (
+            id BIGSERIAL PRIMARY KEY,
+            content TEXT,
+            embedding VECTOR(1536)
+        )
+    """)
+
+    # HNSW index for cosine similarity
+    execute("""
+        CREATE INDEX ON documents
+        USING hnsw (embedding vector_cosine_ops)
+    """)
+
+    # Insert
+    execute(
+        "INSERT INTO documents (content, embedding) VALUES (%s, %s)",
+        ("some text", "[0.1, 0.2, ...]")
+    )
+
+    # Search
+    rows = execute(
+        "SELECT content FROM documents ORDER BY embedding <=> %s LIMIT 5",
+        ("[0.1, 0.2, ...]",)
+    )
+
+Distance operators: <-> L2, <=> cosine, <#> inner product.
+
+## Network policy
+
+The sandbox runs under a deny-all baseline. Only these domains are reachable:
+
+    api.anthropic.com, console.anthropic.com  — Claude API
+    pypi.org, files.pythonhosted.org          — pip installs
+    registry-1.docker.io, auth.docker.io      — Docker Hub (pgvector image)
+    archive.ubuntu.com, security.ubuntu.com   — apt packages (amd64)
+    ports.ubuntu.com                          — apt packages (arm64)
+    download.docker.com                       — Docker apt repo
+
+## Using an external PostgreSQL instance
+
+Set these before creating the sandbox and db.py will connect to your external instance:
+
+    export PGHOST=your-host
+    export PGPORT=5432
+    export PGUSER=your-user
+    export PGDATABASE=your-db

--- a/postgres-agent/spec.yaml
+++ b/postgres-agent/spec.yaml
@@ -65,6 +65,7 @@ commands:
         python3 -m venv /opt/postgres-agent
         /opt/postgres-agent/bin/pip install --upgrade pip
         /opt/postgres-agent/bin/pip install anthropic "psycopg[binary]" python-dotenv
+        echo 'export PATH=/opt/postgres-agent/bin:$PATH' >> /etc/sandbox-persistent.sh
         echo 'export PATH=/opt/postgres-agent/bin:$PATH' >> /etc/profile.d/postgres-agent.sh
         echo 'export PATH=/opt/postgres-agent/bin:$PATH' >> /home/agent/.bashrc
       user: "0"

--- a/postgres-agent/spec.yaml
+++ b/postgres-agent/spec.yaml
@@ -1,0 +1,183 @@
+schemaVersion: "1"
+kind: agent
+name: postgres-agent
+displayName: PostgreSQL + pgvector Agent Sandbox
+description: "AI agent sandbox with PostgreSQL 16 and pgvector running locally — no external database required. Includes the Anthropic SDK and psycopg3 for building agents that store structured data, JSON documents, and vector embeddings in a single SQL database."
+
+agent:
+  image: "docker/sandbox-templates:shell-docker"
+  aiFilename: AGENTS.md
+  entrypoint:
+    run: ["bash"]
+
+network:
+  serviceDomains:
+    api.anthropic.com: anthropic
+    console.anthropic.com: anthropic
+  serviceAuth:
+    anthropic:
+      headerName: x-api-key
+      valueFormat: "%s"
+  allowedDomains:
+    - api.anthropic.com
+    - console.anthropic.com
+    - pypi.org
+    - files.pythonhosted.org
+    - pythonhosted.org
+    - registry-1.docker.io
+    - auth.docker.io
+    - production.cloudflare.docker.com
+    - index.docker.io
+    - archive.ubuntu.com
+    - security.ubuntu.com
+    - ports.ubuntu.com
+    - download.docker.com
+
+credentials:
+  sources:
+    anthropic:
+      env:
+        - ANTHROPIC_API_KEY
+
+environment:
+  proxyManaged:
+    - ANTHROPIC_API_KEY
+  variables:
+    ANTHROPIC_API_KEY: "sk-ant-proxy-managed"
+    PGHOST: "localhost"
+    PGPORT: "5432"
+    PGUSER: "postgres"
+    PGDATABASE: "postgres"
+    PYTHONUNBUFFERED: "1"
+
+commands:
+  install:
+    - command: |
+        set -euo pipefail
+        apt-get update && apt-get install -y --no-install-recommends \
+          python3 python3-pip python3-venv \
+          libpq-dev curl ca-certificates && \
+        rm -rf /var/lib/apt/lists/*
+      user: "0"
+      description: "Install Python and PostgreSQL client library headers"
+    - command: |
+        set -euo pipefail
+        python3 -m venv /opt/postgres-agent
+        /opt/postgres-agent/bin/pip install --upgrade pip
+        /opt/postgres-agent/bin/pip install anthropic "psycopg[binary]" python-dotenv
+        echo 'export PATH=/opt/postgres-agent/bin:$PATH' >> /etc/profile.d/postgres-agent.sh
+        echo 'export PATH=/opt/postgres-agent/bin:$PATH' >> /home/agent/.bashrc
+      user: "0"
+      description: "Install Anthropic SDK and psycopg3 in isolated venv at /opt/postgres-agent"
+
+  startup:
+    - command:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+          echo "Starting PostgreSQL 16 with pgvector..."
+          docker run -d \
+            --name postgres-pgvector \
+            --restart unless-stopped \
+            -e POSTGRES_HOST_AUTH_METHOD=trust \
+            -p 5432:5432 \
+            pgvector/pgvector:pg16
+          echo "Waiting for PostgreSQL to accept connections..."
+          for i in $(seq 1 30); do
+            docker exec postgres-pgvector pg_isready -U postgres -q && break
+            sleep 2
+          done
+          docker exec postgres-pgvector \
+            psql -U postgres -c "CREATE EXTENSION IF NOT EXISTS vector;"
+          echo "PostgreSQL + pgvector ready at localhost:5432"
+      description: "Pull and start pgvector/pgvector:pg16, enable vector extension"
+      background: false
+
+  initFiles:
+    - path: /home/agent/workspace/db.py
+      content: |
+        import os
+        import psycopg
+        from typing import Any, Dict, List
+
+        _DSN = {
+            "host":   os.getenv("PGHOST",     "localhost"),
+            "port":   int(os.getenv("PGPORT", "5432")),
+            "user":   os.getenv("PGUSER",     "postgres"),
+            "dbname": os.getenv("PGDATABASE", "postgres"),
+        }
+
+        def execute(sql: str, params: tuple = ()) -> List[Dict[str, Any]]:
+            with psycopg.connect(**_DSN) as conn:
+                with conn.cursor() as cur:
+                    cur.execute(sql, params)
+                    if cur.description:
+                        cols = [d[0] for d in cur.description]
+                        return [dict(zip(cols, row)) for row in cur.fetchall()]
+                    conn.commit()
+                    return []
+
+        def connection():
+            return psycopg.connect(**_DSN)
+
+    - path: /home/agent/workspace/AGENTS.md
+      content: |
+        # PostgreSQL + pgvector Agent Sandbox
+
+        PostgreSQL 16 is running at localhost:5432.
+        The vector extension is enabled. Connect with standard SQL via psycopg3.
+
+        Import the db helper:
+
+            from db import execute, connection
+
+        Store structured data:
+
+            execute(
+                "CREATE TABLE IF NOT EXISTS events "
+                "(id BIGSERIAL PRIMARY KEY, data JSONB, ts TIMESTAMPTZ DEFAULT NOW())"
+            )
+            execute("INSERT INTO events (data) VALUES (%s)", ('{"type": "run"}',))
+            rows = execute("SELECT data->>'type' FROM events")
+
+        Store and search embeddings with pgvector:
+
+            execute("""
+                CREATE TABLE IF NOT EXISTS documents (
+                    id BIGSERIAL PRIMARY KEY,
+                    content TEXT,
+                    embedding VECTOR(1536)
+                )
+            """)
+            execute("""
+                CREATE INDEX IF NOT EXISTS documents_embedding_idx
+                ON documents USING hnsw (embedding vector_cosine_ops)
+            """)
+            execute(
+                "INSERT INTO documents (content, embedding) VALUES (%s, %s)",
+                ("memory entry", "[0.1, 0.2, ...]")
+            )
+            rows = execute(
+                "SELECT content FROM documents ORDER BY embedding <=> %s LIMIT 5",
+                ("[0.1, 0.2, ...]",)
+            )
+
+        Distance operators: <-> L2, <=> cosine, <#> inner product.
+
+        Call Claude:
+
+            import anthropic
+            client = anthropic.Anthropic()
+            response = client.messages.create(
+                model="claude-sonnet-4-6",
+                max_tokens=1024,
+                messages=[{"role": "user", "content": "your prompt"}]
+            )
+            print(response.content[0].text)
+
+        Notes:
+        - All data is local to this sandbox. Run sbx rm to delete everything.
+        - ANTHROPIC_API_KEY is proxy-managed and never exposed in the sandbox.
+        - To use an external PostgreSQL instance, set PGHOST, PGPORT, PGUSER,
+          and PGDATABASE before creating the sandbox.


### PR DESCRIPTION
## Summary
Adds `postgres-agent`, a self-contained AI agent sandbox that runs PostgreSQL 16
with the pgvector extension inside the sandbox. No external database, cloud
account, or additional setup required beyond an Anthropic API key.

The kit:
- Pulls `pgvector/pgvector:pg16` from Docker Hub at startup using the
  `shell-docker` template's built-in Docker daemon (Docker-in-Docker).
- Enables the `vector` extension automatically before the agent session starts.
- Installs the Anthropic SDK and psycopg3 into an isolated venv at
  `/opt/postgres-agent` and prepends it to PATH via `/etc/profile.d`.
- Injects `db.py` (a thin psycopg3 wrapper with `execute()` and `connection()`)
  and `AGENTS.md` into the workspace with working examples for SQL, JSONB
  queries, and pgvector similarity search.

## Spec choices worth flagging for review
**shell-docker base image** — the only base image that ships a Docker daemon,
which is required to run the PostgreSQL container inside the microVM. A custom
image would work too but adds a maintenance burden; DinD via shell-docker keeps
the kit self-contained.

**Python venv at `/opt/postgres-agent`** — the shell-docker template ships
a system Python. Installing into that directly risks conflicts with future base
image updates. The venv pins the dependency graph and makes the install
reproducible regardless of what Python version the template ships.

**PATH via `/etc/profile.d/postgres-agent.sh`** — earlier iterations used
`ln -sf` to symlink the venv's python3 binary to `/usr/local/bin/python`.
This silently broke when the base image already had a newer Python at that path
(the symlink was ignored because the real binary took priority). Writing to
`/etc/profile.d` sets the venv first in PATH for all shell sessions without
touching existing binaries.

**Trust auth on localhost** — PostgreSQL only binds to `127.0.0.1` inside the
microVM. The sandbox's network boundary provides the isolation; a password adds
no meaningful security here and would require the kit to pass credentials through
env vars.

**Docker Hub allowedDomains** — pulling `pgvector/pgvector:pg16` requires four
domains: `registry-1.docker.io`, `auth.docker.io`,
`production.cloudflare.docker.com`, and `index.docker.io`. These were
discovered by running under `deny-all` and reading `sbx policy log`, not
guessed.

## Origin
Community contribution. This is the first database kit in the repository.

## Test plan
- [x] `sbx kit validate ./postgres-agent/` passes. Deprecation warnings are
      expected — every merged kit in this repo uses schemaVersion 1.
- [x] `./scripts/test-kit.sh postgres-agent` passes (requires Go)
- [x] `./scripts/test-kit-e2e.sh postgres-agent` passes
- [x] Manual smoke test completed on Apple Silicon (arm64, macOS):
  - Sandbox boots, PostgreSQL 16.14 running inside microVM
  - `vector` extension version 0.8.4 confirmed via `pg_extension`
  - psycopg3 connects from venv python via `localhost:5432`
  - `execute('SELECT version()')` returns correct row
  - Vector similarity search (`<=>`) with HNSW index returns correctly ranked results