### PR TITLE
feat(spec): accept family-qualified port protocols

### DIFF
--- a/skills/kit-author/topics/lifecycle.md
+++ b/skills/kit-author/topics/lifecycle.md
@@ -61,7 +61,7 @@ After normalization, only the canonical fields are populated. The legacy fields 
 - **permissions.network** — entry strings are exact host, exact host+port, or leading-label wildcard (`*.example.com`). Overlap between `allow` and `deny` is **legal** — at request time, deny wins.
 - **Credentials** — each entry has `service` set; `apiKey.inject[].format` (when set) is well-formed; a v2 `apiKey.inject[].scheme` is mutually exclusive with `format` and expands to it; `oauth.tokenEndpoint` has host+path.
 - **Volumes** — every entry has an absolute `path`; `type ∈ {"", "tmpfs"}`; `size` if set must parse as a byte-size string; `mode` if set must be octal.
-- **PublishedPorts** — `container` in 1..65535; `protocol ∈ {"", "tcp", "udp"}`.
+- **PublishedPorts** — `container` in 1..65535; `protocol ∈ {"", "tcp", "tcp4", "tcp6", "udp", "udp4", "udp6"}`.
 - **Locked** — each entry is a well-formed dotted YAML path; no duplicates.
 - **setup.files** — only `${WORKDIR}` placeholder is allowed; mode is octal; container paths are absolute.
 - **Static files** — relative-to-target only. Absolute paths and `..` traversal rejected. Symlink resolution must stay inside the artifact root.

--- a/skills/kit-author/topics/spec-anatomy.md
+++ b/skills/kit-author/topics/spec-anatomy.md
@@ -330,15 +330,20 @@ Ports the kit wants the sandbox runtime to publish on the host when the sandbox 
 ```yaml
 ports:
   - container: 8080
-    protocol: tcp                              # "tcp" (default) or "udp"
+    protocol: tcp                              # "tcp" (default), tcp4, tcp6, udp, udp4, udp6
     name: web                                  # informational label for `sbx ports`
   - container: 9418                            # git-daemon
   - container: 53
     protocol: udp
     name: dns
+  - container: 3000
+    protocol: tcp4                             # IPv4-only service: bind 127.0.0.1 only
+    name: web-v4
 ```
 
-Host port allocation is **always ephemeral** on `127.0.0.1`. Users wanting a pinned host port still use `sbx ports --publish <host>:<container>` on top of the kit's declaration. A kit can't pick a host port because two kits requesting the same one would collide on the user's machine.
+Host port allocation is **always ephemeral** on loopback. Users wanting a pinned host port still use `sbx ports --publish <host>:<container>` on top of the kit's declaration. A kit can't pick a host port because two kits requesting the same one would collide on the user's machine.
+
+The bare `tcp`/`udp` forms bind whichever loopback families the sandbox endpoint supports — on a dual-stack host, both `127.0.0.1` and `::1` under one host port. The family-qualified forms pin the binding: `tcp4`/`udp4` bind `127.0.0.1` only, `tcp6`/`udp6` bind `::1` only. Reach for a v4-only form when the service inside the container listens on IPv4 only (e.g. `--bind 0.0.0.0`) — otherwise a browser that resolves `localhost` to `::1` hits a host binding with nothing behind it and the connection is reset.
 
 Port publishing is **inbound service exposure** — a separate concern from outbound egress under `permissions.network`.
 

--- a/spec/SPEC-v2.md
+++ b/spec/SPEC-v2.md
@@ -505,13 +505,21 @@ key.)
 ```yaml
 ports:
   - container: 8080          # REQUIRED, 1..65535
-    protocol: tcp            # "" (→ tcp) | "tcp" | "udp"
+    protocol: tcp            # "" (→ tcp) | tcp | tcp4 | tcp6 | udp | udp4 | udp6
     name: web                # optional informational label
 ```
 
-Host ports are always allocated **ephemerally on `127.0.0.1`**; a kit cannot pin
+Host ports are always allocated **ephemerally on loopback**; a kit cannot pin
 a host port (two kits requesting the same one would collide). Users pin with
 `sbx ports --publish <host>:<container>`.
+
+The bare `tcp`/`udp` forms bind whichever loopback families the sandbox
+endpoint supports — on a dual-stack host, both `127.0.0.1` and `::1` under one
+host port. The family-qualified forms pin it: `tcp4`/`udp4` bind `127.0.0.1`
+only, `tcp6`/`udp6` bind `::1` only. Declare a v4-only form when the service
+in the container listens on IPv4 only (e.g. `--bind 0.0.0.0`), so a browser
+resolving `localhost` to `::1` cannot land on a host binding with nothing
+behind it.
 
 ### 5.4 `credentials`
 
@@ -737,7 +745,7 @@ the per-field rules above:
   on a `kind: mixin` (rejected on `kind: sandbox`).
 - **Volumes**: `type` is `""` or `tmpfs`; `path` absolute; `size` a valid
   byte-size; `mode` octal.
-- **ports**: `container` in 1..65535; `protocol` in `{"", tcp, udp}` (validation error messages spell this `publishedPorts[...]`, the canonical field name).
+- **ports**: `container` in 1..65535; `protocol` in `{"", tcp, tcp4, tcp6, udp, udp4, udp6}` (validation error messages spell this `publishedPorts[...]`, the canonical field name).
 - **environment**: variable keys are valid shell identifiers.
 - **setup**: `install[].command` non-empty; `startup[].command` non-empty;
   `files[].path` absolute; `files[].mode` octal; only `${WORKDIR}` placeholder

--- a/spec/types.go
+++ b/spec/types.go
@@ -284,7 +284,17 @@ type PublishedPort struct {
 	// Required. Must be in 1..65535.
 	Container int `json:"container" yaml:"container"`
 
-	// Protocol is "tcp" or "udp". Optional; defaults to "tcp" if empty.
+	// Protocol is one of SupportedPortProtocols. Optional; defaults to
+	// "tcp" if empty.
+	//
+	// The bare "tcp"/"udp" forms let the runtime bind whichever loopback
+	// families the sandbox endpoint supports — on a dual-stack host that is
+	// both 127.0.0.1 and ::1 under one host port. The family-qualified
+	// forms pin the binding: "tcp4"/"udp4" bind 127.0.0.1 only,
+	// "tcp6"/"udp6" bind ::1 only. Declare a v4-only form when the service
+	// inside the container listens on IPv4 only (e.g. `--bind 0.0.0.0`),
+	// so a browser resolving `localhost` to ::1 cannot land on a host
+	// binding with nothing behind it.
 	Protocol string `json:"protocol,omitempty" yaml:"protocol,omitempty"`
 
 	// Name is an optional human-readable label for the port, surfaced by

--- a/spec/validate.go
+++ b/spec/validate.go
@@ -122,19 +122,25 @@ func ValidateNetworkPolicy(n *NetworkPolicy) error {
 	return nil
 }
 
+// SupportedPortProtocols enumerates the protocol tokens a PublishedPort may
+// declare, matching the set the sandbox runtime's port-publish API accepts.
+// The family-qualified forms pin the host binding to one loopback address
+// (see PublishedPort.Protocol); the bare forms leave the choice to the
+// runtime. An empty protocol is also valid and defaults to "tcp".
+var SupportedPortProtocols = []string{"tcp", "tcp4", "tcp6", "udp", "udp4", "udp6"}
+
 // ValidatePublishedPorts validates the canonical top-level publishedPorts
 // list: each entry's container port must be in 1..65535 and its protocol must
-// be empty (defaulted to "tcp" at consumption time), "tcp", or "udp".
+// be empty (defaulted to "tcp" at consumption time) or one of
+// SupportedPortProtocols.
 func ValidatePublishedPorts(ports []PublishedPort) error {
 	for i, p := range ports {
 		if p.Container < 1 || p.Container > 65535 {
 			return fmt.Errorf("publishedPorts[%d].container must be in 1..65535 (got %d)", i, p.Container)
 		}
-		switch p.Protocol {
-		case "", "tcp", "udp":
-			// "" is accepted and defaults to "tcp" at consumption time.
-		default:
-			return fmt.Errorf("publishedPorts[%d].protocol must be empty, \"tcp\" or \"udp\" (got %q)", i, p.Protocol)
+		if p.Protocol != "" && !slices.Contains(SupportedPortProtocols, p.Protocol) {
+			return fmt.Errorf("publishedPorts[%d].protocol must be empty or one of %s (got %q)",
+				i, strings.Join(SupportedPortProtocols, ", "), p.Protocol)
 		}
 	}
 

--- a/spec/validate_test.go
+++ b/spec/validate_test.go
@@ -180,6 +180,17 @@ func TestValidatePublishedPorts(t *testing.T) {
 		}))
 	})
 
+	t.Run("family_qualified_protocols", func(t *testing.T) {
+		// The runtime's port-publish API accepts the family-qualified forms
+		// to pin a binding to one loopback address; kits must be able to
+		// declare them for services that listen on a single IP family.
+		for _, proto := range SupportedPortProtocols {
+			require.NoError(t,
+				ValidatePublishedPorts([]PublishedPort{{Container: 8080, Protocol: proto}}),
+				"protocol=%s", proto)
+		}
+	})
+
 	t.Run("container_out_of_range", func(t *testing.T) {
 		for _, p := range []int{0, -1, 65536, 70000} {
 			require.ErrorContains(t, ValidatePublishedPorts([]PublishedPort{{Container: p}}),
@@ -189,9 +200,14 @@ func TestValidatePublishedPorts(t *testing.T) {
 	})
 
 	t.Run("invalid_protocol", func(t *testing.T) {
-		require.ErrorContains(t,
-			ValidatePublishedPorts([]PublishedPort{{Container: 8080, Protocol: "sctp"}}),
-			"publishedPorts[0].protocol must be empty, \"tcp\" or \"udp\"")
+		// "TCP" stays rejected: widening the set to the family-qualified
+		// forms does not also make the match case-insensitive.
+		for _, proto := range []string{"sctp", "tcp5", "TCP", "tcp/4"} {
+			require.ErrorContains(t,
+				ValidatePublishedPorts([]PublishedPort{{Container: 8080, Protocol: proto}}),
+				"publishedPorts[0].protocol must be empty or one of tcp, tcp4, tcp6, udp, udp4, udp6",
+				"protocol=%s", proto)
+		}
 	})
 }
 


### PR DESCRIPTION
- Related to #162

## Summary

`publishedPorts` rejected `tcp4`/`tcp6`/`udp4`/`udp6`, so a kit had no way to pin its host binding to a single loopback family:

```
ERROR: resolve kits: kit "./code-server": publishedPorts[0].protocol must be empty, "tcp" or "udp" (got "tcp4")
```

Every consumer downstream of this validator already handles all six tokens — the sandbox runtime's port-publish API, its OpenAPI enum, and the portmapper (which folds the qualified forms back to `tcp`/`udp`). This validator was the only thing narrowing them.

The gap bites services listening on IPv4 only inside the container. A bare `tcp` binds both `127.0.0.1` and `::1` under one host port on a dual-stack host, so a browser that resolves `localhost` to `::1` reaches a binding with nothing behind it and the connection is reset — the symptom documented around in #162.

## Spec choices worth flagging for review

- **One validator covers both schema versions.** `ValidatePublishedPorts` runs ungated after normalization promotes v1 `network.publishedPorts` into the canonical list, so v1 and v2 kits both get the wider set with no version branch.
- **Uppercase stays rejected.** `"TCP"` still errors; only the token set widens, not the matching rule.
- **No kit in this repo is switched to `tcp4` here.** Validation runs client-side in `sbx` against the pinned `spec` module, so a kit declaring `tcp4` hard-fails on any `sbx` built before this lands. Kits should only adopt the qualified forms once a release carrying this is the floor.
- `SupportedPortProtocols` is exported to mirror `SupportedSchemaVersions`, and so the error message and the accepted set cannot drift.

## Test plan

- `go test -count=1 ./spec/... ./tck/... ./scripts/...` — the set CI's self-test leg runs. All pass.
- `TestValidatePublishedPorts` gains a case asserting every entry of `SupportedPortProtocols` validates, and the negative case now covers `sctp`, `tcp5`, `TCP`, and `tcp/4`.
- Docs updated in step with the rule: `spec/SPEC-v2.md` (grammar + validation summary), `skills/kit-author/topics/spec-anatomy.md`, `skills/kit-author/topics/lifecycle.md`. The "always ephemeral on `127.0.0.1`" phrasing in those two docs was already stale versus the runtime's dual-stack loopback default — corrected where touched, since that default is exactly what makes the qualified forms necessary.

## Origin

Fell out of investigating the `localhost` connection reset behind #162.
