### PR TITLE
Add Codex and Claude ACP kits

### DIFF
--- a/claude-acp/README.md
+++ b/claude-acp/README.md
@@ -1,0 +1,58 @@
+# claude-acp
+
+Run the Claude ACP adapter inside a Docker Sandbox.
+
+This is a v2 mixin for the built-in `claude` sandbox agent. It adds
+`/home/agent/.local/bin/claude-acp`, a small launcher that runs
+`@agentclientprotocol/claude-agent-acp` with `CLAUDE_CODE_EXECUTABLE=claude`.
+
+## Authentication
+
+`claude-acp` inherits Anthropic authentication from the built-in `claude`
+sandbox agent.
+
+For non-interactive API-key auth, seed the Anthropic credential with `sbx`
+before creating the sandbox:
+
+```console
+$ echo "$ANTHROPIC_API_KEY" | sbx secret set -g anthropic
+```
+
+You can also import a detected host environment variable:
+
+```console
+$ sbx secret import anthropic
+```
+
+For Claude subscription or console login, the Claude ACP adapter advertises
+terminal auth methods to ACP clients that support `_meta["terminal-auth"]`.
+Those clients should run the advertised auth command in the same sandbox
+context, separate from the adapter's JSON-RPC stdio stream. Normal ACP adapter
+sessions still run without a TTY; only the advertised auth handoff is
+terminal-oriented.
+
+If an Anthropic API key is configured through `sbx`, terminal auth is not
+needed. If you add an API key after a sandbox has already been created, recreate
+the sandbox so the built-in `claude` kit can refresh its Claude settings.
+
+## Usage
+
+Create a sandbox:
+
+```console
+$ sbx create --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=claude-acp" --name my-task claude /path/to/task
+```
+
+Run the adapter over stdio:
+
+```console
+$ sbx exec -i my-task /home/agent/.local/bin/claude-acp
+```
+
+Do not allocate a TTY for ACP sessions; the adapter expects newline-delimited
+JSON-RPC on stdin/stdout.
+
+## References
+
+- [Kit spec](spec.yaml)
+- [Credential bindings](../skills/kit-author/topics/bindings.md)

--- a/claude-acp/spec.yaml
+++ b/claude-acp/spec.yaml
@@ -1,0 +1,36 @@
+schemaVersion: "2"
+kind: mixin
+name: claude-acp
+displayName: Claude ACP
+description: Runs the Claude ACP adapter inside a Claude sandbox over stdio.
+
+caps:
+  network:
+    allow:
+      - api.github.com
+      - gist.github.com
+      - github.com
+      - registry.npmjs.org
+      - raw.githubusercontent.com
+
+commands:
+  initFiles:
+    - path: /home/agent/.local/bin/claude-acp
+      mode: "0755"
+      description: Launch the Claude ACP adapter with the sandboxed Claude binary.
+      content: |
+        #!/bin/bash
+        set -e
+        if [ -z "$CLAUDE_CODE_EXECUTABLE" ]; then
+          export CLAUDE_CODE_EXECUTABLE=claude
+        fi
+        exec npx -y @agentclientprotocol/claude-agent-acp@0.51.0 "$@"
+
+agentContext: |
+  The Claude ACP adapter is available at `/home/agent/.local/bin/claude-acp`.
+  Host tools should run it with a non-TTY stdin/stdout stream, for example
+  `sbx exec -i <sandbox> /home/agent/.local/bin/claude-acp`.
+  The launcher sets `CLAUDE_CODE_EXECUTABLE=claude` when that variable is not
+  already set, so the adapter uses the sandboxed Claude Code binary.
+  If the host has a global sbx GitHub secret, `GH_TOKEN` is available in the
+  sandbox as a proxy-managed sentinel for `gh` and git HTTPS operations.

--- a/claude-acp/spec.yaml
+++ b/claude-acp/spec.yaml
@@ -4,7 +4,7 @@ name: claude-acp
 displayName: Claude ACP
 description: Runs the Claude ACP adapter inside a Claude sandbox over stdio.
 
-caps:
+permissions:
   network:
     allow:
       - api.github.com
@@ -13,8 +13,8 @@ caps:
       - registry.npmjs.org
       - raw.githubusercontent.com
 
-commands:
-  initFiles:
+setup:
+  files:
     - path: /home/agent/.local/bin/claude-acp
       mode: "0755"
       description: Launch the Claude ACP adapter with the sandboxed Claude binary.
@@ -26,11 +26,12 @@ commands:
         fi
         exec npx -y @agentclientprotocol/claude-agent-acp@0.51.0 "$@"
 
-agentContext: |
-  The Claude ACP adapter is available at `/home/agent/.local/bin/claude-acp`.
-  Host tools should run it with a non-TTY stdin/stdout stream, for example
-  `sbx exec -i <sandbox> /home/agent/.local/bin/claude-acp`.
-  The launcher sets `CLAUDE_CODE_EXECUTABLE=claude` when that variable is not
-  already set, so the adapter uses the sandboxed Claude Code binary.
-  If the host has a global sbx GitHub secret, `GH_TOKEN` is available in the
-  sandbox as a proxy-managed sentinel for `gh` and git HTTPS operations.
+agentInstructions:
+  content: |
+    The Claude ACP adapter is available at `/home/agent/.local/bin/claude-acp`.
+    Host tools should run it with a non-TTY stdin/stdout stream, for example
+    `sbx exec -i <sandbox> /home/agent/.local/bin/claude-acp`.
+    The launcher sets `CLAUDE_CODE_EXECUTABLE=claude` when that variable is not
+    already set, so the adapter uses the sandboxed Claude Code binary.
+    If the host has a global sbx GitHub secret, `GH_TOKEN` is available in the
+    sandbox as a proxy-managed sentinel for `gh` and git HTTPS operations.

--- a/codex-acp/README.md
+++ b/codex-acp/README.md
@@ -1,0 +1,59 @@
+# codex-acp
+
+Run the Codex ACP adapter inside a Docker Sandbox.
+
+This is a v2 mixin for the built-in `codex` sandbox agent. It adds
+`/home/agent/.local/bin/codex-acp`, a small launcher that runs
+`@agentclientprotocol/codex-acp` with `CODEX_PATH=codex`.
+
+## Authentication
+
+`codex-acp` inherits OpenAI authentication from the built-in `codex` sandbox
+agent. Seed OpenAI auth with `sbx` before creating the sandbox so the
+non-interactive ACP adapter can start authenticated.
+
+For ChatGPT OAuth:
+
+```console
+$ sbx secret set -g openai --oauth
+```
+
+For an OpenAI API key:
+
+```console
+$ echo "$OPENAI_API_KEY" | sbx secret set -g openai
+```
+
+You can also import a detected host environment variable:
+
+```console
+$ sbx secret import openai
+```
+
+The Codex ACP adapter does not advertise a terminal-auth command. Keep provider
+credentials in the `sbx` credential store rather than passing API keys through
+`sbx exec` argv or ad-hoc environment variables. If you add OpenAI auth after a
+sandbox has already been created, recreate the sandbox so the built-in `codex`
+kit can refresh its Codex auth files.
+
+## Usage
+
+Create a sandbox:
+
+```console
+$ sbx create --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=codex-acp" --name my-task codex /path/to/task
+```
+
+Run the adapter over stdio:
+
+```console
+$ sbx exec -i my-task /home/agent/.local/bin/codex-acp
+```
+
+Do not allocate a TTY for ACP sessions; the adapter expects newline-delimited
+JSON-RPC on stdin/stdout.
+
+## References
+
+- [Kit spec](spec.yaml)
+- [Credential bindings](../skills/kit-author/topics/bindings.md)

--- a/codex-acp/spec.yaml
+++ b/codex-acp/spec.yaml
@@ -4,7 +4,7 @@ name: codex-acp
 displayName: Codex ACP
 description: Runs the Codex ACP adapter inside a Codex sandbox over stdio.
 
-caps:
+permissions:
   network:
     allow:
       - api.github.com
@@ -13,8 +13,8 @@ caps:
       - registry.npmjs.org
       - raw.githubusercontent.com
 
-commands:
-  initFiles:
+setup:
+  files:
     - path: /home/agent/.local/bin/codex-acp
       mode: "0755"
       description: Launch the Codex ACP adapter with the sandboxed Codex binary.
@@ -26,9 +26,10 @@ commands:
         fi
         exec npx -y @agentclientprotocol/codex-acp@1.1.0 "$@"
 
-agentContext: |
-  The Codex ACP adapter is available at `/home/agent/.local/bin/codex-acp`.
-  Host tools should run it with a non-TTY stdin/stdout stream, for example
-  `sbx exec -i <sandbox> /home/agent/.local/bin/codex-acp`.
-  If the host has a global sbx GitHub secret, `GH_TOKEN` is available in the
-  sandbox as a proxy-managed sentinel for `gh` and git HTTPS operations.
+agentInstructions:
+  content: |
+    The Codex ACP adapter is available at `/home/agent/.local/bin/codex-acp`.
+    Host tools should run it with a non-TTY stdin/stdout stream, for example
+    `sbx exec -i <sandbox> /home/agent/.local/bin/codex-acp`.
+    If the host has a global sbx GitHub secret, `GH_TOKEN` is available in the
+    sandbox as a proxy-managed sentinel for `gh` and git HTTPS operations.

--- a/codex-acp/spec.yaml
+++ b/codex-acp/spec.yaml
@@ -1,0 +1,34 @@
+schemaVersion: "2"
+kind: mixin
+name: codex-acp
+displayName: Codex ACP
+description: Runs the Codex ACP adapter inside a Codex sandbox over stdio.
+
+caps:
+  network:
+    allow:
+      - api.github.com
+      - gist.github.com
+      - github.com
+      - registry.npmjs.org
+      - raw.githubusercontent.com
+
+commands:
+  initFiles:
+    - path: /home/agent/.local/bin/codex-acp
+      mode: "0755"
+      description: Launch the Codex ACP adapter with the sandboxed Codex binary.
+      content: |
+        #!/bin/bash
+        set -e
+        if [ -z "$CODEX_PATH" ]; then
+          export CODEX_PATH=codex
+        fi
+        exec npx -y @agentclientprotocol/codex-acp@1.1.0 "$@"
+
+agentContext: |
+  The Codex ACP adapter is available at `/home/agent/.local/bin/codex-acp`.
+  Host tools should run it with a non-TTY stdin/stdout stream, for example
+  `sbx exec -i <sandbox> /home/agent/.local/bin/codex-acp`.
+  If the host has a global sbx GitHub secret, `GH_TOKEN` is available in the
+  sandbox as a proxy-managed sentinel for `gh` and git HTTPS operations.


### PR DESCRIPTION
Summary:
- add v2 `codex-acp` and `claude-acp` mixins for the built-in Codex and Claude sandboxes
- install non-TTY stdio launchers under `/home/agent/.local/bin/` for ACP adapters
- document provider authentication: Codex via `sbx` OpenAI OAuth/API-key secrets; Claude via `sbx` Anthropic API-key secrets or ACP terminal-auth advertisement
- document `sbx create` and `sbx exec -i` usage for ACP clients

Validation:
- `git diff --check origin/main..HEAD`
- checked README relative links