### PR TITLE
feat(playwright): add Playwright browser-automation mixin kit

### DIFF
--- a/playwright/README.md
+++ b/playwright/README.md
@@ -1,0 +1,76 @@
+# playwright
+
+A mixin kit that installs the **Playwright** browser-automation toolchain inside the sandbox: the `playwright` CLI and `@playwright/test` **v1.61.1** from npm, plus **Chromium** (and its headless shell) with all required system libraries. Pair it with any agent (Claude, Gemini, …) to let the agent write and run end-to-end tests, scrape or screenshot pages, generate PDFs, and debug web apps served inside the sandbox — all headless, all sandbox-local.
+
+## Usage
+
+```console
+$ sbx run claude --kit ./playwright/ .
+```
+
+Or straight from this repository:
+
+```console
+$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=playwright" claude
+```
+
+Prerequisites:
+
+- A base image with Node.js ≥ 18 and npm — all standard agent templates ship it. The install fails loudly with a clear message if npm is missing.
+
+Inside the sandbox:
+
+```console
+$ playwright --version                       # CLI on PATH for every user
+$ npx playwright test                        # run a project's test suite
+$ npx playwright screenshot http://localhost:3000 page.png
+```
+
+Driving a browser from code works with the globally installed library or a project-local one:
+
+```js
+const { chromium } = require('playwright');
+const browser = await chromium.launch();     // headless; finds browsers via PLAYWRIGHT_BROWSERS_PATH
+```
+
+## How it works
+
+### Why browsers live in /opt/ms-playwright
+
+Kit install hooks run as root, but the agent runs as uid 1000. Playwright's default browser location is per-user (`~/.cache/ms-playwright`), so a root-time install would strand the browsers in `/root/.cache` where the agent can't use them. The kit sets `PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright` as a container-wide environment variable and installs there — the same approach as the official Playwright Docker image. The directory is left world-writable (also matching the official image) so the agent user can fetch additional browser builds at runtime when a project pins a different Playwright version.
+
+### Why NODE_PATH is set
+
+Node resolves `require('@playwright/test')` by walking `node_modules` up from the requiring file, so a bare `smoke.spec.js` in an empty directory can't see the globally installed packages — `npx playwright test` finds the runner but the test file fails to import. Setting `NODE_PATH` to the global npm root (`/usr/local/share/npm-global/lib/node_modules`, the standard agent templates' prefix) adds it as a resolution fallback, making zero-config test runs work. Projects with their own `node_modules` are unaffected: the local copy always wins, and on a template with a different npm prefix the path simply doesn't exist and Node skips it. Note `environment.variables` is last-wins across kits — a kit composed after this one that also sets `NODE_PATH` overrides this value.
+
+### Why Chromium only
+
+Each browser engine is a 100–150 MB download plus its own set of apt-installed system libraries. Chromium covers the overwhelming majority of agent tasks (testing, scraping, screenshots, PDFs), keeps sandbox creation fast, and keeps the system-library footprint small. Firefox and WebKit binaries *can* be fetched at runtime (`npx playwright install firefox webkit` — the CDN domains are allowed), but their extra system libraries are not installed; fork the kit and extend the second install command if you need cross-engine runs out of the box.
+
+### Why headless only
+
+The sandbox has no display server, so `--headed`, `--ui` mode, and `codegen` won't work. Everything else — screenshots, PDFs, videos, traces — works headless, and Playwright's default headless Chromium shell is what CI systems run anyway.
+
+### Why the version is pinned
+
+Kits are cached in user workflows and re-run on every sandbox creation, so a floating `latest` would make sandbox builds non-reproducible. The kit pins `playwright@1.61.1` and `@playwright/test@1.61.1`; npm verifies the downloaded tarballs against the sha512 integrity values in the registry metadata, so pinning the version pins the content. Browser builds are keyed to the Playwright version, so they're transitively pinned too. To bump: change `PLAYWRIGHT_VERSION` in `spec.yaml` and the version references in `agentContext` and this README.
+
+### Why these domains
+
+`caps.network.allow` is the kit's complete outbound contract — CI runs e2e under a `deny-all` policy.
+
+| Domain | Why |
+| --- | --- |
+| `registry.npmjs.org` | npm tarballs for `playwright` + `@playwright/test` (install time) |
+| `cdn.playwright.dev` | Playwright's primary browser-binary CDN (install time; runtime for version-mismatched projects) |
+| `playwright.download.prss.microsoft.com` | Documented fallback CDN Playwright rotates to on primary failure |
+| `archive.ubuntu.com` | Ubuntu apt archive, amd64 — `--with-deps` installs Chromium's system libraries |
+| `security.ubuntu.com` | Ubuntu security pocket, amd64 — refreshed by the same `apt-get update` |
+| `ports.ubuntu.com` | Ubuntu archive/security for arm64 (Apple Silicon sandboxes) |
+| `download.docker.com` | Docker's apt repo, pre-added by the `*-docker` templates — `apt-get update` refreshes every configured source and fails if any is blocked |
+
+**Runtime reminder:** the allowlist covers installing and running Playwright itself, not the sites a test visits. Servers on `localhost` inside the sandbox always work; navigating to external sites fails with a proxy error unless the user's sandbox policy allows those domains.
+
+## Cleanup
+
+Everything is sandbox-local: npm packages, browsers in `/opt/ms-playwright`, and apt-installed libraries all disappear with the sandbox (`sbx rm <name>`). Nothing touches the host's browsers, caches, or displays.

--- a/playwright/spec.yaml
+++ b/playwright/spec.yaml
@@ -1,0 +1,100 @@
+schemaVersion: "2"
+kind: mixin
+name: playwright
+displayName: Playwright
+description: "Playwright browser-automation toolchain for sandbox agents — the playwright CLI and @playwright/test v1.61.1 with Chromium, installed to a shared system browsers path so the agent user can run headless browser automation and end-to-end tests entirely inside the sandbox."
+
+environment:
+  variables:
+    # Install hooks run as root but the agent runs as uid 1000, so the default
+    # per-user ~/.cache/ms-playwright would leave the browsers in root's home
+    # where the agent can't see them. A fixed system path shared by every user
+    # (the same trick the official Playwright Docker image uses) fixes that.
+    PLAYWRIGHT_BROWSERS_PATH: /opt/ms-playwright
+    # Lets `require('@playwright/test')` resolve from the global npm install
+    # in zero-config runs (a bare .spec.js with no package.json). Node only
+    # searches node_modules up the file's directory tree; NODE_PATH adds the
+    # global root as a fallback. Projects with their own node_modules are
+    # unaffected — the local copy always wins.
+    NODE_PATH: /usr/local/share/npm-global/lib/node_modules
+
+caps:
+  network:
+    allow:
+      # npm packages (install time): playwright + @playwright/test tarballs.
+      - "registry.npmjs.org:443"
+      # Browser binaries (install time, and runtime if a project pins a
+      # different Playwright version and fetches its matching build):
+      # cdn.playwright.dev is the primary CDN, the prss.microsoft.com host
+      # is the documented fallback Playwright rotates to on CDN failure.
+      - "cdn.playwright.dev:443"
+      - "playwright.download.prss.microsoft.com:443"
+      # `playwright install --with-deps` apt-installs Chromium's system
+      # libraries. `apt-get update` refreshes every configured source, so all
+      # template sources must be reachable: Ubuntu hosts amd64 packages on
+      # archive/security and arm64 packages on ports.ubuntu.com, and the
+      # *-docker templates pre-add Docker's apt repo.
+      - "archive.ubuntu.com:80"
+      - "security.ubuntu.com:80"
+      - "ports.ubuntu.com:80"
+      - "download.docker.com:443"
+
+commands:
+  install:
+    # To bump Playwright: change PLAYWRIGHT_VERSION here and in agentContext /
+    # README. npm itself verifies the package tarballs against the sha512
+    # integrity values in the registry metadata, so pinning the exact version
+    # pins the content.
+    - command: |
+        set -euo pipefail
+        command -v npm >/dev/null || { echo "npm not found: this mixin needs a base image with Node.js >= 18 (all standard agent templates ship it)" >&2; exit 1; }
+        if [ -n "${HTTP_PROXY:-}" ]; then
+          npm config set proxy "$HTTP_PROXY"
+          npm config set https-proxy "$HTTP_PROXY"
+        fi
+        PLAYWRIGHT_VERSION=1.61.1
+        npm install -g "playwright@${PLAYWRIGHT_VERSION}" "@playwright/test@${PLAYWRIGHT_VERSION}"
+        ln -sf "$(command -v playwright)" /usr/local/bin/playwright
+        playwright --version
+      user: "0"
+      description: "Install playwright + @playwright/test v1.61.1 from registry.npmjs.org, version pinned"
+    - command: |
+        set -euo pipefail
+        export PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
+        playwright install --with-deps chromium
+        rm -rf /var/lib/apt/lists/*
+        # World-writable like the official Playwright image: lets the agent
+        # user (uid 1000) add matching browser builds at runtime when a
+        # project pins a different Playwright version.
+        chmod -R 777 /opt/ms-playwright
+      user: "0"
+      description: "Install Chromium (+ headless shell) into /opt/ms-playwright and its system libraries via apt"
+
+agentContext: |
+  ## Playwright
+
+  playwright and @playwright/test v1.61.1 are installed globally (the
+  `playwright` CLI is on PATH). Chromium and its headless shell live in
+  /opt/ms-playwright; PLAYWRIGHT_BROWSERS_PATH points there system-wide —
+  don't unset or override it, or Playwright will look in ~/.cache and try to
+  re-download.
+
+  - Run test suites with `npx playwright test`; drive a browser from a script
+    with `const { chromium } = require('playwright')`. Zero-config works: a
+    bare `smoke.spec.js` with no package.json resolves `@playwright/test`
+    from the global install via NODE_PATH. Projects with their own
+    node_modules use their local copy as usual.
+  - Headless only: the sandbox has no display server, so `--headed`, `--ui`,
+    and `codegen` will not work. Screenshots, PDFs, traces, and videos all
+    work headless.
+  - If a project pins a different Playwright version, its first run may need
+    the matching browser build: `npx playwright install chromium` fetches it
+    at runtime (the browser CDN domains are allowed, and /opt/ms-playwright
+    is writable).
+  - Only Chromium is installed. `npx playwright install firefox webkit` can
+    download the other engines, but their extra system libraries are not
+    installed — prefer Chromium, or extend the kit if you need cross-engine
+    runs.
+  - Sites under test must be reachable through the sandbox network policy:
+    localhost servers always work; external sites will fail with a proxy
+    error unless their domains are in the sandbox's allowed domains.


### PR DESCRIPTION
## Summary

Adds a `playwright` mixin kit that gives any sandbox agent a working browser-automation toolchain: the `playwright` CLI and `@playwright/test` v1.61.1 from npm (version pinned), plus Chromium and its headless shell with all the apt system libraries they need.

With this kit an agent can run end-to-end tests, screenshot pages, generate PDFs, and drive a headless browser against apps served inside the sandbox — with zero project setup.

## Spec choices worth flagging for review

- **Browsers install to `/opt/ms-playwright`, not the default `~/.cache`.** Install hooks run as root but the agent runs as uid 1000, so a default install would strand the browsers in `/root/.cache` where the agent can't use them. The kit sets `PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright` container-wide and leaves the directory world-writable — the same approach as the official Playwright Docker image — so the agent can also fetch a matching browser build at runtime if a project pins a different Playwright version.
- **`NODE_PATH` points at the global npm root.** Node resolves `require('@playwright/test')` by walking up from the test file, so a bare `smoke.spec.js` with no `package.json` can't see the global install. `NODE_PATH=/usr/local/share/npm-global/lib/node_modules` makes zero-config runs work; projects with their own `node_modules` still win, and on templates with a different npm prefix the path simply doesn't exist and Node ignores it.
- **Chromium only.** Keeps the download and the apt footprint small; Firefox/WebKit binaries can be fetched at runtime (the CDN domains are allowed) but their system libraries aren't installed. The README explains how to extend the kit for cross-engine runs.
- **Headless only, by design.** The sandbox has no display server, so `--headed`, `--ui`, and `codegen` won't work. Screenshots, PDFs, traces, and videos all work headless.
- **Version pinning relies on npm's own integrity check.** Unlike the binary-download kits (k8s-tools, trivy, …) there are no manual SHA256s: pinning the exact npm version pins the content, because npm verifies tarballs against the sha512 in the registry metadata. Browser builds are keyed to the Playwright version, so they're transitively pinned.
- **Both browser CDNs are allowlisted — and both are real.** `sbx policy log` from the e2e run shows hits on `cdn.playwright.dev` *and* the `playwright.download.prss.microsoft.com` fallback, so neither entry is speculative.

## Origin

Written for this repository from scratch, following the k8s-tools / trivy kit conventions and the official Playwright Docker image's browser-path approach.

## Test plan

CI runs `kit validate` and the TCK on every PR. CI does **not** run e2e
fork PRs (Docker Hub secrets aren't exposed there), so the e2e step below is
required from your side before requesting review.

- [x] `sbx kit validate ./playwright/` passes
- [x] `./scripts/test-kit.sh playwright` passes (the TCK, 100.6s — both install
      commands executed in a real container)
- [x] `./scripts/test-kit-e2e.sh playwright` passes (158s under the `deny-all`
      baseline, scoped to `--app-name sbx-kits-contrib-tck`). Zero bloc
      requests in `sbx policy log`; every `network.allow` entry was observed
      in the log, not guessed.
- [x] Manual smoke: `sbx run --kit ./playwright/ claude` on the scoped
      deny-all daemon, then as the agent user (uid 1000):
      - `playwright --version` → 1.61.1, `PLAYWRIGHT_BROWSERS_PATH` set,
        browsers present in `/opt/ms-playwright`
      - `playwright screenshot "data:text/html,<h1>…</h1>" smoke.png` →
        headless Chromium launched and produced a 9.6 KB PNG
      - a bare `smoke.spec.js` with no `package.json` → `npx playwright test`
        → **1 passed**, resolving `@playwright/test` via the kit's `NOD`
