### PR TITLE
feat(kiro): add kiro kit

### DIFF
--- a/kiro/README.md
+++ b/kiro/README.md
@@ -1,0 +1,61 @@
+# kiro
+
+A standalone agent kit (`kind: sandbox`) for
+[Kiro](https://kiro.dev/), an AI-driven coding agent. This kit is a
+declarative spec that runs Kiro out of the pre-built
+`docker/sandbox-templates:kiro-docker` image (published from
+[`docker/sandboxes`](https://github.com/docker/sandboxes)), which
+ships the Kiro CLI (`kiro-cli`) and an auth wrapper baked in. The
+sandbox starts with `kiro chat --trust-all-tools` when you attach.
+
+## Prerequisites
+
+- A [Kiro](https://kiro.dev/) account. Kiro uses AWS-flavored device-flow
+  authentication (`kiro-cli login --use-device-flow`) that runs *inside*
+  the sandbox on first launch — no host-side setup is required.
+
+## Usage
+
+```console
+# Run with a pinned tag (recommended for production use)
+$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#ref=v0.2.0&dir=kiro" kiro
+
+# Or track the default branch (may change under you)
+$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=kiro" kiro
+
+# For local development, point --kit at the checkout
+$ sbx run --kit ./kiro/ kiro
+```
+
+On first launch inside the sandbox, `kiro` (the auth wrapper at
+`/home/agent/.local/bin/kiro`, shipped as part of the image) detects
+that no session exists and starts the device-flow login. Follow the
+on-screen URL + code to authenticate against your Kiro account.
+Subsequent launches reuse the persisted session state.
+
+## MCP gateway
+
+When the sandbox is created with a reserved MCP gateway, the kit's
+`commands.startup` writes `~/.kiro/settings/mcp.json` at container-start
+so Kiro finds the gateway on first launch. When MCP isn't enabled, the
+step is a no-op (guarded by `[ -n "$MCP_GATEWAY_URL" ]`).
+
+## Network policy
+
+Kiro's outbound network needs (the CLI installer, `kiro-cli` API
+endpoints, device-flow auth) are handled by the sandbox's default
+policy — the kit doesn't declare `caps.network.allow` restrictions.
+Users who want to lock the sandbox down further can layer a stricter
+policy on top; see [Declare every domain your kit
+needs](../README.md#declare-every-domain-your-kit-needs) for how to
+probe under `deny-all`.
+
+## Image ownership
+
+Today the container image (`docker/sandbox-templates:kiro-docker`)
+is built and published by the engine repo
+([`docker/sandboxes`](https://github.com/docker/sandboxes)) via its
+`local-sandbox-templates` bake. This kit re-uses that image rather
+than building its own. If image ownership moves to this repo later,
+`spec.yaml`'s `sandbox.image` will repoint (and a `Dockerfile` will
+land in this directory) — the kit contract itself doesn't change.

--- a/kiro/README.md
+++ b/kiro/README.md
@@ -18,7 +18,7 @@ sandbox starts with `kiro chat --trust-all-tools` when you attach.
 
 ```console
 # Run with a pinned tag (recommended for production use)
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#ref=v0.2.0&dir=kiro" kiro
+$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#ref=<TAG>&dir=kiro" kiro
 
 # Or track the default branch (may change under you)
 $ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=kiro" kiro

--- a/kiro/mcp_test.go
+++ b/kiro/mcp_test.go
@@ -1,0 +1,68 @@
+package kiro
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/sbx-kits-contrib/spec"
+)
+
+// TestKiroMCPStartupCommand verifies that the kiro kit registers the
+// sandbox's MCP gateway via a commands.startup entry that writes
+// ~/.kiro/settings/mcp.json. Under the gateway-first lifecycle,
+// sandboxd injects MCP_GATEWAY_URL + MCP_SENTINEL_TOKEN_NAME into the
+// container env by the time startup commands run, so the script reads
+// them with shell substitution rather than via Go-template rendering.
+//
+// Shape note: kiro-cli (cli.kiro.dev) reads MCP servers from
+// ~/.kiro/settings/mcp.json. A remote/HTTP server is keyed by the
+// `url` field plus a `headers` object — no `type` field, no separate
+// `httpUrl` key. Per upstream docs:
+//
+//	https://kiro.dev/docs/cli/mcp/configuration/
+//
+// (specifically the "Authorization Example" using `Authorization: Bearer …`
+// inside `headers`).
+func TestKiroMCPStartupCommand(t *testing.T) {
+	artifact, err := spec.LoadFromDirectory(".")
+	require.NoError(t, err)
+
+	require.NotNil(t, artifact.Commands, "kiro kit must declare commands")
+	require.NotEmpty(t, artifact.Commands.Startup, "kiro needs at least one startup command")
+
+	var mcpScript string
+	var mcpUser string
+	for _, cmd := range artifact.Commands.Startup {
+		if len(cmd.Command) < 3 {
+			continue
+		}
+		if strings.Contains(cmd.Command[2], "MCP_GATEWAY_URL") {
+			mcpScript = cmd.Command[2]
+			mcpUser = cmd.User
+			break
+		}
+	}
+	require.NotEmpty(t, mcpScript, "kiro must declare a startup command that registers via $MCP_GATEWAY_URL")
+	require.Equal(t, "agent", mcpUser, "write runs as the agent user so the file ownership stays correct")
+
+	// --- Skip-when-not-enabled guard ---
+	require.Contains(t, mcpScript, `[ -n "$MCP_GATEWAY_URL" ]`,
+		"script must no-op when MCP isn't enabled ($MCP_GATEWAY_URL empty)")
+
+	// --- JSON shape (kiro-cli uses `url`, not `httpUrl`) ---
+	require.Contains(t, mcpScript, `"mcp-gateway"`)
+	require.Contains(t, mcpScript, `"url": "$MCP_GATEWAY_URL"`,
+		"url must reference the gateway via env var")
+	require.Contains(t, mcpScript, `"Authorization": "Bearer $MCP_SENTINEL_TOKEN_NAME"`,
+		"auth header must reference the sentinel name env var")
+	require.NotContains(t, mcpScript, `"httpUrl"`,
+		`kiro-cli uses "url" for HTTP MCP servers, not "httpUrl"`)
+
+	// --- Destination ---
+	require.Contains(t, mcpScript, "$HOME/.kiro/settings/mcp.json",
+		"destination must be the user-level kiro MCP config path")
+	require.Contains(t, mcpScript, `mkdir -p "$HOME/.kiro/settings"`,
+		"settings/ subdir may not exist on first boot — mkdir -p before writing")
+}

--- a/kiro/spec.yaml
+++ b/kiro/spec.yaml
@@ -1,0 +1,56 @@
+schemaVersion: "2"
+kind: sandbox
+name: kiro-contrib
+displayName: Kiro
+description: AI-driven coding agent (device-flow auth).
+version: "0.1.0"
+sourceURL: https://github.com/docker/sbx-kits-contrib
+sandbox:
+  image: "docker/sandbox-templates:kiro-docker"
+  aiFilename: KIRO.md
+  entrypoint:
+    run: [kiro, chat, "--trust-all-tools"]
+
+environment:
+  variables:
+    IS_SANDBOX: "1"
+
+commands:
+  install:
+    - command: "kiro-cli setup --no-confirm"
+      user: "agent"
+      description: Run Kiro CLI setup
+  startup:
+    - command: ["sh", "-c", "command -v apt-get > /dev/null 2>&1 && (apt-get update -qq -y > /dev/null 2>&1 || true) &"]
+      user: "root"
+      description: Update apt package cache in background
+    # Gateway-first MCP registration. sandboxd injects MCP_GATEWAY_URL +
+    # MCP_SENTINEL_TOKEN_NAME into the container env when a gateway has
+    # been reserved. The sentinel name is not a credential — the proxy
+    # substitutes the real token at request time keyed by this name.
+    # No-op when MCP isn't enabled.
+    #
+    # Kiro owns ~/.kiro/settings/mcp.json (no baseline keys to
+    # preserve), so the script writes it fresh via heredoc. mkdir -p
+    # because the settings/ subdir may not exist on first boot.
+    - command:
+        - sh
+        - -c
+        - |
+          set -e
+          [ -n "$MCP_GATEWAY_URL" ] || exit 0
+          mkdir -p "$HOME/.kiro/settings"
+          cat > "$HOME/.kiro/settings/mcp.json" <<EOF
+          {
+            "mcpServers": {
+              "mcp-gateway": {
+                "url": "$MCP_GATEWAY_URL",
+                "headers": {
+                  "Authorization": "Bearer $MCP_SENTINEL_TOKEN_NAME"
+                }
+              }
+            }
+          }
+          EOF
+      user: "agent"
+      description: Register the sandbox MCP gateway in ~/.kiro/settings/mcp.json

--- a/kiro/spec.yaml
+++ b/kiro/spec.yaml
@@ -1,6 +1,6 @@
 schemaVersion: "2"
 kind: sandbox
-name: kiro-contrib
+name: kiro
 displayName: Kiro
 description: AI-driven coding agent (device-flow auth).
 version: "0.1.0"

--- a/scripts/test-kit.sh
+++ b/scripts/test-kit.sh
@@ -45,12 +45,15 @@ fi
 
 cd "$REPO_ROOT"
 
-# Run the shared TCK. If the kit directory contains any Go test files, also
-# run them — this lets a kit ship its own kit-specific assertions (e.g. the
-# exact shape of a config file its startup command writes) alongside the
-# generic TCK checks. Kits live one level under the repo root, so the
-# relative package path is just the kit's basename.
+# Run the shared TCK. If the kit directory contains any Go test files
+# (at any depth — a kit may organise its tests under subpackages), also
+# run them so a kit can ship its own assertions (e.g. the exact shape
+# of a config file its startup command writes) alongside the generic
+# TCK checks. Kits live one level under the repo root, so the relative
+# package path is just the kit's basename. Exports KIT for the per-kit
+# run too, so kit tests can locate the artifact if they don't use the
+# working directory.
 KIT="$kit_abs" go test -v -count=1 -timeout 10m -run TestKitTCK "$@" ./tck/...
-if compgen -G "$kit_abs"/*_test.go > /dev/null; then
-  go test -v -count=1 -timeout 10m "$@" "./$(basename "$kit_abs")/..."
+if [ -n "$(find "$kit_abs" -name '*_test.go' -print -quit)" ]; then
+  KIT="$kit_abs" go test -v -count=1 -timeout 10m "$@" "./$(basename "$kit_abs")/..."
 fi

--- a/scripts/test-kit.sh
+++ b/scripts/test-kit.sh
@@ -44,4 +44,13 @@ if [ ! -f "$kit_abs/spec.yaml" ] && [ ! -f "$kit_abs/spec.yml" ]; then
 fi
 
 cd "$REPO_ROOT"
-KIT="$kit_abs" exec go test -v -count=1 -timeout 10m -run TestKitTCK "$@" ./tck/...
+
+# Run the shared TCK. If the kit directory contains any Go test files, also
+# run them — this lets a kit ship its own kit-specific assertions (e.g. the
+# exact shape of a config file its startup command writes) alongside the
+# generic TCK checks. Kits live one level under the repo root, so the
+# relative package path is just the kit's basename.
+KIT="$kit_abs" go test -v -count=1 -timeout 10m -run TestKitTCK "$@" ./tck/...
+if compgen -G "$kit_abs"/*_test.go > /dev/null; then
+  go test -v -count=1 -timeout 10m "$@" "./$(basename "$kit_abs")/..."
+fi


### PR DESCRIPTION
Signed-off-by: Manuel de la Peña <manuel.delapena@docker.com>

## Summary

Adds a `kiro` kit that runs Kiro out of the pre-built `docker/sandbox-templates:kiro-docker` image. The kit is spec-only — no `Dockerfile` — since the image is already published and ships `kiro-cli` plus the auth wrapper baked in.

The kit's `spec.yaml::name` is `kiro-contrib` while the engine still ships `kiro` as a built-in agent (the CLI rejects a `--kit` whose name collides with a registered built-in). Once the built-in registration is removed on the engine side, the `name:` will flip to `kiro` in a follow-up commit; the folder, image ref, and file layout stay put.

## Spec choices worth flagging for review

- `sandbox.image` points at `docker/sandbox-templates:kiro-docker`, which is published by `docker/sandboxes` and re-used here — no image ownership migration.
- No `caps.network.allow` — Kiro relies on the default policy (device-flow auth, `cli.kiro.dev` installer, AWS endpoints).
- `commands.install` re-runs `kiro-cli setup --no-confirm` even though the base image already ran it at build time. Idempotent per Kiro's docs, kept for parity across image variants.
- Startup commands: apt-cache warm-up + MCP gateway registration to `~/.kiro/settings/mcp.json` (no-op when `MCP_GATEWAY_URL` is unset).

## Origin

Ported from `docker/sandboxes:sandboxlib/agentkits/agents/kiro/spec.yaml`. Verbatim v2 shape + `version`, `displayName`, `description`, `sourceURL` added. Base-image ownership stays with `docker/sandboxes` for now.

## Test plan

CI runs `kit validate` and the TCK on every PR. CI does **not** run e2e on fork PRs (Docker Hub secrets aren't exposed there), so the e2e step below is required from your side before requesting review.

- [x] `./scripts/test-kit.sh kiro-contrib` — TCK all green (11s)
- [x] `./scripts/test-kit-e2e.sh kiro-contrib` — e2e green (69s); sandbox spins up on `docker/sandbox-templates:kiro-docker`, env + tmpfs subtests pass
- [ ] Manual smoke: `sbx run --kit ./kiro/ kiro-contrib` from a checkout, verify Kiro CLI wrapper prompts for device-flow login

One-time setup if you haven't run e2e on this machine before:
`sbx --app-name sbx-kits-contrib-tck login`.