### PR TITLE
Add grok kit

### DIFF
--- a/grok/README.md
+++ b/grok/README.md
@@ -7,15 +7,17 @@ and runs `grok --yolo --no-auto-update` as the entrypoint when you attach.
 
 ## Prerequisites
 
-- An [xAI](https://console.x.ai) account and API key.
-- Store the API key in the sandbox credential store:
+- An [xAI](https://console.x.ai) account.
+- Optional: store an API key in the sandbox credential store to skip login:
 
   ```console
   $ sbx secret set xai
   ```
 
   The command prompts for the key securely. The sandbox proxy manages it, so
-  the key itself never enters the sandbox.
+  the key itself never enters the sandbox. Without an API key, select
+  **Login with Grok** when the agent starts. For a headless login, run
+  `grok login --device-code` inside the sandbox.
 
 ## Usage
 
@@ -43,12 +45,13 @@ represented in `XAI_API_KEY` by a proxy-managed sentinel rather than baked
 into the container. `permissions.network.allow` grants the corresponding
 outbound access.
 
-`grok`'s browser-based OAuth login (`grok login`, the interactive default)
-isn't wired up by this kit — there's no browser inside the sandbox to
-complete it. Setting the `xai` secret sidesteps that entirely: per Grok's own
+Grok's OAuth flow uses `auth.x.ai` for login and
+`cli-chat-proxy.grok.com` for authenticated inference and settings. Both are
+allowed by the kit. In a headless environment, run
+`grok login --device-code`; otherwise select **Login with Grok** in the TUI.
+Per Grok's own
 [auth precedence](https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-pager/docs/user-guide/02-authentication.md#auth-precedence),
-the API key is used whenever no session token is already active, which is
-always true for a fresh sandbox.
+a stored session takes precedence over the optional API key.
 
 ## How the install works
 

--- a/grok/README.md
+++ b/grok/README.md
@@ -1,0 +1,62 @@
+# grok
+
+A standalone agent kit (`kind: agent`) for [Grok Build](https://github.com/xai-org/grok-build)
+(`grok`), xAI's terminal-based coding agent. The kit installs Grok Build into
+the sandbox at creation time, wires its API auth through the sandbox proxy,
+and runs `grok --yolo --no-auto-update` as the entrypoint when you attach.
+
+## Prerequisites
+
+- An [xAI](https://console.x.ai) account and API key.
+- `$XAI_API_KEY` exported on your host. The sandbox proxy manages it — the
+  key itself never enters the sandbox.
+
+## Usage
+
+Run the kit. Pass the kit's name (`grok`) as the agent argument:
+
+```console
+$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=grok" grok
+```
+
+Or with a local clone of this repo:
+
+```console
+$ sbx run --kit ./grok/ grok
+```
+
+The first launch installs Grok Build via its official install script.
+Subsequent launches reuse the sandbox.
+
+## How auth works
+
+`network.serviceDomains` maps `api.x.ai` (the xAI chat-completions API) to
+the `xai` service, and `network.serviceAuth.xai` tells the proxy to inject
+`Authorization: Bearer <key>` on outbound requests to that host. The key
+comes from `XAI_API_KEY`, sourced via `credentials.sources.xai.env` and
+marked `environment.proxyManaged` so it's substituted by the proxy rather
+than baked into the container.
+
+`grok`'s browser-based OAuth login (`grok login`, the interactive default)
+isn't wired up by this kit — there's no browser inside the sandbox to
+complete it. Setting `XAI_API_KEY` sidesteps that entirely: per Grok's own
+[auth precedence](https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-pager/docs/user-guide/02-authentication.md#auth-precedence),
+the API key is used whenever no session token is already active, which is
+always true for a fresh sandbox.
+
+## How the install works
+
+Grok Build's installer (`x.ai/cli/install.sh`) only symlinks `grok` onto an
+existing, writable `PATH` directory — either `~/.local/bin` or
+`/usr/local/bin` — it never creates one. `~/.local/bin` is on `PATH` already
+via the `shell-docker` base image, but the image never creates the
+directory itself, so on a fresh container the installer would silently fall
+back to appending `~/.bashrc`, which a non-interactive kit entrypoint never
+sources. `commands.install` works around this by `mkdir -p ~/.local/bin`
+before running the installer, so `grok` is on `PATH` immediately.
+
+## Customization
+
+Grok Build reads project rules from `AGENTS.md` (also `CLAUDE.md` and a few
+other filenames, for compatibility with other agents' conventions — see
+[Project Rules](https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-pager/docs/user-guide/12-project-rules.md)).

--- a/grok/README.md
+++ b/grok/README.md
@@ -8,8 +8,14 @@ and runs `grok --yolo --no-auto-update` as the entrypoint when you attach.
 ## Prerequisites
 
 - An [xAI](https://console.x.ai) account and API key.
-- `$XAI_API_KEY` exported on your host. The sandbox proxy manages it — the
-  key itself never enters the sandbox.
+- Store the API key in the sandbox credential store:
+
+  ```console
+  $ sbx secret set xai
+  ```
+
+  The command prompts for the key securely. The sandbox proxy manages it, so
+  the key itself never enters the sandbox.
 
 ## Usage
 
@@ -32,13 +38,14 @@ Subsequent launches reuse the sandbox.
 
 `credentials[].apiKey.inject` tells the proxy to inject
 `Authorization: Bearer <key>` on outbound requests to `api.x.ai` (the xAI
-chat-completions API). The key comes from `XAI_API_KEY` on the host and is
-represented by a proxy-managed sentinel rather than baked into the container.
-`permissions.network.allow` grants the corresponding outbound access.
+chat-completions API). The key comes from the host credential store and is
+represented in `XAI_API_KEY` by a proxy-managed sentinel rather than baked
+into the container. `permissions.network.allow` grants the corresponding
+outbound access.
 
 `grok`'s browser-based OAuth login (`grok login`, the interactive default)
 isn't wired up by this kit — there's no browser inside the sandbox to
-complete it. Setting `XAI_API_KEY` sidesteps that entirely: per Grok's own
+complete it. Setting the `xai` secret sidesteps that entirely: per Grok's own
 [auth precedence](https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-pager/docs/user-guide/02-authentication.md#auth-precedence),
 the API key is used whenever no session token is already active, which is
 always true for a fresh sandbox.

--- a/grok/README.md
+++ b/grok/README.md
@@ -1,6 +1,6 @@
 # grok
 
-A standalone agent kit (`kind: agent`) for [Grok Build](https://github.com/xai-org/grok-build)
+A standalone agent kit (`kind: sandbox`) for [Grok Build](https://github.com/xai-org/grok-build)
 (`grok`), xAI's terminal-based coding agent. The kit installs Grok Build into
 the sandbox at creation time, wires its API auth through the sandbox proxy,
 and runs `grok --yolo --no-auto-update` as the entrypoint when you attach.
@@ -30,12 +30,11 @@ Subsequent launches reuse the sandbox.
 
 ## How auth works
 
-`network.serviceDomains` maps `api.x.ai` (the xAI chat-completions API) to
-the `xai` service, and `network.serviceAuth.xai` tells the proxy to inject
-`Authorization: Bearer <key>` on outbound requests to that host. The key
-comes from `XAI_API_KEY`, sourced via `credentials.sources.xai.env` and
-marked `environment.proxyManaged` so it's substituted by the proxy rather
-than baked into the container.
+`credentials[].apiKey.inject` tells the proxy to inject
+`Authorization: Bearer <key>` on outbound requests to `api.x.ai` (the xAI
+chat-completions API). The key comes from `XAI_API_KEY` on the host and is
+represented by a proxy-managed sentinel rather than baked into the container.
+`permissions.network.allow` grants the corresponding outbound access.
 
 `grok`'s browser-based OAuth login (`grok login`, the interactive default)
 isn't wired up by this kit — there's no browser inside the sandbox to
@@ -52,7 +51,7 @@ existing, writable `PATH` directory — either `~/.local/bin` or
 via the `shell-docker` base image, but the image never creates the
 directory itself, so on a fresh container the installer would silently fall
 back to appending `~/.bashrc`, which a non-interactive kit entrypoint never
-sources. `commands.install` works around this by `mkdir -p ~/.local/bin`
+sources. `setup.install` works around this by `mkdir -p ~/.local/bin`
 before running the installer, so `grok` is on `PATH` immediately.
 
 ## Customization

--- a/grok/spec.yaml
+++ b/grok/spec.yaml
@@ -23,6 +23,10 @@ permissions:
       # here, confirmed against a real deny-all sandbox (403 Forbidden
       # without this line).
       - "api.x.ai:443"
+      # Grok login discovers its OAuth configuration from auth.x.ai, then
+      # uses the Grok chat proxy for authenticated inference and settings.
+      - "auth.x.ai:443"
+      - "cli-chat-proxy.grok.com:443"
 
 credentials:
   - service: xai

--- a/grok/spec.yaml
+++ b/grok/spec.yaml
@@ -1,0 +1,69 @@
+schemaVersion: "2"
+kind: sandbox
+name: grok
+displayName: Grok Build
+description: xAI's terminal-based coding agent, powered by Grok models.
+
+sandbox:
+  image: "docker/sandbox-templates:shell-docker"
+  aiFilename: AGENTS.md
+  entrypoint:
+    run: [grok, "--yolo", "--no-auto-update"]
+
+caps:
+  network:
+    allow:
+      # Installer + binary download (BASE_URL_PRIMARY in
+      # https://x.ai/cli/install.sh). The script falls back to
+      # storage.googleapis.com if x.ai is unreachable; that fallback is
+      # intentionally not allowed here, so the primary path is the only one
+      # that works under deny-all.
+      - "x.ai:443"
+      # The xAI chat-completions API. Declaring it in credentials[].apiKey.inject
+      # (below) wires header injection but does NOT implicitly allow the
+      # domain through the network policy — it still needs an explicit entry
+      # here, confirmed against a real deny-all sandbox (403 Forbidden
+      # without this line).
+      - "api.x.ai:443"
+
+credentials:
+  - service: xai
+    apiKey:
+      name: XAI_API_KEY
+      proxyManaged: true
+      inject:
+        - domain: api.x.ai
+          header: Authorization
+          format: Bearer %s
+
+commands:
+  install:
+    # The installer only symlinks `grok` onto an existing, writable PATH
+    # directory (~/.local/bin or /usr/local/bin); it does not create either.
+    # ~/.local/bin is on PATH already (shell-docker template), but the base
+    # image never creates it, so on a fresh container the installer would
+    # silently fall through to rewriting .bashrc/.zshrc instead — which a
+    # non-interactive kit entrypoint never sources. Pre-creating the
+    # directory here makes the installer's own PATH-symlink step succeed.
+    - command: |
+        set -e
+        mkdir -p "$HOME/.local/bin"
+        curl -fsSL https://x.ai/cli/install.sh | bash
+      user: "1000"
+      description: Install Grok Build (grok)
+
+agentContext: |
+  ## Grok Build
+
+  Grok Build (`grok`) is xAI's terminal-based coding agent. It is installed
+  as `grok` on `PATH` and started with `--yolo`, which auto-approves tool
+  calls (file edits, shell commands, etc.) without prompting — the sandbox
+  itself is the safety boundary. `--no-auto-update` disables the CLI's
+  background update check, since the sandbox is recreated from the kit
+  rather than self-updated in place.
+
+  Set `XAI_API_KEY` on your host (get one from https://console.x.ai) and the
+  sandbox proxy injects it as `Authorization: Bearer <key>` on outbound
+  requests to `api.x.ai`. Project rules go in `AGENTS.md`. See
+  <https://github.com/xai-org/grok-build> and
+  <https://docs.x.ai/build/overview> for usage.

--- a/grok/spec.yaml
+++ b/grok/spec.yaml
@@ -6,11 +6,9 @@ description: xAI's terminal-based coding agent, powered by Grok models.
 
 sandbox:
   image: "docker/sandbox-templates:shell-docker"
-  aiFilename: AGENTS.md
-  entrypoint:
-    run: [grok, "--yolo", "--no-auto-update"]
+  entrypoint: [grok, "--yolo", "--no-auto-update"]
 
-caps:
+permissions:
   network:
     allow:
       # Installer + binary download (BASE_URL_PRIMARY in
@@ -30,13 +28,12 @@ credentials:
   - service: xai
     apiKey:
       name: XAI_API_KEY
-      proxyManaged: true
       inject:
         - domain: api.x.ai
           header: Authorization
           format: Bearer %s
 
-commands:
+setup:
   install:
     # The installer only symlinks `grok` onto an existing, writable PATH
     # directory (~/.local/bin or /usr/local/bin); it does not create either.
@@ -52,18 +49,20 @@ commands:
       user: "1000"
       description: Install Grok Build (grok)
 
-agentContext: |
-  ## Grok Build
+agentInstructions:
+  filename: AGENTS.md
+  content: |
+    ## Grok Build
 
-  Grok Build (`grok`) is xAI's terminal-based coding agent. It is installed
-  as `grok` on `PATH` and started with `--yolo`, which auto-approves tool
-  calls (file edits, shell commands, etc.) without prompting — the sandbox
-  itself is the safety boundary. `--no-auto-update` disables the CLI's
-  background update check, since the sandbox is recreated from the kit
-  rather than self-updated in place.
+    Grok Build (`grok`) is xAI's terminal-based coding agent. It is installed
+    as `grok` on `PATH` and started with `--yolo`, which auto-approves tool
+    calls (file edits, shell commands, etc.) without prompting — the sandbox
+    itself is the safety boundary. `--no-auto-update` disables the CLI's
+    background update check, since the sandbox is recreated from the kit
+    rather than self-updated in place.
 
-  Set `XAI_API_KEY` on your host (get one from https://console.x.ai) and the
-  sandbox proxy injects it as `Authorization: Bearer <key>` on outbound
-  requests to `api.x.ai`. Project rules go in `AGENTS.md`. See
-  <https://github.com/xai-org/grok-build> and
-  <https://docs.x.ai/build/overview> for usage.
+    Set `XAI_API_KEY` on your host (get one from https://console.x.ai) and the
+    sandbox proxy injects it as `Authorization: Bearer <key>` on outbound
+    requests to `api.x.ai`. Project rules go in `AGENTS.md`. See
+    <https://github.com/xai-org/grok-build> and
+    <https://docs.x.ai/build/overview> for usage.

--- a/grok/testdata/tck.yaml
+++ b/grok/testdata/tck.yaml
@@ -1,0 +1,1 @@
+promptArgs: ["-p"]


### PR DESCRIPTION
<!--
Thanks for contributing to sbx-kits-contrib!

PRs from forks have CI's `test-kit-e2e` job SKIPPED because GitHub does not
expose `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` to fork-triggered workflows.
The e2e assertions will not run on your PR — your laptop is the only place
they run before merge. See the checklist below.
-->

## Summary

Standalone agent kit (kind: sandbox, kit-spec v2) for xAI's Grok Build CLI (grok), following the same shape as the amp/junie/gemini kits: curl install script, XAI_API_KEY auth proxied to api.x.ai via the credentials block, and --yolo for unattended tool approval.

Spec choices worth flagging for review:
- caps.network.allow lists both x.ai (installer) and api.x.ai (chat API) explicitly. Declaring a domain in credentials[].apiKey.inject wires header injection but does NOT implicitly allow it through the network policy — confirmed against a real sandbox under the reviewer's default deny policy (403 Forbidden on api.x.ai until the explicit allow entry was added).
- commands.install does `mkdir -p ~/.local/bin` before running the installer. Grok's installer only symlinks the `grok` binary onto an existing, writable PATH directory (~/.local/bin or /usr/local/bin) and never creates one; ~/.local/bin is on PATH via the shell-docker template but the base image never creates the directory itself, so on a fresh container the installer would otherwise silently fall back to appending ~/.bashrc, which a non-interactive kit entrypoint never sources.
- No OAuth wiring: grok's browser-based login has no path from inside a headless sandbox, so the kit relies solely on XAI_API_KEY, which is also what xAI's own docs recommend for CI/automation.

### Try it

#### If you want to use your API key, import it first (otherwise you can sign in inside the sandbox)
```
$ you'll paste the key directly into sbx's own prompt
$ sbx secret set -g xai
```

#### Run it:
```
sbx run --kit ./grok/ grok
```

<img width="1728" height="433" alt="image" src="https://github.com/user-attachments/assets/91cb3345-530a-4081-9f66-367c69c8b425" />

## Spec choices worth flagging for review

N/A

## Origin

https://github.com/xai-org/grok-build

## Test plan

CI runs `kit validate` and the TCK on every PR. CI does **not** run e2e on
fork PRs (Docker Hub secrets aren't exposed there), so the e2e step below is
required from your side before requesting review.

- [ ] `sbx kit validate ./<kit>/` passes
- [ ] `./scripts/test-kit.sh <kit>` passes (the TCK)
- [ ] `./scripts/test-kit-e2e.sh <kit>` passes. The script applies the same
      `deny-all` baseline CI uses and scopes everything to its own daemon
      (`--app-name sbx-kits-contrib-tck`), so my main sbx state is untouched.
      Every entry I added to `network.allowedDomains` came from
      `sbx --app-name sbx-kits-contrib-tck policy log <tck-e2e-…>`, not a guess.
- [ ] Manual smoke: `sbx run --kit ./<kit>/ <agent>` and verified the kit's
      binary / files / env are inside the running container.

One-time setup if you haven't run e2e on this machine before:
`sbx --app-name sbx-kits-contrib-tck login`.

See [CONTRIBUTING.md → Verifying locally](../CONTRIBUTING.md#verifying-locally)
and [README → Declare every domain your kit needs](../README.md#declare-every-domain-your-kit-needs)
for the cross-arch domain gotchas (`archive.ubuntu.com`,
`security.ubuntu.com`, `ports.ubuntu.com`) and the package-manager refresh trap.
