### PR TITLE
Create a kit for adding a Claude Code status line

### DIFF
--- a/claude-sbx-statusline/README.md
+++ b/claude-sbx-statusline/README.md
@@ -11,7 +11,9 @@ session renders a compact dashboard of where you are and what the session is cos
 
 The kit ships the script to `~/.claude/statusline.sh` and registers it under `statusLine`
 in `~/.claude/settings.json` — **merging** into the file so the claude base image's other
-settings are preserved.
+settings are preserved. Only the `statusLine` key is written; if the file already had one,
+it is replaced with this kit's script (that's the point of installing the kit), and every
+other key is left as-is.
 
 ## What you get
 
@@ -52,8 +54,10 @@ $ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=c
   }
   ```
 
-  It creates the file if missing and leaves every other key untouched, then `chown`s
-  `~/.claude` back to the `agent` user. Re-running is idempotent.
+  It creates the file if missing and leaves every other key untouched — only `statusLine`
+  is set (replacing a prior one if present) — then `chown`s `~/.claude` back to the `agent`
+  user. Re-running is idempotent. The temp file is created inside `~/.claude` so the final
+  `mv` is an atomic same-filesystem rename rather than a cross-device copy.
 - Note that the script does _not_ perform any checks to verify that you are indeed inside a sandbox. Care should be taken to not put this status line to your host's Claude Code installation as it would then incorrectly state that you are inside a sandbox when you are not.
 
 ## Requirements

--- a/claude-sbx-statusline/README.md
+++ b/claude-sbx-statusline/README.md
@@ -1,0 +1,61 @@
+# claude-sbx-statusline
+
+A two-line [Claude Code status line](https://docs.claude.com/en/docs/claude-code/statusline)
+for Docker Sandboxes. Compose this mixin onto the built-in `claude` agent and every
+session renders a compact dashboard of where you are and what the session is costing:
+
+- **Line 1** — 🐳 Docker Sandboxes · sandbox host · working directory · git branch
+  (with a `*` dirty marker).
+- **Line 2** — model · context-window used % (colour-coded) · memory used/total ·
+  1-minute load average · session cost in USD.
+
+The kit ships the script to `~/.claude/statusline.sh` and registers it under `statusLine`
+in `~/.claude/settings.json` — **merging** into the file so the claude base image's other
+settings are preserved.
+
+## What you get
+
+```
+🐳🏖️  Docker Sandboxes · my-sandbox · /home/agent/workspace (main*)
+Claude Opus 4.8 · ctx 32%/200k · mem 1.2/8.0G · load 0.41 · $0.87
+```
+
+Segments are omitted when there's nothing to show (e.g. the git segment is blank outside a
+repo, the context segment is blank early in a session). Memory reads the cgroup v2 limit so
+it reflects the sandbox's allocation, not the host's.
+
+## Quick start
+
+Pair the mixin with the `claude` agent via `--kit`:
+
+```console
+$ sbx run claude --kit ./claude-sbx-statusline .
+```
+
+Or pull it straight from this repo (pinned by ref):
+
+```console
+$ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=claude-sbx-statusline" .
+```
+
+## How it works
+
+- **`files/home/.claude/statusline.sh`** is copied to `~/.claude/statusline.sh` at sandbox
+  start. The engine preserves the file's executable bit, so Claude Code can invoke it
+  directly. The script receives the session JSON on stdin and prints the two lines.
+- **The `install` hook** (run as root) merges the `statusLine` block into
+  `~/.claude/settings.json` with `jq`:
+
+  ```json
+  {
+    "statusLine": { "type": "command", "command": "~/.claude/statusline.sh" }
+  }
+  ```
+
+  It creates the file if missing and leaves every other key untouched, then `chown`s
+  `~/.claude` back to the `agent` user. Re-running is idempotent.
+
+## Requirements
+
+The script and the install merge both use `jq`, which is present on the `claude-code` base
+image. It also uses `git`, `awk`, and `hostname` — all standard on the base image.

--- a/claude-sbx-statusline/README.md
+++ b/claude-sbx-statusline/README.md
@@ -54,6 +54,7 @@ $ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=c
 
   It creates the file if missing and leaves every other key untouched, then `chown`s
   `~/.claude` back to the `agent` user. Re-running is idempotent.
+- Note that the script does _not_ perform any checks to verify that you are indeed inside a sandbox. Care should be taken to not put this status line to your host's Claude Code installation as it would then incorrectly state that you are inside a sandbox when you are not.
 
 ## Requirements
 

--- a/claude-sbx-statusline/files/home/.claude/statusline.sh
+++ b/claude-sbx-statusline/files/home/.claude/statusline.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Claude Code status line for Docker Sandboxes (two lines).
+#   line 1:  :whale: Docker Sandboxes · HOST · PWD (branch*)
+#   line 2:  MODEL · ctx NN%/Wk · mem U/TG · load L · $COST
+# Receives session JSON on stdin. Runs on every render, so each segment stays cheap.
+
+input=$(cat)
+
+dir=$(printf '%s' "$input" | jq -r '.workspace.current_dir // .cwd // empty')
+[ -z "$dir" ] && dir=$(pwd)
+model=$(printf '%s' "$input" | jq -r '.model.display_name // empty')
+pct=$(printf '%s' "$input" | jq -r '.context_window.used_percentage // empty')
+winsz=$(printf '%s' "$input" | jq -r '(.context_window.context_window_size // 0) / 1000 | floor')
+cost=$(printf '%s' "$input" | jq -r '.cost.total_cost_usd // 0')
+
+# ANSI colours
+RST=$'\033[0m'; BOLD=$'\033[1m'; DIM=$'\033[2m'
+CYAN=$'\033[36m'; YELLOW=$'\033[33m'; BLUE=$'\033[34m'
+GREEN=$'\033[32m'; RED=$'\033[31m'; MAGENTA=$'\033[35m'
+WHITE=$'\033[37m'; SEP=$'\033[90m'
+
+# join SEGMENTS... -> non-empty segments separated by " · "
+join() {
+  local out="" s
+  for s in "$@"; do
+    [ -z "$s" ] && continue
+    if [ -z "$out" ]; then out="$s"; else out="${out}${SEP} · ${RST}${s}"; fi
+  done
+  printf '%s' "$out"
+}
+
+# --- Git branch + dirty marker (blank when not a repo) ---
+git_seg=""
+if branch=$(git -C "$dir" rev-parse --abbrev-ref HEAD 2>/dev/null); then
+  if [ -n "$(git -C "$dir" status --porcelain 2>/dev/null)" ]; then
+    git_seg=" ${GREEN}(${branch}${RED}*${GREEN})${RST}"
+  else
+    git_seg=" ${GREEN}(${branch})${RST}"
+  fi
+fi
+
+# --- Model ---
+model_seg=""
+[ -n "$model" ] && model_seg="${BOLD}${WHITE}${model}${RST}"
+
+# --- Context, colour-coded; blank early in a session ---
+ctx_seg=""
+if [ -n "$pct" ] && [ "$pct" != "null" ]; then
+  p=${pct%.*}
+  if   [ "$p" -ge 80 ]; then c=$RED
+  elif [ "$p" -ge 50 ]; then c=$YELLOW
+  else c=$GREEN; fi
+  ctx_seg="${c}ctx ${p}%${DIM}/${winsz}k${RST}"
+fi
+
+# --- Memory: prefer cgroup v2 limit, fall back to /proc/meminfo ---
+mem_seg=""
+if [ -r /sys/fs/cgroup/memory.current ] && [ -r /sys/fs/cgroup/memory.max ]; then
+  cur=$(cat /sys/fs/cgroup/memory.current)
+  max=$(cat /sys/fs/cgroup/memory.max)
+  if [ "$max" = "max" ]; then
+    max=$(awk '/^MemTotal:/{print $2*1024}' /proc/meminfo)
+  fi
+elif [ -r /proc/meminfo ]; then
+  max=$(awk '/^MemTotal:/{print $2*1024}' /proc/meminfo)
+  avail=$(awk '/^MemAvailable:/{print $2*1024}' /proc/meminfo)
+  cur=$((max - avail))
+fi
+if [ -n "$max" ] && [ "$max" -gt 0 ] 2>/dev/null; then
+  read -r u t pctm <<<"$(awk -v c="$cur" -v m="$max" \
+    'BEGIN{printf "%.1f %.1f %d", c/1073741824, m/1073741824, (c*100)/m}')"
+  if   [ "$pctm" -ge 90 ]; then mc=$RED
+  elif [ "$pctm" -ge 70 ]; then mc=$YELLOW
+  else mc=$CYAN; fi
+  mem_seg="${mc}mem ${u}/${t}G${RST}"
+fi
+
+# --- CPU 1-min load average ---
+load_seg=""
+if [ -r /proc/loadavg ]; then
+  load=$(awk '{print $1}' /proc/loadavg)
+  load_seg="${MAGENTA}load ${load}${RST}"
+fi
+
+# --- Cost ---
+cost_seg="${MAGENTA}$(printf '$%.2f' "$cost")${RST}"
+
+line1=$(join "${BOLD}${CYAN}🐳 Docker Sandboxes${RST}" "${YELLOW}$(hostname)${RST}" "${BLUE}${dir}${RST}${git_seg}")
+line2=$(join "$model_seg" "$ctx_seg" "$mem_seg" "$load_seg" "$cost_seg")
+
+printf '%s\n%s' "$line1" "$line2"

--- a/claude-sbx-statusline/files/home/.claude/statusline.sh
+++ b/claude-sbx-statusline/files/home/.claude/statusline.sh
@@ -6,12 +6,16 @@
 
 input=$(cat)
 
-dir=$(printf '%s' "$input" | jq -r '.workspace.current_dir // .cwd // empty')
+# One jq pass extracts every field (one per line); renders run often, so avoid
+# re-forking jq. Line-per-field read preserves empty fields (tab-splitting would
+# collapse leading blanks, since tab is IFS whitespace).
+{ read -r dir; read -r model; read -r pct; read -r winsz; read -r cost; } < <(printf '%s' "$input" | jq -r '
+  .workspace.current_dir // .cwd // "",
+  .model.display_name // "",
+  .context_window.used_percentage // "",
+  ((.context_window.context_window_size // 0) / 1000 | floor),
+  .cost.total_cost_usd // 0')
 [ -z "$dir" ] && dir=$(pwd)
-model=$(printf '%s' "$input" | jq -r '.model.display_name // empty')
-pct=$(printf '%s' "$input" | jq -r '.context_window.used_percentage // empty')
-winsz=$(printf '%s' "$input" | jq -r '(.context_window.context_window_size // 0) / 1000 | floor')
-cost=$(printf '%s' "$input" | jq -r '.cost.total_cost_usd // 0')
 
 # ANSI colours
 RST=$'\033[0m'; BOLD=$'\033[1m'; DIM=$'\033[2m'

--- a/claude-sbx-statusline/spec.yaml
+++ b/claude-sbx-statusline/spec.yaml
@@ -1,0 +1,27 @@
+schemaVersion: "2"
+kind: mixin
+name: claude-sbx-statusline
+displayName: Claude Code Status Line
+description: Adds a two-line Docker Sandboxes status line to Claude Code (host, cwd, git branch, model, context %, memory, load, cost). Ships ~/.claude/statusline.sh and registers it under statusLine in ~/.claude/settings.json without clobbering existing settings.
+
+commands:
+  install:
+    - command: |
+        set -e
+        mkdir -p /home/agent/.claude
+        f=/home/agent/.claude/settings.json
+        [ -f "$f" ] || echo '{}' > "$f"
+        tmp=$(mktemp)
+        jq '.statusLine = {type: "command", command: "~/.claude/statusline.sh"}' "$f" > "$tmp"
+        mv "$tmp" "$f"
+        chown -R agent:agent /home/agent/.claude
+      user: "0"
+      description: Register ~/.claude/statusline.sh under statusLine in ~/.claude/settings.json (merge, preserves existing keys)
+
+agentContext: |
+  ## Status line
+
+  This sandbox renders a custom Claude Code status line via
+  ~/.claude/statusline.sh, registered under `statusLine` in
+  ~/.claude/settings.json. It shows the sandbox host, working directory, git
+  branch, model, context-window %, memory, load average, and session cost.

--- a/claude-sbx-statusline/spec.yaml
+++ b/claude-sbx-statusline/spec.yaml
@@ -2,7 +2,7 @@ schemaVersion: "2"
 kind: mixin
 name: claude-sbx-statusline
 displayName: Claude Code Status Line
-description: Adds a two-line Docker Sandboxes status line to Claude Code (host, cwd, git branch, model, context %, memory, load, cost). Ships ~/.claude/statusline.sh and registers it under statusLine in ~/.claude/settings.json without clobbering existing settings.
+description: Adds a two-line Docker Sandboxes status line to Claude Code (host, cwd, git branch, model, context %, memory, load, cost). Ships ~/.claude/statusline.sh and sets the statusLine key in ~/.claude/settings.json, merging so every other setting is preserved (an existing statusLine is intentionally replaced, since installing this status line is the point of the kit).
 
 commands:
   install:
@@ -11,12 +11,15 @@ commands:
         mkdir -p /home/agent/.claude
         f=/home/agent/.claude/settings.json
         [ -f "$f" ] || echo '{}' > "$f"
-        tmp=$(mktemp)
+        # Set only the statusLine key (any existing one is replaced by design);
+        # the jq merge leaves all other settings untouched. Temp file lives in the
+        # same dir as $f so the mv below is an atomic rename, not a cross-fs copy.
+        tmp=$(mktemp -p /home/agent/.claude)
         jq '.statusLine = {type: "command", command: "~/.claude/statusline.sh"}' "$f" > "$tmp"
         mv "$tmp" "$f"
         chown -R agent:agent /home/agent/.claude
       user: "0"
-      description: Register ~/.claude/statusline.sh under statusLine in ~/.claude/settings.json (merge, preserves existing keys)
+      description: Set the statusLine key in ~/.claude/settings.json to ~/.claude/statusline.sh (jq merge, so all other keys are preserved; any existing statusLine is replaced by design)
 
 agentContext: |
   ## Status line


### PR DESCRIPTION
The status line is useful for reminding ourselves which sandbox and working directory we are on and the fact that the Claude Code session is inside a Docker Sandbox. Note that the script does not perform any checks so the script should not be reused as-is for a Claude Code installation on a host machine.

https://code.claude.com/docs/en/statusline