### PR TITLE
fix(tck): honor spec.sandbox.image for kind:sandbox kits

### DIFF
--- a/tck/suite.go
+++ b/tck/suite.go
@@ -564,10 +564,15 @@ func readOutput(t *testing.T, r io.Reader) string {
 
 // containerImage returns the image to use for container tests,
 // resolving well-known agent templates for mixins with extends.
+//
+// After normalize, both v1 `kind: agent` and v2 `kind: sandbox` end up as
+// KindSandbox (spec/normalize.go migrates the v1 alias with a deprecation
+// warning), so this check matches every non-mixin kit — including v2-native
+// specs that never wrote `kind: agent`.
 func containerImage(a *spec.Artifact) (string, error) {
-	if a.Manifest.Kind == spec.KindAgent {
+	if a.Manifest.Kind == spec.KindSandbox {
 		if a.Manifest.Template == "" {
-			return "", fmt.Errorf("agent artifact %q has no template", a.Manifest.Name)
+			return "", fmt.Errorf("sandbox artifact %q has no template", a.Manifest.Name)
 		}
 		return a.Manifest.Template, nil
 	}

--- a/tck/tck_test.go
+++ b/tck/tck_test.go
@@ -89,18 +89,18 @@ func TestResolveWorkdir(t *testing.T) {
 }
 
 func TestContainerImage(t *testing.T) {
-	t.Run("agent_uses_template", func(t *testing.T) {
+	t.Run("sandbox_uses_template", func(t *testing.T) {
 		a := &spec.Artifact{
-			Manifest: spec.Manifest{Kind: spec.KindAgent, Template: "my/image:v1"},
+			Manifest: spec.Manifest{Kind: spec.KindSandbox, Template: "my/image:v1"},
 		}
 		img, err := containerImage(a)
 		require.NoError(t, err)
 		require.Equal(t, "my/image:v1", img)
 	})
 
-	t.Run("agent_without_template_errors", func(t *testing.T) {
+	t.Run("sandbox_without_template_errors", func(t *testing.T) {
 		a := &spec.Artifact{
-			Manifest: spec.Manifest{Kind: spec.KindAgent, Name: "bad"},
+			Manifest: spec.Manifest{Kind: spec.KindSandbox, Name: "bad"},
 		}
 		_, err := containerImage(a)
 		require.ErrorContains(t, err, "no template")


### PR DESCRIPTION
Signed-off-by: Manuel de la Peña <manuel.delapena@docker.com>

## Summary

`containerImage()` in the TCK checks `Kind == KindAgent`, but `spec/normalize.go` migrates that v1 alias to `KindSandbox` at load time. After normalize no artifact carries `KindAgent` anymore, so the check never matched and every `kind: sandbox` (or v1 `kind: agent`) kit fell through to `DefaultShellImage` — regardless of what `spec.sandbox.image` declared.

Kits that happen to declare `docker/sandbox-templates:shell-docker` pass by coincidence (fallback = declared). Kits that declare a different image get tested against the wrong container.

The fix is one-line: check `KindSandbox`. Post-normalize this covers both v1 `kind: agent` and v2 `kind: sandbox` inputs since normalize collapses them.

## Behavior delta per existing kit

| Kit | image declared | before fix | after fix |
| --- | --- | --- | --- |
| amp, crush, hermes-agent, junie, nanobot, openclaw, pi, trivy | shell-docker | shell-docker (fallback) | shell-docker (declared) |
| claude-ollama, nanoclaw | claude-code-docker | shell-docker (fallback, wrong) | claude-code-docker (declared, correct) |
| opencode-model-runner | opencode-docker | shell-docker (fallback, wrong) | opencode-docker (declared, correct) |

No test regressions expected — the install commands of the 3 kits whose effective image changes are all shell operations (`mkdir`, `printf`, `cat > file`) that work in either image.

## For kit authors in the wild

If your kit imports the TCK via `github.com/docker/sbx-kits-contrib/tck`, this fix affects test-time behavior only if:

1. Your spec declares `sandbox.image` (or v1 `agent.image`) **other than** `docker/sandbox-templates:shell-docker`, **and**
2. You did not already override with `tck.WithImage(...)` in your Suite construction.

If both are true, the TCK now spins up your **declared** image for container tests instead of silently falling back to shell-docker. Expected outcomes:

- **Tests get more accurate** — install commands, files, env vars are exercised against the image you'll actually run in production.
- **If your install commands were relying on binaries present in shell-docker but not in your declared image**, tests may start failing — that's a latent bug this fix surfaces.
- If you specifically want to preserve the pre-fix behavior (testing against a lighter shell base), add `tck.WithImage("docker/sandbox-templates:shell-docker")` to your `NewSuiteFromDir` call. That override is unchanged.

If your spec already declares `shell-docker` (or you already use `WithImage`), no behavior change.

## API surface

`containerImage` is unexported. No import-surface change; existing consumers compile and link unchanged after the bump.

## Repro before the fix

Any `kind: sandbox` kit that declares an image other than `docker/sandbox-templates:shell-docker` whose install command needs a binary from the declared image will fail the TCK's `container/install_execution` subtest.

## Test plan

- [x] `go build ./tck/...` clean
- [x] `go test ./tck/...` compiles + short subset passes
- [ ] CI matrix runs against all 11 kits in this repo
- [ ] Follow-up PR: kiro kit extraction (was the surfacing use case; blocked on this)