### PR TITLE
fix(playwright): allow storage.googleapis.com for Chromium download

### DIFF
--- a/playwright/spec.yaml
+++ b/playwright/spec.yaml
@@ -29,6 +29,13 @@ caps:
       # is the documented fallback Playwright rotates to on CDN failure.
       - "cdn.playwright.dev:443"
       - "playwright.download.prss.microsoft.com:443"
+      # On amd64, Playwright's Chromium is a "Chrome for Testing" build:
+      # cdn.playwright.dev only issues a 302 redirect and the actual
+      # chrome-linux64.zip is served from Google's Chrome-for-Testing bucket
+      # on storage.googleapis.com. Without this, `playwright install chromium`
+      # fails with a proxy 403 (Blocked by network policy) under deny-all.
+      # (arm64 builds come from prss.microsoft.com instead, hence the split.)
+      - "storage.googleapis.com:443"
       # `playwright install --with-deps` apt-installs Chromium's system
       # libraries. `apt-get update` refreshes every configured source, so all
       # template sources must be reachable: Ubuntu hosts amd64 packages on


### PR DESCRIPTION
## Problem

The playwright kit's e2e (`test-kit-e2e`) fails on `main` with:

```
ERROR: request failed: 500 Internal Server Error: failed to run sandbox container
```

## Root cause

On **amd64**, `playwright install --with-deps chromium` downloads a **Chrome for Testing** build. `cdn.playwright.dev` only issues a **302 redirect** — the actual `chrome-linux64.zip` is served from Google's Chrome-for-Testing bucket on **`storage.googleapis.com`**, which was **not** in the kit's allow-list. Under the e2e **deny-all** policy the proxy returns `403 Blocked by network policy: domain storage.googleapis.com:443`, so the browser download fails.

In **sbx v0.35.0**, kit install commands run as a container **start hook**, so a failing install surfaces as the opaque `500 ... failed to run sandbox container`. This is why CI (amd64) failed while local/**arm64** runs passed — arm64 Chromium comes from `prss.microsoft.com`, which was already allowed.

Captured from the CI daemon log:
```
Error: Download failed: server returned code 403 body 'Blocked by network policy: domain storage.googleapis.com:443'
  URL: https://cdn.playwright.dev/builds/cft/149.0.7827.55/linux64/chrome-linux64.zip
```

## Fix

Add `storage.googleapis.com:443` to `caps.network.allow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)