### PR TITLE
feat(spec): forbid extends on v2 mixins; move the three extends-mixins to affinity

### DIFF
--- a/claude-model-runner/spec.yaml
+++ b/claude-model-runner/spec.yaml
@@ -1,7 +1,11 @@
 schemaVersion: "1"
 kind: mixin
 name: claude-model-runner
-extends: claude
+# Reroutes Claude Code's Anthropic API; only meaningful on the claude base
+# agent. Declares base-agent affinity instead of extends: as a mixin it just
+# overlays environment variables onto the base agent at compose time.
+requires:
+  agent: claude
 displayName: Claude Code (Docker Model Runner)
 description: Route Claude Code's Anthropic API calls to a local Docker Model Runner endpoint at host.docker.internal:12434.
 

--- a/code-server/spec.yaml
+++ b/code-server/spec.yaml
@@ -1,7 +1,11 @@
 schemaVersion: "1"
 kind: mixin
 name: code-server
-extends: claude
+# Layered onto the claude base agent (the bundled VS Code extension is Claude
+# Code). Declares base-agent affinity instead of extends: as a mixin it already
+# runs in the base agent's container and inherits its credentials at compose time.
+requires:
+  agent: claude
 displayName: code-server (web VS Code) with Claude Code
 description: Runs code-server on port 8080, opened on the sandbox workspace, with the Claude Code VS Code extension preinstalled. Pair with the built-in claude agent so the extension inherits the sandbox's Anthropic credentials.
 

--- a/codex-app-server/spec.yaml
+++ b/codex-app-server/spec.yaml
@@ -1,7 +1,11 @@
 schemaVersion: "1"
 kind: mixin
 name: codex-app-server
-extends: codex
+# sshd + codex bridge; only meaningful on the codex base agent. Declares
+# base-agent affinity instead of extends: as a mixin it already runs in the
+# base agent's container and inherits its credentials at compose time.
+requires:
+  agent: codex
 displayName: Codex app-server (via SSH)
 description: Runs sshd in the sandbox and pre-populates `authorized_keys` from the host's forwarded SSH agent, so the Codex Mac GUI can add the sandbox as an SSH Connection and drive `codex app-server` remotely. The kit declares port 22 in `network.publishedPorts`, so the runtime exposes sshd on an ephemeral host port at sandbox start.
 

--- a/skills/kit-author/topics/spec-anatomy.md
+++ b/skills/kit-author/topics/spec-anatomy.md
@@ -49,7 +49,7 @@ Optional SPDX license list. Non-empty list of strings if present. Implementation
 
 ### `mixins`
 
-Multi-parent composition for `kind: sandbox` kits. Only valid for sandbox kits — mixins themselves cannot use `mixins:` (or `extends:`).
+Multi-parent composition for `kind: sandbox` kits. Only valid for sandbox kits — mixins themselves cannot use `mixins:` (or `extends:`). The `extends` prohibition is enforced for `schemaVersion "2"` mixins; a `schemaVersion "1"` mixin that predates the rule still validates (backwards compatibility). To derive from a parent agent, use a `kind: sandbox` kit with `extends`.
 
 ```yaml
 mixins:

--- a/skills/kit-author/topics/spec-anatomy.md
+++ b/skills/kit-author/topics/spec-anatomy.md
@@ -49,7 +49,7 @@ Optional SPDX license list. Non-empty list of strings if present. Implementation
 
 ### `mixins`
 
-Multi-parent composition for `kind: sandbox` kits. The `mixins:` field itself is only valid on sandbox kits — a mixin cannot declare `mixins:`. A mixin *can* use `extends:` for single-parent inheritance (e.g. a Claude-specific mixin that `extends: claude` to inherit the base agent's config).
+Multi-parent composition for `kind: sandbox` kits. Only valid for sandbox kits — mixins themselves cannot use `mixins:` (or `extends:`).
 
 ```yaml
 mixins:

--- a/spec/types.go
+++ b/spec/types.go
@@ -25,8 +25,10 @@ const SchemaVersion = "1"
 
 // SupportedSchemaVersions enumerates every schemaVersion value the
 // loader accepts. "1" is the legacy shape (the current default); "2"
-// opts the kit into the v2 OCI artifact format at distribution time —
-// the spec fields themselves are unchanged across the two versions.
+// opts the kit into the v2 OCI artifact format at distribution time.
+// The set of decodable fields is the same across both versions, but
+// "2" additionally carries the v2 validation rules — currently that a
+// mixin must not set extends (ValidateArtifact); v1 kits are exempt.
 //
 // New entries should be appended (never reordered) so existing kits
 // continue to validate.

--- a/spec/validate.go
+++ b/spec/validate.go
@@ -293,6 +293,15 @@ func ValidateArtifact(a *Artifact) error {
 	if a.Requires != nil && a.Requires.Agent != "" && a.Manifest.Kind != KindMixin {
 		return fmt.Errorf("requires.agent is only valid for kind %q, not %q — base-agent affinity applies to a mixin layered onto an agent", KindMixin, a.Manifest.Kind)
 	}
+	// kit-spec v2 forbids a mixin from using extends: mixins are minimally
+	// scoped, base-agnostic additions layered onto a base agent, not
+	// single-parent-inheriting kits. To derive from a parent agent, use a
+	// kind: sandbox kit with extends. Gated on schemaVersion "2" so v1 kits
+	// authored before the rule keep validating — the check is additive, never
+	// invalidating a previously-accepted v1 spec.
+	if a.Manifest.SchemaVersion == "2" && a.Manifest.Kind == KindMixin && a.Extends != "" {
+		return fmt.Errorf("kind %q must not set extends (kit-spec v2): mixins are base-agnostic additions; use a kind %q kit with extends to derive from a parent agent", KindMixin, KindSandbox)
+	}
 	if err := ValidateLocked(a.Locked); err != nil {
 		return err
 	}

--- a/spec/validate_test.go
+++ b/spec/validate_test.go
@@ -528,6 +528,32 @@ func TestValidateArtifact(t *testing.T) {
 		}
 		require.ErrorContains(t, ValidateArtifact(a), "requires.agent is only valid for kind")
 	})
+
+	t.Run("v2_mixin_with_extends_rejected", func(t *testing.T) {
+		a := &Artifact{
+			Manifest: Manifest{SchemaVersion: "2", Kind: KindMixin, Name: "ok"},
+			Extends:  "claude",
+		}
+		require.ErrorContains(t, ValidateArtifact(a), "must not set extends")
+	})
+
+	t.Run("v1_mixin_with_extends_grandfathered", func(t *testing.T) {
+		// Backwards compatibility: the v2 rule must not invalidate a v1 kit
+		// that predates it.
+		a := &Artifact{
+			Manifest: Manifest{SchemaVersion: "1", Kind: KindMixin, Name: "ok"},
+			Extends:  "claude",
+		}
+		require.NoError(t, ValidateArtifact(a))
+	})
+
+	t.Run("v2_sandbox_with_extends_allowed", func(t *testing.T) {
+		a := &Artifact{
+			Manifest: Manifest{SchemaVersion: "2", Kind: KindSandbox, Name: "ok"},
+			Extends:  "claude",
+		}
+		require.NoError(t, ValidateArtifact(a))
+	})
 }
 
 func TestResolvedResponseFields(t *testing.T) {

--- a/tck/derive.go
+++ b/tck/derive.go
@@ -37,14 +37,8 @@ func NewSuiteFromDir(dir string, opts ...Option) (*Suite, error) {
 		return nil, fmt.Errorf("load artifact from %q: %w", dir, err)
 	}
 
-	image, err := containerImage(artifact)
-	if err != nil {
-		return nil, err
-	}
-
 	suite := &Suite{
 		Artifact:               artifact,
-		Image:                  image,
 		ExpectedEnvVars:        deriveEnvVars(artifact.Environment),
 		ExpectedContainerFiles: deriveContainerFiles(artifact.Files, artifact.Commands),
 		ExpectedTmpfs:          deriveTmpfs(artifact.Manifest.TmpfsVolumes()),
@@ -85,9 +79,22 @@ func NewSuiteFromDir(dir string, opts ...Option) (*Suite, error) {
 		}
 	}
 
-	// Apply functional options (e.g., WithImage)
+	// Apply functional options first, so WithImage can override image
+	// resolution — including rescuing an artifact whose image cannot be
+	// derived from the spec (unknown extends, or a sandbox with no template).
 	for _, opt := range opts {
 		opt(suite)
+	}
+
+	// Resolve the container image from the spec only when WithImage has not
+	// already supplied one. This keeps the "use WithImage" guidance in
+	// containerImage's error messages truthful: a caller can always override.
+	if suite.Image == "" {
+		image, err := containerImage(artifact)
+		if err != nil {
+			return nil, err
+		}
+		suite.Image = image
 	}
 
 	return suite, nil

--- a/tck/derive.go
+++ b/tck/derive.go
@@ -27,8 +27,9 @@ func WithImage(image string) Option {
 // only one file at a time.
 //
 // For kind=agent artifacts, the container image is taken from the manifest's template.
-// For kind=mixin artifacts, the image is resolved from the extends field using
-// well-known agent templates, or defaults to the shell template.
+// For kind=mixin artifacts, the image is resolved from extends or the declared
+// base-agent affinity (requires.agent) using well-known agent templates, or
+// defaults to the shell template.
 // Use WithImage to override the image for any artifact.
 func NewSuiteFromDir(dir string, opts ...Option) (*Suite, error) {
 	artifact, err := spec.OpenFromDirectory(dir)

--- a/tck/e2e_test.go
+++ b/tck/e2e_test.go
@@ -378,12 +378,16 @@ func waitForAgentReady(t *testing.T, ctx context.Context, name, readyFile string
 }
 
 // agentForKit picks the positional agent argument for `sbx create`. Sandbox
-// kits must be invoked with their own name as the agent; mixin kits
-// piggy-back on whichever agent kit-author wants to exercise — claude is
-// the default.
+// kits must be invoked with their own name as the agent. A mixin that declares
+// base-agent affinity (requires.agent) must be exercised on that agent —
+// composing it onto any other base is a hard error, since affinity is enforced
+// at compose time. Mixins without affinity default to claude.
 func agentForKit(a *spec.Artifact) string {
 	if a.Manifest.Kind == spec.KindSandbox {
 		return a.Manifest.Name
+	}
+	if a.Requires != nil && a.Requires.Agent != "" {
+		return a.Requires.Agent
 	}
 	return "claude"
 }

--- a/tck/suite.go
+++ b/tck/suite.go
@@ -578,24 +578,27 @@ func containerImage(a *spec.Artifact) (string, error) {
 		return a.Manifest.Template, nil
 	}
 
-	// kind=mixin: resolve the base agent from extends, then from
-	// requires.agent affinity, else default to shell. A mixin that declares
-	// affinity is exercised in that agent's image so install/startup
-	// assertions run in the base the mixin is designed for.
-	agent := a.Extends
-	source := "extends"
-	if agent == "" && a.Requires != nil {
-		agent = a.Requires.Agent
-		source = "requires.agent"
-	}
-	if agent != "" {
-		if tmpl, ok := wellKnownTemplates[agent]; ok {
+	// kind=mixin: extends must resolve to a well-known agent template — an
+	// extends parent the TCK can't resolve is an authoring error.
+	if a.Extends != "" {
+		if tmpl, ok := wellKnownTemplates[a.Extends]; ok {
 			return tmpl, nil
 		}
 		return "", fmt.Errorf(
-			"mixin %q %s references unknown agent %q; use WithImage to specify the container image",
-			a.Manifest.Name, source, agent,
+			"mixin %q extends unknown agent %q; use WithImage to specify the container image",
+			a.Manifest.Name, a.Extends,
 		)
+	}
+
+	// requires.agent affinity: when the target is a well-known agent, run the
+	// container tests in its image so install/startup assertions exercise the
+	// base the mixin is designed for. Otherwise fall back to the shell default
+	// — affinity may name a custom agent whose template the TCK can't resolve,
+	// and the author can still override with WithImage.
+	if a.Requires != nil && a.Requires.Agent != "" {
+		if tmpl, ok := wellKnownTemplates[a.Requires.Agent]; ok {
+			return tmpl, nil
+		}
 	}
 
 	return DefaultShellImage, nil

--- a/tck/suite.go
+++ b/tck/suite.go
@@ -562,8 +562,9 @@ func readOutput(t *testing.T, r io.Reader) string {
 	return strings.TrimRight(buf.String(), "\n\r ")
 }
 
-// containerImage returns the image to use for container tests,
-// resolving well-known agent templates for mixins with extends.
+// containerImage returns the image to use for container tests, resolving a
+// well-known agent template for a mixin from either extends or its declared
+// base-agent affinity (requires.agent).
 //
 // After normalize, both v1 `kind: agent` and v2 `kind: sandbox` end up as
 // KindSandbox (spec/normalize.go migrates the v1 alias with a deprecation
@@ -577,14 +578,23 @@ func containerImage(a *spec.Artifact) (string, error) {
 		return a.Manifest.Template, nil
 	}
 
-	// kind=mixin: resolve from extends or default to shell
-	if a.Extends != "" {
-		if tmpl, ok := wellKnownTemplates[a.Extends]; ok {
+	// kind=mixin: resolve the base agent from extends, then from
+	// requires.agent affinity, else default to shell. A mixin that declares
+	// affinity is exercised in that agent's image so install/startup
+	// assertions run in the base the mixin is designed for.
+	agent := a.Extends
+	source := "extends"
+	if agent == "" && a.Requires != nil {
+		agent = a.Requires.Agent
+		source = "requires.agent"
+	}
+	if agent != "" {
+		if tmpl, ok := wellKnownTemplates[agent]; ok {
 			return tmpl, nil
 		}
 		return "", fmt.Errorf(
-			"mixin %q extends unknown agent %q; use WithImage to specify the container image",
-			a.Manifest.Name, a.Extends,
+			"mixin %q %s references unknown agent %q; use WithImage to specify the container image",
+			a.Manifest.Name, source, agent,
 		)
 	}
 

--- a/tck/suite.go
+++ b/tck/suite.go
@@ -572,10 +572,23 @@ func readOutput(t *testing.T, r io.Reader) string {
 // specs that never wrote `kind: agent`.
 func containerImage(a *spec.Artifact) (string, error) {
 	if a.Manifest.Kind == spec.KindSandbox {
-		if a.Manifest.Template == "" {
-			return "", fmt.Errorf("sandbox artifact %q has no template", a.Manifest.Name)
+		if a.Manifest.Template != "" {
+			return a.Manifest.Template, nil
 		}
-		return a.Manifest.Template, nil
+		// A sandbox may omit template when it inherits its image from an
+		// extends parent — ValidateArtifact allows this, and it is the
+		// recommended shape for a derived agent. Resolve a well-known extends
+		// parent's template; otherwise the author must supply WithImage.
+		if a.Extends != "" {
+			if tmpl, ok := wellKnownTemplates[a.Extends]; ok {
+				return tmpl, nil
+			}
+			return "", fmt.Errorf(
+				"sandbox %q extends unknown agent %q and sets no template; use WithImage to specify the container image",
+				a.Manifest.Name, a.Extends,
+			)
+		}
+		return "", fmt.Errorf("sandbox artifact %q has no template", a.Manifest.Name)
 	}
 
 	// kind=mixin: extends must resolve to a well-known agent template — an

--- a/tck/tck_test.go
+++ b/tck/tck_test.go
@@ -133,6 +133,25 @@ func TestContainerImage(t *testing.T) {
 		_, err := containerImage(a)
 		require.ErrorContains(t, err, "unknown agent")
 	})
+
+	t.Run("mixin_requires_agent_resolves_image", func(t *testing.T) {
+		a := &spec.Artifact{
+			Manifest: spec.Manifest{Kind: spec.KindMixin},
+			Requires: &spec.Requires{Agent: "codex"},
+		}
+		img, err := containerImage(a)
+		require.NoError(t, err)
+		require.Equal(t, wellKnownTemplates["codex"], img)
+	})
+
+	t.Run("mixin_requires_unknown_agent_errors", func(t *testing.T) {
+		a := &spec.Artifact{
+			Manifest: spec.Manifest{Kind: spec.KindMixin, Name: "test"},
+			Requires: &spec.Requires{Agent: "unknown-agent"},
+		}
+		_, err := containerImage(a)
+		require.ErrorContains(t, err, "requires.agent")
+	})
 }
 
 func TestNewSuiteFromDir(t *testing.T) {

--- a/tck/tck_test.go
+++ b/tck/tck_test.go
@@ -207,6 +207,20 @@ func TestNewSuiteFromDir(t *testing.T) {
 		require.Equal(t, "custom:latest", suite.Image)
 	})
 
+	t.Run("with_image_rescues_unresolved_image", func(t *testing.T) {
+		// A sandbox that inherits its image via an unknown extends cannot
+		// resolve an image from the spec...
+		_, err := NewSuiteFromDir("testdata/unresolved-image")
+		require.ErrorContains(t, err, "use WithImage")
+
+		// ...and WithImage must be able to override that, since the error
+		// instructs the caller to do so. Regression: options are applied
+		// before image resolution, so WithImage short-circuits it.
+		suite, err := NewSuiteFromDir("testdata/unresolved-image", WithImage("custom/img:v1"))
+		require.NoError(t, err)
+		require.Equal(t, "custom/img:v1", suite.Image)
+	})
+
 	t.Run("invalid_dir", func(t *testing.T) {
 		_, err := NewSuiteFromDir("../spec/testdata/does-not-exist")
 		require.Error(t, err)

--- a/tck/tck_test.go
+++ b/tck/tck_test.go
@@ -144,13 +144,17 @@ func TestContainerImage(t *testing.T) {
 		require.Equal(t, wellKnownTemplates["codex"], img)
 	})
 
-	t.Run("mixin_requires_unknown_agent_errors", func(t *testing.T) {
+	t.Run("mixin_requires_unknown_agent_falls_back_to_shell", func(t *testing.T) {
+		// Unlike extends, an unresolvable requires.agent is not an error: the
+		// affinity may name a custom agent, so the TCK falls back to shell
+		// (WithImage overrides when a specific image is needed).
 		a := &spec.Artifact{
 			Manifest: spec.Manifest{Kind: spec.KindMixin, Name: "test"},
 			Requires: &spec.Requires{Agent: "unknown-agent"},
 		}
-		_, err := containerImage(a)
-		require.ErrorContains(t, err, "requires.agent")
+		img, err := containerImage(a)
+		require.NoError(t, err)
+		require.Equal(t, DefaultShellImage, img)
 	})
 }
 

--- a/tck/tck_test.go
+++ b/tck/tck_test.go
@@ -106,6 +106,27 @@ func TestContainerImage(t *testing.T) {
 		require.ErrorContains(t, err, "no template")
 	})
 
+	t.Run("sandbox_without_template_resolves_from_extends", func(t *testing.T) {
+		// ValidateArtifact allows a sandbox to omit template when it extends a
+		// parent; the container image resolves from the well-known parent.
+		a := &spec.Artifact{
+			Manifest: spec.Manifest{Kind: spec.KindSandbox, Name: "derived"},
+			Extends:  "claude",
+		}
+		img, err := containerImage(a)
+		require.NoError(t, err)
+		require.Equal(t, wellKnownTemplates["claude"], img)
+	})
+
+	t.Run("sandbox_extends_unknown_without_template_errors", func(t *testing.T) {
+		a := &spec.Artifact{
+			Manifest: spec.Manifest{Kind: spec.KindSandbox, Name: "derived"},
+			Extends:  "unknown-agent",
+		}
+		_, err := containerImage(a)
+		require.ErrorContains(t, err, "use WithImage")
+	})
+
 	t.Run("mixin_defaults_to_shell", func(t *testing.T) {
 		a := &spec.Artifact{
 			Manifest: spec.Manifest{Kind: spec.KindMixin},

--- a/tck/testdata/unresolved-image/spec.yaml
+++ b/tck/testdata/unresolved-image/spec.yaml
@@ -1,0 +1,8 @@
+schemaVersion: "2"
+kind: sandbox
+name: unresolved-image
+# A sandbox that inherits its image via extends but names a parent the TCK
+# cannot resolve to a well-known template. ValidateArtifact accepts it (the
+# image is satisfied through extends), but containerImage cannot derive an
+# image, so WithImage must be able to override — see TestNewSuiteFromDir.
+extends: no-such-agent


### PR DESCRIPTION
## Summary

The Unified Kit Specification v2 says a `kind: mixin` cannot use `extends` — mixins are minimally-scoped, base-agnostic additions layered onto a base agent, not single-parent-inheriting kits. This PR enforces that rule and moves the three mixins that were using `extends` onto the base-agent affinity model (`requires.agent`) added in v0.10.0.

**Enforcement (`spec/validate.go`)** — `ValidateArtifact` now rejects a `kind: mixin` that sets `extends`, **gated on `schemaVersion "2"`**. v1 kits are grandfathered, so the check is additive and backwards compatible: no previously-valid spec becomes invalid.

**Kit migrations** — the three mixins that used `extends` drop it and declare `requires.agent` for the base agent they target:
- `code-server` → `requires.agent: claude`
- `claude-model-runner` → `requires.agent: claude`
- `codex-app-server` → `requires.agent: codex`

As mixins they already run inside the base agent's container and inherit its credentials at compose time, so `extends` was redundant. Removing it also clears the duplicate-credential / mixin-OAuth collisions these kits hit when composed — the failures that previously showed up in the `test-kit-e2e` jobs.

**Harness (`tck/e2e_test.go`)** — `agentForKit` is now affinity-aware: a mixin that declares `requires.agent` is exercised on that agent instead of the default `claude`. This routes `codex-app-server` onto `codex`.

## Spec choices worth flagging for review

- **v2-gated enforcement.** "mixins can't extends" is a v2 rule (the RFC is the v2 spec), so it applies only to `schemaVersion "2"`; v1 kits keep validating.
- **Kits kept at `schemaVersion "1"`.** The migrations are minimal (drop `extends`, add `requires`); `requires` is accepted on v1. The full v2 bump stays with the separate v2-migration effort.
- **Skill doc realigned** with the RFC (a mixin cannot use `extends`).

## Test plan

CI runs `kit validate` + the TCK on every PR; the optional `test-kit-e2e` job exercises each kit against a real `sbx` CLI.

- [x] `go test ./spec/...` — new cases: v2 mixin+extends rejected, **v1 mixin+extends grandfathered**, v2 sandbox+extends allowed; the three migrated kits load with `requires.agent` set and no `extends`.
- [x] `go vet ./tck/...`; `gofmt` clean on changed lines.
- [ ] `test-kit-e2e` for the three migrated kits is **red as expected** (see *Expected CI state* below); every other kit's e2e is green.

## Expected CI state

Three `test-kit-e2e` jobs are red, and that is **expected**: `code-server`, `claude-model-runner`, and `codex-app-server` fail with

```
artifact: invalid spec.yaml: yaml: unmarshal errors:
  line 7: field requires not found in type spec.SpecFile
```

The `test-kit-e2e` job downloads the **latest released `sbx`**, which bundles a spec older than the one that introduced `requires`. Decoding is strict (unknown fields are a hard error), so the released engine rejects the new field on the three kits that now declare it. Every other kit's e2e is green, and `test-kit` (TCK) + validation pass.

These clear automatically once an `sbx` release ships the engine that understands `requires`. Until then the three reds are advisory version-skew, not a defect in the kits. (Follow-up: point the e2e job at the latest nightly `sbx` instead of the latest release, so new spec fields are exercised as soon as they land.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
