### PR TITLE
feat(kit): add redis-agent mixin with Redis 7 and cache.py helper

### DIFF
--- a/redis-agent/README.md
+++ b/redis-agent/README.md
@@ -1,0 +1,97 @@
+# redis-agent
+
+Mixin kit that adds a local Redis instance to any sandbox agent. Redis runs
+inside the sandbox via Docker-in-Docker and is ready on localhost:6379. Includes
+redis-py in an isolated Python venv with a cache.py helper covering the patterns
+AI agents use most: key-value caching, pub/sub messaging, and task queues.
+
+## Usage
+
+    sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=redis-agent" claude
+
+Swap claude for any other agent — pi, hermes-agent, or your own custom agent.
+
+## Prerequisites
+
+No external accounts or credentials required. Redis runs entirely inside the sandbox.
+
+## How it works
+
+### Redis inside the sandbox
+
+The startup command pulls redis:7-alpine from Docker Hub and runs it inside the
+sandbox's private Docker daemon (the shell-docker template ships with
+Docker-in-Docker). Redis listens on localhost:6379 with no authentication.
+
+Because Redis runs inside the microVM, sbx rm deletes everything including all
+stored data. Redis does not persist to disk by default — a sandbox restart clears
+all keys.
+
+### Python environment
+
+redis-py (with the hiredis C extension for performance) is installed into an
+isolated venv at /opt/redis-agent. The venv is prepended to PATH via
+/etc/sandbox-persistent.sh, which is sourced in every shell context including
+non-interactive agent tool calls (via BASH_ENV).
+
+## What is inside the sandbox
+
+    /home/agent/workspace/
+    cache.py    # redis-py helper — set/get, enqueue/dequeue, publish/subscribe
+    REDIS.md    # Loaded by the agent on startup
+
+### cache.py
+
+Key-value cache with optional TTL:
+
+    from cache import set, get, delete
+
+    set("result:run-42", {"status": "done", "tokens": 1024}, ttl=3600)
+    value = get("result:run-42")   # returns the dict, not a JSON string
+    delete("result:run-42")
+
+Task queue (blocking producer/consumer):
+
+    from cache import enqueue, dequeue
+
+    # Producer agent
+    enqueue("tasks", {"type": "summarize", "doc_id": "abc123"})
+
+    # Consumer agent — blocks until a task arrives
+    task = dequeue("tasks", timeout=30)
+
+Pub/sub (event-driven agents):
+
+    from cache import publish, subscribe
+
+    # Publisher
+    publish("agent-events", {"event": "analysis_complete", "id": "run-42"})
+
+    # Subscriber
+    ps = subscribe("agent-events")
+    for msg in ps.listen():
+        print(msg["data"])
+
+Raw redis-py client for advanced use:
+
+    from cache import client
+    r = client()
+    r.incr("counter")
+    r.expire("my-key", 60)
+
+## Network policy
+
+The sandbox runs under a deny-all baseline. Only these domains are reachable:
+
+    registry-1.docker.io, auth.docker.io                    -- Docker Hub (Redis image)
+    production.cloudflare.docker.com, index.docker.io       -- Docker Hub CDN and index
+    pypi.org, files.pythonhosted.org, pythonhosted.org      -- pip installs
+    archive.ubuntu.com, security.ubuntu.com, ports.ubuntu.com -- apt (amd64 + arm64)
+    download.docker.com                                     -- Docker apt repo
+
+## Using an external Redis instance
+
+Set REDIS_URL before creating the sandbox and cache.py will connect to your
+external instance instead of the local one:
+
+    export REDIS_URL=redis://your-host:6379

--- a/redis-agent/spec.yaml
+++ b/redis-agent/spec.yaml
@@ -153,6 +153,18 @@ commands:
             ps.subscribe(channel)
             return ps
 
+
+        def listen(ps):
+            """
+            Iterate over messages from a pubsub object, decoding JSON automatically.
+            Usage: for msg in listen(subscribe('channel')): print(msg)
+            """
+            for msg in ps.listen():
+                try:
+                    yield json.loads(msg["data"])
+                except (json.JSONDecodeError, TypeError):
+                    yield msg["data"]
+
     - path: /home/agent/workspace/REDIS.md
       content: |
         # Redis Agent Sandbox
@@ -182,9 +194,10 @@ commands:
             publish("agent-events", {"event": "analysis_complete", "id": "run-42"})
 
             # Subscriber
+            from cache import subscribe, listen
             ps = subscribe("agent-events")
-            for msg in ps.listen():
-                print(msg["data"])
+            for msg in listen(ps):
+                print(msg)  # already decoded from JSON
 
         Direct redis-py client for advanced use:
 

--- a/redis-agent/spec.yaml
+++ b/redis-agent/spec.yaml
@@ -1,0 +1,199 @@
+schemaVersion: "1"
+kind: mixin
+name: redis-agent
+displayName: Redis
+description: "Adds a local Redis instance to any sandbox agent. Redis runs inside the sandbox via Docker-in-Docker and is ready on localhost:6379. Includes redis-py in an isolated Python venv with a cache.py helper covering the patterns AI agents use most: key-value caching, pub/sub messaging, and task queues."
+
+network:
+  allowedDomains:
+    - registry-1.docker.io
+    - auth.docker.io
+    - production.cloudflare.docker.com
+    - index.docker.io
+    - pypi.org
+    - files.pythonhosted.org
+    - pythonhosted.org
+    - archive.ubuntu.com
+    - security.ubuntu.com
+    - ports.ubuntu.com
+    - download.docker.com
+
+environment:
+  variables:
+    REDIS_URL: "redis://localhost:6379"
+    REDIS_HOST: "localhost"
+    REDIS_PORT: "6379"
+
+commands:
+  install:
+    - command: |
+        set -euo pipefail
+        apt-get update && apt-get install -y --no-install-recommends \
+          python3 python3-pip python3-venv ca-certificates && \
+        rm -rf /var/lib/apt/lists/*
+      user: "0"
+      description: "Install Python and system dependencies"
+    - command: |
+        set -euo pipefail
+        python3 -m venv /opt/redis-agent
+        /opt/redis-agent/bin/pip install --upgrade pip
+        /opt/redis-agent/bin/pip install "redis[hiredis]"
+        # Put the venv on PATH for every shell context. The sandbox's persistent env
+        # file is sourced non-interactively (via BASH_ENV) as well as for login and
+        # interactive shells, so agents — which run bash non-interactively — also get
+        # `python`/`pip` from the venv and can `from cache import ...` out of the box.
+        # profile.d is kept as a belt-and-suspenders fallback for login shells.
+        echo 'export PATH=/opt/redis-agent/bin:$PATH' >> /etc/sandbox-persistent.sh
+        echo 'export PATH=/opt/redis-agent/bin:$PATH' >> /etc/profile.d/redis-agent.sh
+      user: "0"
+      description: "Install redis-py with hiredis in isolated venv at /opt/redis-agent"
+
+  startup:
+    - command:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+          echo "Starting Redis..."
+          docker run -d \
+            --name redis \
+            --restart unless-stopped \
+            -p 6379:6379 \
+            redis:7-alpine
+          echo "Waiting for Redis to accept connections..."
+          for i in $(seq 1 30); do
+            docker exec redis redis-cli ping 2>/dev/null | grep -q PONG && break
+            sleep 1
+          done
+          echo "Redis ready at localhost:6379"
+      description: "Pull and start redis:7-alpine"
+      background: false
+
+  initFiles:
+    - path: /home/agent/workspace/cache.py
+      content: |
+        """
+        Redis helper for sandbox agents.
+        Connects to Redis at REDIS_URL (default: redis://localhost:6379).
+        """
+        import os
+        import json
+        import redis
+
+        _client = None
+
+
+        def client() -> redis.Redis:
+            global _client
+            if _client is None:
+                _client = redis.from_url(
+                    os.getenv("REDIS_URL", "redis://localhost:6379"),
+                    decode_responses=True,
+                )
+            return _client
+
+
+        # ── Key-value cache ───────────────────────────────────────────────────────
+
+        def set(key: str, value, ttl: int = None) -> None:
+            """Store a value. Pass ttl (seconds) to auto-expire."""
+            v = json.dumps(value) if not isinstance(value, str) else value
+            client().set(key, v, ex=ttl)
+
+
+        def get(key: str, default=None):
+            """Retrieve a value. Returns default if the key does not exist."""
+            v = client().get(key)
+            if v is None:
+                return default
+            try:
+                return json.loads(v)
+            except (json.JSONDecodeError, TypeError):
+                return v
+
+
+        def delete(*keys: str) -> int:
+            """Delete one or more keys. Returns the number of keys removed."""
+            return client().delete(*keys)
+
+
+        # ── Task queue ────────────────────────────────────────────────────────────
+
+        def enqueue(queue: str, task) -> int:
+            """Push a task onto the right end of a list queue. Returns queue length."""
+            return client().rpush(queue, json.dumps(task))
+
+
+        def dequeue(queue: str, timeout: int = 0):
+            """
+            Block until a task is available on the left end of the queue.
+            Returns the task, or None if timeout is reached.
+            timeout=0 blocks indefinitely.
+            """
+            result = client().blpop(queue, timeout=timeout)
+            if result is None:
+                return None
+            _, raw = result
+            return json.loads(raw)
+
+
+        # ── Pub/sub ───────────────────────────────────────────────────────────────
+
+        def publish(channel: str, message) -> int:
+            """Publish a message to a channel. Returns the number of subscribers."""
+            return client().publish(channel, json.dumps(message))
+
+
+        def subscribe(channel: str):
+            """
+            Return a pubsub object subscribed to channel.
+            Iterate with: for msg in ps.listen(): ...
+            """
+            ps = client().pubsub(ignore_subscribe_messages=True)
+            ps.subscribe(channel)
+            return ps
+
+    - path: /home/agent/workspace/REDIS.md
+      content: |
+        # Redis Agent Sandbox
+
+        Redis 7 is running at localhost:6379 (no authentication).
+        Import the cache helper:
+
+            from cache import set, get, delete, enqueue, dequeue, publish, subscribe
+
+        Key-value cache (with optional TTL):
+
+            set("result:run-42", {"status": "done", "tokens": 1024}, ttl=3600)
+            value = get("result:run-42")
+            delete("result:run-42")
+
+        Task queue (producer/consumer):
+
+            # Producer agent
+            enqueue("tasks", {"type": "summarize", "doc_id": "abc123"})
+
+            # Consumer agent (blocks until task arrives)
+            task = dequeue("tasks", timeout=30)
+
+        Pub/sub (event-driven agents):
+
+            # Publisher
+            publish("agent-events", {"event": "analysis_complete", "id": "run-42"})
+
+            # Subscriber
+            ps = subscribe("agent-events")
+            for msg in ps.listen():
+                print(msg["data"])
+
+        Direct redis-py client for advanced use:
+
+            from cache import client
+            r = client()
+            r.incr("counter")
+            r.expire("my-key", 60)
+
+        Notes:
+        - All data is local to this sandbox. Run sbx rm to delete everything.
+        - Redis data is not persisted to disk — restart clears all keys.
+        - To use an external Redis instance, set REDIS_URL before creating the sandbox.


### PR DESCRIPTION
## Summary

Adds `redis-agent`, a mixin kit that runs Redis 7 inside the sandbox via
Docker-in-Docker and gives any agent a pre-wired `cache.py` helper.

The kit layers on top of any agent that provides a Docker daemon — `claude`,
`pi`, `hermes-agent` — without replacing it:

    sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=redis-agent" claude

Includes:

- `redis:7-alpine` pulled and started automatically at sandbox creation
- `redis-py` with the `hiredis` C extension installed in an isolated venv at `/opt/redis-agent`
- `cache.py` helper covering the three patterns AI agents use most: key-value caching with optional TTL, blocking task queues (enqueue/dequeue), and pub/sub messaging (publish/subscribe/listen)
- `REDIS.md` with working code examples for all three patterns

## Spec choices worth flagging for review

**kind: mixin** — Redis is a backing service, not an agent. The mixin model lets developers layer Redis on top of whatever agent they are already running rather than replacing it with a new entrypoint.

**Docker daemon dependency** — the startup command runs `docker run redis:7-alpine` inside the sandbox, which requires the target agent to provide a Docker daemon. This works with shell-docker based agents (`claude`, `pi`, `hermes-agent`). It will not work with agents that use a plain base image without Docker.

**redis:7-alpine** — minimal image (~40 MB compressed). No persistence flags; data lives in memory only, which matches the ephemeral sandbox lifecycle.

**No authentication** — Redis publishes on `0.0.0.0` within the microVM but is isolated by the sandbox network boundary. A password would add no meaningful security and would require passing credentials through env vars.

**PATH via `/etc/sandbox-persistent.sh`** — `profile.d` and `.bashrc` are not sourced in non-interactive shells. AI agents run bash tool calls non-interactively, so writing the venv PATH export to `sandbox-persistent.sh` (sourced via `BASH_ENV` in every shell context) is the correct mechanism. `profile.d` is kept as a belt-and-suspenders fallback for login shells.

**Docker Hub allowedDomains** — four domains required to pull the Redis image: `registry-1.docker.io`, `auth.docker.io`, `production.cloudflare.docker.com`, `index.docker.io`. Plus pip and apt domains for the Python install. All discovered by probing under deny-all.

## Origin

Community contribution. Redis for ephemeral agent state, caching, and agent-to-agent messaging.

## Test plan

- [x] `sbx kit validate ./redis-agent/` passes
- [x] `./scripts/test-kit.sh redis-agent` passes (24s)
- [x] e2e passes (58s) — run directly with `KIT_UNDER_TEST="$PWD/redis-agent" go test -tags=e2e -v -timeout 25m -count=1 -run TestE2EKit ./tck/...`
- [x] Manual smoke test on Apple Silicon (arm64, macOS):
  - Redis 7-alpine boots inside microVM
  - `python` resolves to venv in non-interactive shell (confirmed via `sandbox-persistent.sh`)
  - `set/get` with JSON serialization and TTL verified
  - `enqueue/dequeue` task queue verified
  - `publish` verified (0 subscribers expected in single-process test)