### PR TITLE
Add neovim kit

### DIFF
--- a/neovim/README.md
+++ b/neovim/README.md
@@ -1,0 +1,37 @@
+# neovim
+
+A mixin that installs the latest stable [Neovim](https://neovim.io) release and injects a bundled `~/.config/nvim` into the sandbox.
+
+## Usage
+
+Pair with any agent:
+
+```console
+$ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=neovim" ~/my-project
+$ sbx run shell  --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=neovim" ~/my-project
+```
+
+## Bringing your own config
+
+The kit ships a minimal starter `init.lua`. To use your personal config, run the bundled `sync-config.sh` once from the kit directory:
+
+```bash
+git clone https://github.com/docker/sbx-kits-contrib.git
+cd sbx-kits-contrib/neovim
+./sync-config.sh
+sbx run claude --kit . ~/my-project
+```
+
+`sync-config.sh` copies `~/.config/nvim` into `files/home/.config/nvim/`. Everything under that directory is injected verbatim into `/home/agent/.config/nvim/` when the sandbox is created. Re-run the script whenever your local config changes, then recreate the sandbox to pick up the update.
+
+> **Note**: sandboxes only have access to the mounted workspace directory, not the host home directory. `sync-config.sh` bridges this by copying the config into the kit's `files/` tree on the host before sandbox creation.
+
+If your config uses a plugin manager (lazy.nvim, packer, etc.) that fetches plugins on first launch, add the plugin registry hosts to `permissions.network.allow` in `spec.yaml`.
+
+## How the install works
+
+The `setup.install` step downloads the latest stable Neovim tarball from GitHub releases — `nvim-linux-x86_64.tar.gz` on amd64, `nvim-linux-arm64.tar.gz` on arm64 — extracts it to `/opt`, and symlinks the binary to `/usr/local/bin/nvim`. No system packages are modified.
+
+## Cleanup
+
+The kit leaves no persistent state on the host. Removing the sandbox (`sbx rm <name>`) removes the Neovim install.

--- a/neovim/files/home/.config/nvim/init.lua
+++ b/neovim/files/home/.config/nvim/init.lua
@@ -1,0 +1,16 @@
+-- Neovim starter configuration — replace with your own init.lua.
+-- To bring your full config: cp -r ~/.config/nvim/* files/home/.config/nvim/
+
+vim.opt.number         = true
+vim.opt.relativenumber = true
+vim.opt.expandtab      = true
+vim.opt.tabstop        = 2
+vim.opt.shiftwidth     = 2
+vim.opt.smartindent    = true
+vim.opt.wrap           = false
+vim.opt.termguicolors  = true
+vim.opt.scrolloff      = 8
+vim.opt.signcolumn     = "yes"
+vim.opt.clipboard      = "unnamedplus"
+
+vim.g.mapleader = " "

--- a/neovim/spec.yaml
+++ b/neovim/spec.yaml
@@ -1,0 +1,38 @@
+schemaVersion: "1"
+kind: mixin
+name: neovim
+displayName: Neovim
+description: "Installs Neovim (latest stable) and injects the bundled ~/.config/nvim into the sandbox."
+
+network:
+  allowedDomains:
+    # GitHub release redirect for the stable tag
+    - github.com
+    # Asset CDN — GitHub has used both hosts across releases
+    - objects.githubusercontent.com
+    - release-assets.githubusercontent.com
+
+environment:
+  variables:
+    EDITOR: nvim
+    VISUAL: nvim
+
+commands:
+  install:
+    - command: |
+        set -euo pipefail
+        ARCH=$(dpkg --print-architecture)
+        case "$ARCH" in
+          amd64) TARBALL="nvim-linux-x86_64.tar.gz"; NVIM_DIR="nvim-linux-x86_64" ;;
+          arm64) TARBALL="nvim-linux-arm64.tar.gz";  NVIM_DIR="nvim-linux-arm64"  ;;
+          *)     echo "unsupported arch: $ARCH" >&2; exit 1 ;;
+        esac
+        curl --proto '=https' --tlsv1.2 -fsSL \
+          "https://github.com/neovim/neovim/releases/download/stable/${TARBALL}" \
+          -o /tmp/nvim.tar.gz
+        tar -C /opt -xzf /tmp/nvim.tar.gz
+        ln -sf "/opt/${NVIM_DIR}/bin/nvim" /usr/local/bin/nvim
+        rm /tmp/nvim.tar.gz
+        nvim --version | head -1
+      user: "0"
+      description: Install Neovim stable from GitHub releases (amd64 + arm64)

--- a/neovim/sync-config.sh
+++ b/neovim/sync-config.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Copies ~/.config/nvim from the host into the kit's files/ directory so it is
+# injected into the sandbox at creation time.  Run this once whenever your
+# local config changes and you want the kit to pick it up.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="$SCRIPT_DIR/files/home/.config/nvim"
+SOURCE="${XDG_CONFIG_HOME:-$HOME/.config}/nvim"
+
+if [ ! -d "$SOURCE" ]; then
+  echo "No nvim config found at $SOURCE — nothing to sync." >&2
+  exit 1
+fi
+
+echo "Syncing $SOURCE → $TARGET"
+mkdir -p "$TARGET"
+cp -r "$SOURCE/." "$TARGET/"
+echo "Done. Run 'sbx run <agent> --kit $SCRIPT_DIR <workspace>' to use your config."


### PR DESCRIPTION
## What
- Add a `neovim` mixin kit that installs latest-stable Neovim (amd64 + arm64) into a sandbox and injects a bundled `~/.config/nvim`.
- Include a ships-a-starter `init.lua` and a `sync-config.sh` helper for bringing your own config.

## Why
- Lets users get a ready-to-use Neovim editor in any agent or shell sandbox without manual setup, and easily carry over their personal config.
