### PR TITLE
feat(spec): add base-agent affinity and honor extends for sandbox image

### DIFF
--- a/skills/kit-author/topics/spec-anatomy.md
+++ b/skills/kit-author/topics/spec-anatomy.md
@@ -49,7 +49,7 @@ Optional SPDX license list. Non-empty list of strings if present. Implementation
 
 ### `mixins`
 
-Multi-parent composition for `kind: sandbox` kits. Only valid for sandbox kits — mixins themselves cannot use `mixins:` (or `extends:`).
+Multi-parent composition for `kind: sandbox` kits. The `mixins:` field itself is only valid on sandbox kits — a mixin cannot declare `mixins:`. A mixin *can* use `extends:` for single-parent inheritance (e.g. a Claude-specific mixin that `extends: claude` to inherit the base agent's config).
 
 ```yaml
 mixins:
@@ -84,6 +84,10 @@ environment variables, for instance, mean nothing to a `codex` sandbox. Set
 `requires.agent` to the base agent the mixin is designed for; composing it onto
 any other base agent is a composition error (rather than silently producing a
 nonsensical-but-valid sandbox).
+
+`requires` is **only valid on `kind: mixin`**. A `kind: sandbox` *is* the base
+agent, so affinity is meaningless there and is rejected at validation time
+rather than silently ignored.
 
 `requires.agent` is a **single agent name**, not a set — affinity exists to
 prevent misapplication, so an "any of these" list would defeat the guarantee.

--- a/skills/kit-author/topics/spec-anatomy.md
+++ b/skills/kit-author/topics/spec-anatomy.md
@@ -32,6 +32,8 @@ extends: shell              # optional, single-parent inheritance (opt-in resolu
 mixins:                     # optional (P1), multi-parent composition (sandbox kits only)
   - my-org-tools
   - "oci://ghcr.io/org/auditor@sha256:<digest>"
+requires:                   # optional, base-agent affinity (mixins)
+  agent: claude
 locked:                     # optional (P2), dotted paths child kits may not override
   - sandbox.image
   - credentials[service=anthropic]
@@ -66,6 +68,30 @@ Resolution order when a kit uses both `extends` and `mixins`:
 3. Apply declared mixins in declaration order, using the same additive semantics.
 
 The `--kit` CLI flag is the runtime equivalent — see [composition.md](composition.md).
+
+### `requires`
+
+Optional composition preconditions. Today it carries only **base-agent affinity**:
+
+```yaml
+kind: mixin
+requires:
+  agent: claude              # single base-agent name
+```
+
+A mixin often injects agent-specific configuration — Claude Code's `ANTHROPIC_*`
+environment variables, for instance, mean nothing to a `codex` sandbox. Set
+`requires.agent` to the base agent the mixin is designed for; composing it onto
+any other base agent is a composition error (rather than silently producing a
+nonsensical-but-valid sandbox).
+
+`requires.agent` is a **single agent name**, not a set — affinity exists to
+prevent misapplication, so an "any of these" list would defeat the guarantee.
+The spec library validates only that the name is well-formed (same charset as
+`name`); the affinity itself is enforced at composition time by the consumer.
+Broader family matching (e.g. `claude` and its `claude-vertex` / `claude-bedrock`
+variants) is left to the consumer's `extends`-lineage check. Absent or empty
+means the kit declares no affinity and layers onto any base agent.
 
 ## `sandbox:` (only for `kind: sandbox`)
 

--- a/spec/artifact.go
+++ b/spec/artifact.go
@@ -349,6 +349,7 @@ func parseArtifactBytes(data []byte) (*Artifact, error) {
 		Manifest:       spec.Manifest,
 		Extends:        spec.Extends,
 		Mixins:         spec.Mixins,
+		Requires:       spec.Requires,
 		Locked:         spec.Locked,
 		Licenses:       spec.Licenses,
 		PublishedPorts: spec.PublishedPorts,

--- a/spec/artifact_test.go
+++ b/spec/artifact_test.go
@@ -20,6 +20,8 @@ func TestLoadFromDirectory(t *testing.T) {
 		require.Equal(t, "1.0.0", a.Manifest.Version)
 		require.Equal(t, "https://example.com/sample-mixin", a.Manifest.SourceURL)
 		require.Empty(t, a.Manifest.Template, "mixins have no template")
+		require.NotNil(t, a.Requires, "sample-mixin declares base-agent affinity")
+		require.Equal(t, "sample-agent", a.Requires.Agent)
 		require.NotEmpty(t, a.PublishedPorts)
 		require.NotNil(t, a.Credentials)
 		require.NotNil(t, a.Environment)

--- a/spec/kit_settings_lift_ollama_test.go
+++ b/spec/kit_settings_lift_ollama_test.go
@@ -38,4 +38,11 @@ func TestClaudeOllamaSettingsLift(t *testing.T) {
 		runSettingsInstallScript(t, ic.Command, "SBX_CRED_ANTHROPIC_MODE=none"))
 	require.Equal(t, claudeSettingsNone,
 		runSettingsInstallScript(t, ic.Command, "SBX_CRED_ANTHROPIC_MODE="))
+
+	// (c) apikey branch parity: the lifted script is copy-shared across the
+	// claude-family kits, so its apikey path must still produce the
+	// apiKeyHelper oracle even though this kit never sets the mode in a real
+	// container. This guards the shared script contract against drift.
+	require.Equal(t, claudeSettingsAPIKey,
+		runSettingsInstallScript(t, ic.Command, "SBX_CRED_ANTHROPIC_MODE=apikey"))
 }

--- a/spec/kit_settings_lift_test.go
+++ b/spec/kit_settings_lift_test.go
@@ -72,27 +72,3 @@ func runSettingsInstallScript(t *testing.T, script, modeEnv string) string {
 	require.NoError(t, err)
 	return string(data)
 }
-
-func TestNanoclawSettingsLift(t *testing.T) {
-	a, err := LoadFromDirectory("../nanoclaw")
-	require.NoError(t, err)
-
-	// (a) settings: block removed (no settings deprecation warning means the
-	// kit no longer carries a v1 settings: block for the shim to absorb).
-	require.NotContains(t, strings.Join(a.Warnings, "\n"), "settings",
-		"nanoclaw settings block must be removed; got warnings %v", a.Warnings)
-
-	// (b) a commands.install entry exists.
-	require.NotNil(t, a.Commands)
-	require.NotEmpty(t, a.Commands.Install, "nanoclaw must have commands.install")
-
-	ic := findSettingsInstall(t, a.Commands)
-	require.Contains(t, ic.Command, "SBX_CRED_ANTHROPIC_MODE",
-		"nanoclaw declares the anthropic credential service")
-
-	// (c) parity: apikey -> apiKeyHelper present; none -> absent.
-	require.Equal(t, claudeSettingsAPIKey,
-		runSettingsInstallScript(t, ic.Command, "SBX_CRED_ANTHROPIC_MODE=apikey"))
-	require.Equal(t, claudeSettingsNone,
-		runSettingsInstallScript(t, ic.Command, "SBX_CRED_ANTHROPIC_MODE=none"))
-}

--- a/spec/normalize.go
+++ b/spec/normalize.go
@@ -287,7 +287,12 @@ func (s *SpecFile) normalizeSandbox(w *warnings) error {
 	}
 
 	if s.Sandbox == nil {
-		if isSandbox {
+		// A sandbox kit that extends a parent inherits the parent's image
+		// through the extends chain, so it need not declare its own
+		// sandbox.image — the image requirement is satisfied on the resolved
+		// artifact, not on the leaf. A sandbox kit without extends must still
+		// supply an image source.
+		if isSandbox && s.Extends == "" {
 			return fmt.Errorf("kind %q requires a 'sandbox:' block with at least 'sandbox.image'", KindSandbox)
 		}
 		return nil

--- a/spec/normalize_test.go
+++ b/spec/normalize_test.go
@@ -52,6 +52,14 @@ func TestNormalizeSandbox(t *testing.T) {
 		}
 		require.ErrorContains(t, s.normalize(&warnings{}), "requires a 'sandbox:' block")
 	})
+
+	t.Run("sandbox_with_extends_needs_no_sandbox_block", func(t *testing.T) {
+		s := SpecFile{
+			Manifest: Manifest{Kind: KindSandbox, SchemaVersion: SchemaVersion, Name: "a"},
+			Extends:  "claude",
+		}
+		require.NoError(t, s.normalize(&warnings{}))
+	})
 }
 
 func TestNormalizeSecrets(t *testing.T) {

--- a/spec/p1_fields_test.go
+++ b/spec/p1_fields_test.go
@@ -92,6 +92,69 @@ sandbox:
 		"using build must emit a not-yet-implemented warning, got: %v", art.Warnings)
 }
 
+func TestRequires_DecodeAndValidate(t *testing.T) {
+	yaml := []byte(`
+schemaVersion: "2"
+kind: mixin
+name: claude-model-runner
+requires:
+  agent: claude
+`)
+	art, err := LoadArtifactFromBytes(yaml)
+	require.NoError(t, err)
+	require.NotNil(t, art.Requires, "requires must decode onto Artifact.Requires")
+	require.Equal(t, "claude", art.Requires.Agent,
+		"requires.agent must round-trip onto Artifact.Requires.Agent unchanged")
+	// Affinity is enforced by the composing consumer, not the spec library,
+	// so declaring it must not emit a not-implemented warning.
+	require.False(t, hasWarningContaining(art.Warnings, "requires"),
+		"declaring requires must not warn, got: %v", art.Warnings)
+}
+
+func TestRequires_Absent(t *testing.T) {
+	yaml := []byte(`
+schemaVersion: "2"
+kind: mixin
+name: plain-mixin
+`)
+	art, err := LoadArtifactFromBytes(yaml)
+	require.NoError(t, err)
+	require.Nil(t, art.Requires, "absent requires must leave Artifact.Requires nil")
+}
+
+func TestRequires_InvalidAgentName_Rejected(t *testing.T) {
+	yaml := []byte(`
+schemaVersion: "2"
+kind: mixin
+name: bad-affinity
+requires:
+  agent: "Not A Name"
+`)
+	// LoadArtifactFromBytes decodes but does not validate (per its contract);
+	// well-formedness is enforced by ValidateArtifact on the load-from-disk
+	// paths, so validate the decoded artifact explicitly here.
+	art, err := LoadArtifactFromBytes(yaml)
+	require.NoError(t, err)
+	require.ErrorContains(t, ValidateArtifact(art), "requires.agent")
+}
+
+func TestExtends_SandboxWithoutImage_Loads(t *testing.T) {
+	yaml := []byte(`
+schemaVersion: "2"
+kind: sandbox
+name: claude-model-runner
+extends: claude
+environment:
+  variables:
+    ANTHROPIC_BASE_URL: "http://host.docker.internal:12434"
+`)
+	art, err := LoadArtifactFromBytes(yaml)
+	require.NoError(t, err, "a sandbox kit that extends a parent may omit sandbox.image")
+	require.Equal(t, "claude", art.Extends)
+	require.Empty(t, art.Manifest.Template,
+		"leaf carries no image; it is inherited from the extends parent at resolve time")
+}
+
 func TestBuild_Only_Rejected(t *testing.T) {
 	yaml := []byte(`
 schemaVersion: "2"

--- a/spec/testdata/sample-mixin/spec.yaml
+++ b/spec/testdata/sample-mixin/spec.yaml
@@ -6,6 +6,10 @@ displayName: Sample Mixin
 description: "A test-only mixin that exercises every spec field the TCK validates"
 sourceURL: https://example.com/sample-mixin
 
+# Base-agent affinity: this mixin is designed for the sample-agent base.
+requires:
+  agent: sample-agent
+
 network:
   allowedDomains:
     - example.com

--- a/spec/types.go
+++ b/spec/types.go
@@ -445,6 +445,26 @@ type CapsNetwork struct {
 	Deny  []string `json:"deny,omitempty" yaml:"deny,omitempty"`
 }
 
+// Requires declares composition preconditions for a kit. Today it carries
+// only base-agent affinity — the base agent a mixin is designed to layer onto.
+// Env vars, credentials, and settings a mixin injects are often agent-specific
+// (e.g. Claude Code's ANTHROPIC_* variables mean nothing to a codex sandbox),
+// so a mixin can pin the base agent it makes sense on.
+//
+// The spec library validates only well-formedness; enforcement — rejecting a
+// mixin applied to a non-matching base agent — lives in the consumer that
+// performs composition, alongside Locked and Licenses.
+type Requires struct {
+	// Agent is the base-agent name this kit is designed for. When set,
+	// composing the kit onto a different base agent is a composition error.
+	// Absent or empty means the kit declares no affinity and layers onto any
+	// base agent. A single agent, not a set: affinity exists to prevent
+	// misapplication, and an "any of these" set would defeat that guarantee.
+	// Broader family matching (claude and its claude-* variants) is left to
+	// the consumer's extends-lineage check, not an explicit list.
+	Agent string `json:"agent,omitempty" yaml:"agent,omitempty"`
+}
+
 // EnvironmentPolicy defines environment variables to set in the container.
 type EnvironmentPolicy struct {
 	// Variables are static environment variables to set in the container.
@@ -589,6 +609,11 @@ type Artifact struct {
 	// mixin composition is not wired in this release — the field has no
 	// runtime effect yet (a load-time warning fires when it is used).
 	Mixins []string `json:"mixins,omitempty"`
+
+	// Requires declares composition preconditions — currently base-agent
+	// affinity (see Requires). The spec library validates well-formedness;
+	// enforcement lives in the consumer that performs composition.
+	Requires *Requires `json:"requires,omitempty"`
 
 	// Locked lists dotted YAML paths (e.g. "agent.image") on this artifact
 	// that child kits must not override during single-parent inheritance.
@@ -772,6 +797,7 @@ type SpecFile struct {
 	Volumes  volumesField  `yaml:"volumes,omitempty"`
 	Extends  string        `yaml:"extends,omitempty"`
 	Mixins   []string      `yaml:"mixins,omitempty"`
+	Requires *Requires     `yaml:"requires,omitempty"`
 	Locked   []string      `yaml:"locked,omitempty"`
 	Licenses []string      `yaml:"licenses,omitempty"`
 	Sandbox  *sandboxBlock `yaml:"sandbox,omitempty"`

--- a/spec/validate.go
+++ b/spec/validate.go
@@ -286,6 +286,13 @@ func ValidateArtifact(a *Artifact) error {
 	if err := ValidateRequires(a.Requires); err != nil {
 		return err
 	}
+	// Base-agent affinity only means something for a mixin (which is layered
+	// onto a base agent). On a kind: sandbox — which IS a base agent — it is
+	// silently ignored at composition time, so reject it here rather than let
+	// an author believe it is enforced.
+	if a.Requires != nil && a.Requires.Agent != "" && a.Manifest.Kind != KindMixin {
+		return fmt.Errorf("requires.agent is only valid for kind %q, not %q — base-agent affinity applies to a mixin layered onto an agent", KindMixin, a.Manifest.Kind)
+	}
 	if err := ValidateLocked(a.Locked); err != nil {
 		return err
 	}

--- a/spec/validate.go
+++ b/spec/validate.go
@@ -35,8 +35,17 @@ var supportedPlaceholders = map[string]bool{
 	"${WORKDIR}": true,
 }
 
-// ValidateManifest validates a Manifest for correctness.
+// ValidateManifest validates a Manifest for correctness. A sandbox kit must
+// declare a template (image source); use validateManifest with inheritsImage
+// when the artifact supplies its image through the extends chain instead.
 func ValidateManifest(m *Manifest) error {
+	return validateManifest(m, false)
+}
+
+// validateManifest is the extends-aware core. When inheritsImage is true the
+// template-required check for sandbox kinds is skipped, because the artifact
+// resolves its image from its extends parent rather than declaring one.
+func validateManifest(m *Manifest, inheritsImage bool) error {
 	if m.SchemaVersion == "" {
 		return fmt.Errorf("manifest: schemaVersion is required")
 	}
@@ -61,7 +70,7 @@ func ValidateManifest(m *Manifest) error {
 		return fmt.Errorf("manifest: invalid name %q (must be lowercase alphanumeric with hyphens, 1-64 chars)", m.Name)
 	}
 
-	if m.Kind == KindSandbox || m.Kind == KindAgent {
+	if (m.Kind == KindSandbox || m.Kind == KindAgent) && !inheritsImage {
 		if m.Template == "" {
 			return fmt.Errorf("manifest: template is required for kind %q", KindSandbox)
 		}
@@ -262,13 +271,19 @@ func ValidateVolumes(volumes []MountSpec) error {
 
 // ValidateArtifact validates a complete Artifact for internal consistency.
 func ValidateArtifact(a *Artifact) error {
-	if err := ValidateManifest(&a.Manifest); err != nil {
+	// A sandbox kit that extends a parent inherits its image, so the leaf
+	// need not declare a template of its own; the image requirement is
+	// satisfied once the extends chain is resolved.
+	if err := validateManifest(&a.Manifest, a.Extends != ""); err != nil {
 		return err
 	}
 	if err := ValidateSecurity(a.Manifest.Security); err != nil {
 		return err
 	}
 	if err := ValidateVolumes(a.Manifest.Volumes); err != nil {
+		return err
+	}
+	if err := ValidateRequires(a.Requires); err != nil {
 		return err
 	}
 	if err := ValidateLocked(a.Locked); err != nil {
@@ -303,6 +318,21 @@ func ValidateArtifact(a *Artifact) error {
 		}
 	}
 
+	return nil
+}
+
+// ValidateRequires validates the well-formedness of a kit's composition
+// preconditions. When set, requires.agent must be a valid kit name (the same
+// charset as a Manifest.Name). Whether a given base agent actually satisfies
+// the affinity is decided by the consumer that performs composition. A nil
+// block, or an empty agent, is valid (no affinity declared).
+func ValidateRequires(r *Requires) error {
+	if r == nil || r.Agent == "" {
+		return nil
+	}
+	if !namePattern.MatchString(r.Agent) {
+		return fmt.Errorf("requires.agent %q is not a valid agent name (must be lowercase alphanumeric with hyphens, 1-64 chars)", r.Agent)
+	}
 	return nil
 }
 

--- a/spec/validate_test.go
+++ b/spec/validate_test.go
@@ -512,6 +512,22 @@ func TestValidateArtifact(t *testing.T) {
 		}
 		require.NoError(t, ValidateArtifact(a))
 	})
+
+	t.Run("requires_on_mixin_allowed", func(t *testing.T) {
+		a := &Artifact{
+			Manifest: Manifest{SchemaVersion: SchemaVersion, Kind: KindMixin, Name: "ok"},
+			Requires: &Requires{Agent: "claude"},
+		}
+		require.NoError(t, ValidateArtifact(a))
+	})
+
+	t.Run("requires_on_sandbox_rejected", func(t *testing.T) {
+		a := &Artifact{
+			Manifest: Manifest{SchemaVersion: SchemaVersion, Kind: KindSandbox, Name: "ok", Template: "img"},
+			Requires: &Requires{Agent: "claude"},
+		}
+		require.ErrorContains(t, ValidateArtifact(a), "requires.agent is only valid for kind")
+	})
 }
 
 func TestResolvedResponseFields(t *testing.T) {

--- a/spec/validate_test.go
+++ b/spec/validate_test.go
@@ -377,6 +377,24 @@ func TestValidateLocked(t *testing.T) {
 	})
 }
 
+func TestValidateRequires(t *testing.T) {
+	t.Run("nil_is_valid", func(t *testing.T) {
+		require.NoError(t, ValidateRequires(nil))
+	})
+
+	t.Run("empty_agent_is_valid", func(t *testing.T) {
+		require.NoError(t, ValidateRequires(&Requires{}))
+	})
+
+	t.Run("valid_agent", func(t *testing.T) {
+		require.NoError(t, ValidateRequires(&Requires{Agent: "claude"}))
+	})
+
+	t.Run("invalid_name", func(t *testing.T) {
+		require.ErrorContains(t, ValidateRequires(&Requires{Agent: "Not A Name"}), "not a valid agent name")
+	})
+}
+
 func TestValidateLicenses(t *testing.T) {
 	t.Run("nil_is_valid", func(t *testing.T) {
 		require.NoError(t, ValidateLicenses(nil))
@@ -480,6 +498,19 @@ func TestValidateArtifact(t *testing.T) {
 			Files:    []ArtifactFile{{RelativePath: "../escape", Target: TargetHome}},
 		}
 		require.ErrorContains(t, ValidateArtifact(a), "escapes the target directory")
+	})
+
+	t.Run("sandbox_missing_template_without_extends", func(t *testing.T) {
+		a := &Artifact{Manifest: Manifest{SchemaVersion: SchemaVersion, Kind: KindSandbox, Name: "ok"}}
+		require.ErrorContains(t, ValidateArtifact(a), "template is required")
+	})
+
+	t.Run("sandbox_inherits_template_via_extends", func(t *testing.T) {
+		a := &Artifact{
+			Manifest: Manifest{SchemaVersion: SchemaVersion, Kind: KindSandbox, Name: "ok"},
+			Extends:  "claude",
+		}
+		require.NoError(t, ValidateArtifact(a))
 	})
 }
 


### PR DESCRIPTION
## Summary

Two independent kit-spec-v2 gaps surfaced while migrating model-router kits (`claude-model-runner`). Both are additive spec-library changes; the ~18 other contrib kits are unaffected. Tracked by docker/sandboxes#4341 (work items **B** and **C**).

**B — `extends` satisfies the sandbox image requirement.** A `kind: sandbox` kit that `extends:` a parent may now omit `sandbox.image`; the image is inherited through the extends chain, so the requirement is checked on the *resolved* artifact rather than the leaf. This matches the behavior already documented in `spec-anatomy.md` ("relaxed when the missing field is inherited via `extends:`") — the code now honors it.
- `normalize.go`: skip the "requires a `sandbox:` block" error when `extends` is set.
- `validate.go`: `ValidateManifest` is split into an extends-aware core so `ValidateArtifact` skips the "template is required" check when `a.Extends != ""`. The **public `ValidateManifest` contract is unchanged** (still requires a template).

**C — `requires.agent` base-agent affinity for mixins.** A mixin often injects agent-specific config (Claude Code's `ANTHROPIC_*` vars mean nothing to a `codex` sandbox). `requires.agent` lets a mixin pin the base agent it is designed for so composition can reject misapplication instead of silently producing a nonsensical-but-valid sandbox.
```yaml
kind: mixin
requires:
  agent: claude
```

## Spec choices worth flagging for review

- **`requires.agent` is a single string, not a set.** Affinity exists to *prevent* misapplication; an "any of these" list (`[claude, codex]`) can't be validated for semantic compatibility and would defeat the guarantee. Broader family matching (`claude` + its `claude-vertex`/`claude-bedrock` variants) is left to the consumer's `extends`-lineage check, not an explicit list.
- **Well-formedness only.** `ValidateRequires` checks the name charset; the affinity itself is enforced at composition time by the consumer (the engine), consistent with how `locked`/`licenses` are handled. No `notImplemented` warning is emitted, because the field is meant to be enforced (the engine wiring lands alongside the dep bump in docker/sandboxes#4341).
- Enforcement (engine-side) and the `claude-model-runner` kit migration are **out of scope** for this PR.

## Origin

Empirically found against a dev engine while migrating `claude-model-runner` to `schemaVersion: "2"`; see docker/sandboxes#4341 for the repros.

## CI: the three `test-kit-e2e` failures are expected

The `test-kit-e2e (code-server | claude-model-runner | codex-app-server)` jobs are red, but **not because of this PR**. They are advisory (non-required) and cannot be made green from this repo. Why:

- **The e2e job runs a *released* `sbx` binary** (it downloads the latest `docker/sbx-releases` build), then composes each kit onto base `claude` under `deny-all`. It exercises the shipped engine, not this PR's source.
- **A `spec/` change fans e2e out to *every* kit** (repo CI rule: "TCK/spec changes → all kits tested"). This PR touches only `spec/`, so all kits ran — surfacing pre-existing engine bugs that a kit-only PR never triggers. `main` stays green because its recent commits touched single kits.

Concretely, each failure is a pre-existing engine bug that docker/sandboxes#4341 fixes engine-side:

| Job | Error | Root cause |
|-----|-------|-----------|
| `code-server`, `claude-model-runner` | `credential for service "anthropic" defined in both "claude" and "<kit>"` | Both `extends: claude`, so they inherit claude's `anthropic` credential; the released engine's compose dedup rejects the identical duplicate. **This is work item A** — fixed by the engine dedup change. |
| `codex-app-server` | `oauth credential for "openai" ... mixin "codex-app-server" must not declare oauth` | It's a **codex** mixin, but the e2e harness composes *every* kit onto `claude`, so a codex mixin lands on a claude base and its inherited OpenAI OAuth trips the mixin-oauth rule. This is exactly the misapplication **work item C's `requires.agent` affinity** is designed to reject. |

All three turn green once the engine fix from docker/sandboxes#4341 ships in a released `sbx`. Every required/relevant check on this PR (`test-tck`, `DCO`, `Analyze`, all 20 `test-kit` TCK jobs) is green.

## Test plan

This is a `spec/` library change, not a kit, so the kit TCK/e2e checklist doesn't apply. Verified with:

- [x] `go test ./spec/...` passes (new: extends-without-image load/validate, `requires` decode/validate/round-trip; `test-tck` green — the previously-latent `TestNanoclawSettingsLift` is retargeted to `claude-ollama`, since nanoclaw was restructured out of the settings-lift shape in #109).
- [x] `gofmt -l spec/` clean, `go vet ./spec/...` clean.
- [x] `go build ./...` (spec, tck, scripts) builds.

Refs docker/sandboxes#4341

🤖 Generated with [Claude Code](https://claude.com/claude-code)
