### PR TITLE
Add specstory kit

### DIFF
--- a/specstory/README.md
+++ b/specstory/README.md
@@ -1,0 +1,103 @@
+# specstory
+
+A mixin that installs the [SpecStory CLI](https://docs.specstory.com) —
+a wrapper for terminal coding agents (Claude Code, Cursor CLI, Codex CLI,
+Gemini CLI) that saves conversations as local markdown files. The kit is
+agent-agnostic; pair it with whichever agent you're running.
+
+A background `specstory watch` daemon is started at sandbox launch, so
+conversations are auto-saved to `.specstory/history/` on the host
+workspace as they happen — no manual `specstory sync` step after the
+agent exits.
+
+## Usage
+
+```console
+$ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=specstory" ~/my-project
+$ sbx run codex  --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=specstory" ~/my-project
+```
+
+Or with a local clone of this repo:
+
+```console
+$ sbx run claude --kit ./specstory/ ~/my-project
+```
+
+Once attached, just use the agent normally. History files appear on the
+host as conversations happen:
+
+```console
+$ ls ~/my-project/.specstory/history/
+2026-07-20_19-27-20Z-say-exactly-ok.md
+```
+
+The `specstory` CLI is also on PATH for manual use — `specstory sync` to
+re-process prior sessions, `specstory run claude` to wrap the agent with
+auto-save, etc. See the
+[SpecStory CLI docs](https://docs.specstory.com/integrations/terminal-coding-agents)
+for the full command set.
+
+## How auto-save works
+
+The kit starts `specstory watch --no-version-check --no-usage-analytics`
+as a background startup command. `specstory watch` is a long-running
+daemon that monitors agent activity and writes markdown as sessions
+happen.
+
+Two sbx behaviors make this work without any user action:
+
+- **The agent runs from the host mount.** `sbx run` launches the agent
+  with its cwd set to the host workspace mount path (e.g.
+  `/Users/you/my-project`), not the container's default
+  `/home/agent/workspace`. Claude records that cwd against its session,
+  so `specstory` can match it.
+- **The watch daemon is launched from the same mount.** Startup
+  commands run with cwd `/home/agent/workspace`, but sbx sets
+  `WORKSPACE_DIR` to the host mount path. The kit's startup command
+  `cd`s to `$WORKSPACE_DIR` before exec'ing `specstory watch`, so the
+  daemon's cwd matches the agent's cwd and its `./.specstory/history/`
+  output lands on the host via the virtiofs mount.
+
+`--no-version-check` and `--no-usage-analytics` keep the daemon
+local-only — it makes no outbound network calls, so no extra
+`allowedDomains` entries are needed for runtime.
+
+## How the install works
+
+The kit downloads a pinned SpecStory release tarball from the public
+release repo (`github.com/specstoryai/getspecstory`), verifies its
+SHA256 against a digest captured in `spec.yaml`, and extracts the
+single `specstory` binary into `/usr/local/bin/`. The version and
+per-arch digests are sourced from the release's
+`SpecStoryCLI_<version>_checksums.txt` and live in git — bumping
+SpecStory is a one-line version edit + a digest update.
+
+We avoid `brew install` / floating `releases/latest` on purpose: the
+sandbox gets no visibility into what binary landed on PATH with those
+flows. Pinning lets reviewers see what changed when you bump the kit,
+and the SHA256 check fails closed if the release artifact is tampered
+with or the URL is hijacked.
+
+## Network policy
+
+The kit's `allowedDomains` is the complete outbound contract:
+
+- `github.com` — release tag URL for the install-time tarball
+- `release-assets.githubusercontent.com` — 302 target for the binary
+  download
+
+Runtime auto-save is local-only (the watch daemon runs with
+`--no-version-check --no-usage-analytics` and cloud sync is skipped
+when not authenticated), so no runtime domains are needed.
+
+If you wire SpecStory Cloud sync
+([`specstory login`](https://docs.specstory.com) + `specstory sync`)
+and want it reachable inside the sandbox, add `cloud.specstory.com` to
+`allowedDomains` in a fork of this kit.
+
+## Scope of this kit
+
+This is a thin install-and-watch layer. It does **not** configure
+SpecStory Cloud auth, pick a custom output directory, or launch the
+agent through `specstory run` for you — those decisions belong in your
+project or shell setup, not in a generic kit.

--- a/specstory/spec.yaml
+++ b/specstory/spec.yaml
@@ -1,0 +1,60 @@
+schemaVersion: "1"
+kind: mixin
+name: specstory
+displayName: SpecStory CLI
+description: "Installs the SpecStory CLI (https://docs.specstory.com) — a wrapper for terminal coding agents (Claude Code, Cursor CLI, Codex CLI, Gemini CLI) that saves conversations as local markdown. Agent-agnostic; pair with any supported agent."
+
+network:
+  allowedDomains:
+    # github.com — release tag URLs for the install-time tarball.
+    # The download then 302-redirects to release-assets.githubusercontent.com.
+    - github.com
+    - release-assets.githubusercontent.com
+
+commands:
+  install:
+    # Install specstory from a pinned, digest-verified GitHub release tarball on the
+    # public release repo (specstoryai/getspecstory). The tarball extracts a single
+    # `specstory` binary. To bump: change SPECSTORY_VERSION and the per-arch SHA256
+    # below (sourced from SpecStoryCLI_<version>_checksums.txt on the release).
+    - command: |
+        set -euo pipefail
+        SPECSTORY_VERSION=2.3.0
+        ARCH=$(dpkg --print-architecture)
+        case "$ARCH" in
+          amd64)
+            TARBALL="SpecStoryCLI_Linux_x86_64.tar.gz"
+            SHA256="18d67c4e71511f1e84a766db302f935cc9e9746208eef8f427d2f451603c6c82"
+            ;;
+          arm64)
+            TARBALL="SpecStoryCLI_Linux_arm64.tar.gz"
+            SHA256="29f0198665ce9cdb561aff94821f088670d7fdf01c69497b3e50c44090606320"
+            ;;
+          *)
+            echo "unsupported sandbox arch: $ARCH (expected amd64 or arm64)" >&2
+            exit 1
+            ;;
+        esac
+        URL="https://github.com/specstoryai/getspecstory/releases/download/v${SPECSTORY_VERSION}/${TARBALL}"
+        curl --proto '=https' --tlsv1.2 -fsSL -o /tmp/specstory.tgz "$URL"
+        echo "${SHA256}  /tmp/specstory.tgz" | sha256sum -c -
+        tar -C /tmp -xzf /tmp/specstory.tgz specstory
+        install -m 0755 /tmp/specstory /usr/local/bin/specstory
+        rm -f /tmp/specstory /tmp/specstory.tgz
+        specstory --version
+      user: "0"
+      description: "Install SpecStory CLI v2.3.0, version+digest pinned"
+  startup:
+    # Run `specstory watch` in the background from the host-mounted workspace so
+    # conversations are auto-saved to `.specstory/history/` as they happen — no
+    # manual `specstory sync` step after the agent exits.
+    #
+    # Startup commands run with cwd=/home/agent/workspace (the container's WORKDIR),
+    # not the host mount. `specstory watch` is cwd-scoped — it only saves sessions
+    # whose agent cwd matches its own — and writes history relative to its cwd.
+    # So we `cd` to $WORKSPACE_DIR (set by sbx to the host mount path) before
+    # launching: that aligns watch's cwd with the agent's cwd (sbx launches the
+    # agent from the same mount) and lands the markdown files on the host.
+    - command: ["sh", "-c", "cd \"$WORKSPACE_DIR\" && exec specstory watch --no-version-check --no-usage-analytics"]
+      background: true
+      description: "Auto-save agent conversations to .specstory/history/ on the host mount"


### PR DESCRIPTION
## What this adds

A new `specstory` mixin that installs the [SpecStory CLI](https://github.com/specstoryai/getspecstory) — a wrapper for terminal coding agents (Claude Code, Cursor CLI, Codex CLI, Gemini CLI) that saves conversations as local markdown. Agent-agnostic; pair with any supported agent.

I maintain SpecStory, so this kit wraps our own CLI — happy to field any questions about the install flow or the watch daemon behavior.

## How it works

**Install:** Downloads a pinned SpecStory release tarball from the public release repo (`github.com/specstoryai/getspecstory`), verifies its SHA256 against a digest captured in `spec.yaml`, and extracts the single `specstory` binary into `/usr/local/bin/`. Pinned to v2.3.0; per-arch digests sourced from the release's `SpecStoryCLI_2.3.0_checksums.txt`. Bumping is a one-line version edit + a digest update.

**Auto-save at runtime:** The kit starts `specstory watch --no-version-check --no-usage-analytics` as a background startup command, so conversations are auto-saved to `.specstory/history/` on the host workspace as they happen — no manual `specstory sync` step after the agent exits.

Two sbx behaviors make this work without user action:
- `sbx run` launches the agent with cwd set to the host workspace mount path (e.g. `/Users/you/my-project`), not the container's default `/home/agent/workspace`.
- Startup commands run with cwd `/home/agent/workspace`, but sbx sets `WORKSPACE_DIR` to the host mount path. The kit's startup command `cd`s to `$WORKSPACE_DIR` before exec'ing `specstory watch`, so the daemon's cwd matches the agent's cwd and its `./.specstory/history/` output lands on the host via the virtiofs mount.

`--no-version-check` and `--no-usage-analytics` keep the daemon local-only — no outbound network calls at runtime, so no extra `allowedDomains` entries are needed beyond the two install-time domains (`github.com`, `release-assets.githubusercontent.com`).

## Validation

All four local checks from `CONTRIBUTING.md` pass:

- `sbx kit validate ./specstory/` — VALID
- `scripts/test-kit.sh specstory` — TCK PASS (including real `install_execution` against a `shell-docker` container; SHA256 verified against the published artifact)
- `scripts/test-kit-e2e.sh specstory` — e2e PASS under deny-all (network contract complete)
- Manual smoke: created a sandbox with the kit, ran `claude -p "say exactly: ok"`, confirmed `.specstory/history/*.md` appeared on the host automatically via the watch daemon (no manual `specstory sync`). Verified the daemon is persistent across multiple consecutive sessions.

## Scope

Thin install-and-watch layer. Does not configure SpecStory Cloud auth, pick a custom output directory, or launch the agent through `specstory run` for you — those decisions belong in the user's project or shell setup. Authored in v1 schema for compatibility with the current released `sbx`; can migrate to v2 with `scripts/migrate-v1-to-v2.go` once a v2-capable `sbx` stable ships.
