### PR TITLE
feat(spec): decode requires + extends image inheritance in the v2 grammar

### DIFF
--- a/playwright/spec.yaml
+++ b/playwright/spec.yaml
@@ -18,7 +18,7 @@ environment:
     # unaffected — the local copy always wins.
     NODE_PATH: /usr/local/share/npm-global/lib/node_modules
 
-caps:
+permissions:
   network:
     allow:
       # npm packages (install time): playwright + @playwright/test tarballs.
@@ -46,9 +46,9 @@ caps:
       - "ports.ubuntu.com:80"
       - "download.docker.com:443"
 
-commands:
+setup:
   install:
-    # To bump Playwright: change PLAYWRIGHT_VERSION here and in agentContext /
+    # To bump Playwright: change PLAYWRIGHT_VERSION here and in agentInstructions /
     # README. npm itself verifies the package tarballs against the sha512
     # integrity values in the registry metadata, so pinning the exact version
     # pins the content.
@@ -77,31 +77,32 @@ commands:
       user: "0"
       description: "Install Chromium (+ headless shell) into /opt/ms-playwright and its system libraries via apt"
 
-agentContext: |
-  ## Playwright
+agentInstructions:
+  content: |
+    ## Playwright
 
-  playwright and @playwright/test v1.61.1 are installed globally (the
-  `playwright` CLI is on PATH). Chromium and its headless shell live in
-  /opt/ms-playwright; PLAYWRIGHT_BROWSERS_PATH points there system-wide —
-  don't unset or override it, or Playwright will look in ~/.cache and try to
-  re-download.
+    playwright and @playwright/test v1.61.1 are installed globally (the
+    `playwright` CLI is on PATH). Chromium and its headless shell live in
+    /opt/ms-playwright; PLAYWRIGHT_BROWSERS_PATH points there system-wide —
+    don't unset or override it, or Playwright will look in ~/.cache and try to
+    re-download.
 
-  - Run test suites with `npx playwright test`; drive a browser from a script
-    with `const { chromium } = require('playwright')`. Zero-config works: a
-    bare `smoke.spec.js` with no package.json resolves `@playwright/test`
-    from the global install via NODE_PATH. Projects with their own
-    node_modules use their local copy as usual.
-  - Headless only: the sandbox has no display server, so `--headed`, `--ui`,
-    and `codegen` will not work. Screenshots, PDFs, traces, and videos all
-    work headless.
-  - If a project pins a different Playwright version, its first run may need
-    the matching browser build: `npx playwright install chromium` fetches it
-    at runtime (the browser CDN domains are allowed, and /opt/ms-playwright
-    is writable).
-  - Only Chromium is installed. `npx playwright install firefox webkit` can
-    download the other engines, but their extra system libraries are not
-    installed — prefer Chromium, or extend the kit if you need cross-engine
-    runs.
-  - Sites under test must be reachable through the sandbox network policy:
-    localhost servers always work; external sites will fail with a proxy
-    error unless their domains are in the sandbox's allowed domains.
+    - Run test suites with `npx playwright test`; drive a browser from a script
+      with `const { chromium } = require('playwright')`. Zero-config works: a
+      bare `smoke.spec.js` with no package.json resolves `@playwright/test`
+      from the global install via NODE_PATH. Projects with their own
+      node_modules use their local copy as usual.
+    - Headless only: the sandbox has no display server, so `--headed`, `--ui`,
+      and `codegen` will not work. Screenshots, PDFs, traces, and videos all
+      work headless.
+    - If a project pins a different Playwright version, its first run may need
+      the matching browser build: `npx playwright install chromium` fetches it
+      at runtime (the browser CDN domains are allowed, and /opt/ms-playwright
+      is writable).
+    - Only Chromium is installed. `npx playwright install firefox webkit` can
+      download the other engines, but their extra system libraries are not
+      installed — prefer Chromium, or extend the kit if you need cross-engine
+      runs.
+    - Sites under test must be reachable through the sandbox network policy:
+      localhost servers always work; external sites will fail with a proxy
+      error unless their domains are in the sandbox's allowed domains.

--- a/playwright/spec.yaml
+++ b/playwright/spec.yaml
@@ -1,4 +1,4 @@
-schemaVersion: "2"
+schemaVersion: "1"
 kind: mixin
 name: playwright
 displayName: Playwright
@@ -18,7 +18,7 @@ environment:
     # unaffected — the local copy always wins.
     NODE_PATH: /usr/local/share/npm-global/lib/node_modules
 
-permissions:
+caps:
   network:
     allow:
       # npm packages (install time): playwright + @playwright/test tarballs.
@@ -46,9 +46,9 @@ permissions:
       - "ports.ubuntu.com:80"
       - "download.docker.com:443"
 
-setup:
+commands:
   install:
-    # To bump Playwright: change PLAYWRIGHT_VERSION here and in agentInstructions /
+    # To bump Playwright: change PLAYWRIGHT_VERSION here and in agentContext /
     # README. npm itself verifies the package tarballs against the sha512
     # integrity values in the registry metadata, so pinning the exact version
     # pins the content.
@@ -77,32 +77,31 @@ setup:
       user: "0"
       description: "Install Chromium (+ headless shell) into /opt/ms-playwright and its system libraries via apt"
 
-agentInstructions:
-  content: |
-    ## Playwright
+agentContext: |
+  ## Playwright
 
-    playwright and @playwright/test v1.61.1 are installed globally (the
-    `playwright` CLI is on PATH). Chromium and its headless shell live in
-    /opt/ms-playwright; PLAYWRIGHT_BROWSERS_PATH points there system-wide —
-    don't unset or override it, or Playwright will look in ~/.cache and try to
-    re-download.
+  playwright and @playwright/test v1.61.1 are installed globally (the
+  `playwright` CLI is on PATH). Chromium and its headless shell live in
+  /opt/ms-playwright; PLAYWRIGHT_BROWSERS_PATH points there system-wide —
+  don't unset or override it, or Playwright will look in ~/.cache and try to
+  re-download.
 
-    - Run test suites with `npx playwright test`; drive a browser from a script
-      with `const { chromium } = require('playwright')`. Zero-config works: a
-      bare `smoke.spec.js` with no package.json resolves `@playwright/test`
-      from the global install via NODE_PATH. Projects with their own
-      node_modules use their local copy as usual.
-    - Headless only: the sandbox has no display server, so `--headed`, `--ui`,
-      and `codegen` will not work. Screenshots, PDFs, traces, and videos all
-      work headless.
-    - If a project pins a different Playwright version, its first run may need
-      the matching browser build: `npx playwright install chromium` fetches it
-      at runtime (the browser CDN domains are allowed, and /opt/ms-playwright
-      is writable).
-    - Only Chromium is installed. `npx playwright install firefox webkit` can
-      download the other engines, but their extra system libraries are not
-      installed — prefer Chromium, or extend the kit if you need cross-engine
-      runs.
-    - Sites under test must be reachable through the sandbox network policy:
-      localhost servers always work; external sites will fail with a proxy
-      error unless their domains are in the sandbox's allowed domains.
+  - Run test suites with `npx playwright test`; drive a browser from a script
+    with `const { chromium } = require('playwright')`. Zero-config works: a
+    bare `smoke.spec.js` with no package.json resolves `@playwright/test`
+    from the global install via NODE_PATH. Projects with their own
+    node_modules use their local copy as usual.
+  - Headless only: the sandbox has no display server, so `--headed`, `--ui`,
+    and `codegen` will not work. Screenshots, PDFs, traces, and videos all
+    work headless.
+  - If a project pins a different Playwright version, its first run may need
+    the matching browser build: `npx playwright install chromium` fetches it
+    at runtime (the browser CDN domains are allowed, and /opt/ms-playwright
+    is writable).
+  - Only Chromium is installed. `npx playwright install firefox webkit` can
+    download the other engines, but their extra system libraries are not
+    installed — prefer Chromium, or extend the kit if you need cross-engine
+    runs.
+  - Sites under test must be reachable through the sandbox network policy:
+    localhost servers always work; external sites will fail with a proxy
+    error unless their domains are in the sandbox's allowed domains.

--- a/spec/v2.go
+++ b/spec/v2.go
@@ -25,10 +25,11 @@ type specFileV2 struct {
 	SourceURL     string    `yaml:"sourceURL,omitempty"`
 	Security      *Security `yaml:"security,omitempty"`
 
-	Extends  string   `yaml:"extends,omitempty"`
-	Mixins   []string `yaml:"mixins,omitempty"`
-	Locked   []string `yaml:"locked,omitempty"`
-	Licenses []string `yaml:"licenses,omitempty"`
+	Extends  string    `yaml:"extends,omitempty"`
+	Mixins   []string  `yaml:"mixins,omitempty"`
+	Requires *Requires `yaml:"requires,omitempty"`
+	Locked   []string  `yaml:"locked,omitempty"`
+	Licenses []string  `yaml:"licenses,omitempty"`
 
 	Sandbox           *sandboxBlockV2           `yaml:"sandbox,omitempty"`
 	AgentInstructions *agentInstructionsBlockV2 `yaml:"agentInstructions,omitempty"`
@@ -173,7 +174,9 @@ func (s *specFileV2) toArtifact(w *warnings) (*Artifact, error) {
 	if s.Sandbox != nil && !isSandbox {
 		return nil, fmt.Errorf("'sandbox:' block is only valid for kind %q, not %q", KindSandbox, s.Kind)
 	}
-	if s.Sandbox == nil && isSandbox {
+	// A sandbox that extends a parent inherits the parent's image, so it may
+	// omit its own sandbox block; only a root sandbox must supply one.
+	if s.Sandbox == nil && isSandbox && s.Extends == "" {
 		return nil, fmt.Errorf("kind %q requires a 'sandbox:' block with at least 'sandbox.image'", KindSandbox)
 	}
 
@@ -236,6 +239,7 @@ func (s *specFileV2) toArtifact(w *warnings) (*Artifact, error) {
 		Manifest:       m,
 		Extends:        s.Extends,
 		Mixins:         s.Mixins,
+		Requires:       s.Requires,
 		Locked:         s.Locked,
 		Licenses:       s.Licenses,
 		PublishedPorts: s.PublishedPorts,


### PR DESCRIPTION
Compensatory PR for the v2 grammar rewrite (#136): reconciles the forked v2 decoder with the fields the rewrite left behind, so the branch's source-built suites (`test-tck`, `test-kit`) go green, and keeps the one v2 kit green in e2e until the engine can run the new grammar.

## 1. Decode `requires` + extends image inheritance (`spec/v2.go`)

The forked v2 decoder (`specFileV2`) never learned two fields that the v1 path and the canonical `Artifact` already support, so any `schemaVersion: "2"` spec using them fails to decode:

- **`requires`** (base-agent affinity) — `field requires not found in type specFileV2`
- a **`kind: sandbox` that `extends`** a parent — rejected for having no `sandbox:` block, even though the image is inherited

Validation was already present (merged from `main`): `ValidateArtifact` runs `ValidateRequires`, gates `requires` to mixins, and does the extends-aware image check — decode was the only gap.

Greens **`test-tck`**: `TestRequires_DecodeAndValidate`, `TestRequires_InvalidAgentName_Rejected`, `TestExtends_SandboxWithoutImage_Loads`, `TestNewSuiteFromDir/with_image_rescues_unresolved_image`.

## 2. Keep the playwright kit on `schemaVersion: "1"`

`playwright` was the only `schemaVersion: "2"` kit, but it uses **no v2-only fields** (no `requires`, no `extends`) — it just carries `caps`/`commands`/`agentContext`, all of which exist in v1. Under the new strict v2 grammar those names are rejected (`field caps/commands/agentContext not found`), and migrating them to the v2 spellings would make the kit undecodable by any *shipped* `sbx` (the v2 grammar only reaches a released binary after this branch merges → tag → engine dep-bump → release), leaving `test-kit-e2e (playwright)` permanently red.

Dropping it to `schemaVersion: "1"` (original field names) makes it decode on **both** the branch's v1 decoder (`test-kit`) **and** the released `sbx` (`test-kit-e2e`) — both green. Kit-to-v2 migration belongs in a dedicated pass once the engine supports the grammar, not in the grammar-rewrite PR.

## Remaining CI reds: released-`sbx` version-skew (expected, non-gating)

The 3 still-red jobs are all `test-kit-e2e` for the affinity mixins, which run against a **shipped** `sbx` (`releases/latest` = **v0.35.0**) that predates the `requires` field:

| Job | Error under v0.35.0 | Clears when |
|---|---|---|
| code-server, claude-model-runner, codex-app-server | `field requires not found in type spec.SpecFile` | An `sbx` with `requires` ships. Engine support (docker/sandboxes#4349) merged, so it lands in the **next** nightly (the current nightly predates that merge); the nightly-e2e switch is tracked by #148. |

`requires` is a *new* field, absent from every shipped `sbx` (and from the v1 decoder too — hence `type spec.SpecFile`), so no `schemaVersion` change or grammar tweak here can green these; they self-clear once the engine ships. Reverting them to their old `extends` form doesn't help — that hits the original credential-dup error on v0.35.0 that #4341 set out to fix. There is no branch protection on the base, so these do not gate this PR.
