### PR TITLE
ci(tck): download the nightly sbx build for e2e instead of the latest release

### DIFF
--- a/.github/workflows/tck.yml
+++ b/.github/workflows/tck.yml
@@ -159,14 +159,14 @@ jobs:
       - name: Download sbx release
         run: |
           set -euo pipefail
-          VERSION=$(curl -fsSL \
-            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-            https://api.github.com/repos/docker/sbx-releases/releases/latest \
-            | jq -r .tag_name)
-          echo "Resolved latest sbx version: ${VERSION}"
+          # Use the rolling "nightly" build so kits adopting new spec fields are
+          # exercised against the latest sbx instead of the last tagged release.
+          VERSION=nightly
+          echo "Using sbx version: ${VERSION}"
           echo "SBX_VERSION=${VERSION}" >> "$GITHUB_ENV"
 
           curl -fsSL \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
             "https://github.com/docker/sbx-releases/releases/download/${VERSION}/DockerSandboxes-linux.tar.gz" \
             -o /tmp/DockerSandboxes-linux.tar.gz
           tar xzf /tmp/DockerSandboxes-linux.tar.gz -C /tmp


### PR DESCRIPTION
## Summary

Switch the `test-kit-e2e` job to download the rolling **`nightly`** `sbx` build instead of resolving the latest tagged release.

## Why

The released `sbx` binary lags the spec. When a kit adopts a spec field that has landed in the engine but hasn't shipped in a tagged release yet, e2e false-fails: the released engine rejects the (unknown-to-it) field under strict decode. The `nightly` build tracks the latest engine, so newly added spec fields are exercised as soon as they land rather than waiting for the next release.

This is exactly what's happening today with `requires.agent`: the three migrated mixins (`code-server`, `claude-model-runner`, `codex-app-server`) declare `requires.agent`, which the current released `sbx` doesn't understand, so their `test-kit-e2e` jobs fail on an unknown field. Once an `sbx` build that supports `requires` reaches `nightly`, those jobs go green — this PR is what lets e2e pick that up without waiting for a tagged release.

## Caveat

`nightly` is less stable than a tagged release — an unrelated engine regression could red the e2e jobs. That's acceptable because `test-kit-e2e` is advisory (non-gating).

## Changes

- `.github/workflows/tck.yml`: the "Download sbx release" step now uses the `nightly` tag directly instead of the `releases/latest` API lookup. The `GITHUB_TOKEN` auth header moves onto the download `curl`, and `SBX_VERSION=nightly` is still echoed so run logs record which build was used. Surrounding steps are unchanged.
