### PR TITLE
feat(code-server): title the browser tab with the sandbox name

### DIFF
--- a/code-server/spec.yaml
+++ b/code-server/spec.yaml
@@ -44,9 +44,16 @@ commands:
   initFiles:
     - path: /home/agent/.local/bin/start-code-server.sh
       content: |
-        exec code-server --bind-addr 0.0.0.0:8080 --auth none "${WORKDIR}"
+        #!/bin/sh
+        # --app-name puts the sandbox name in the browser tab title, so tabs for
+        # concurrent sandboxes on one workspace are tellable apart. No braces
+        # around SANDBOX_VM_ID: only WORKDIR may be brace-interpolated here.
+        name=$SANDBOX_VM_ID
+        [ -n "$name" ] || name=$(hostname)
+        exec code-server --bind-addr 0.0.0.0:8080 --auth none \
+          --app-name "$name" "${WORKDIR}"
       mode: "0755"
-      description: Startup wrapper with the workspace path baked in at sandbox start
+      description: Startup wrapper with the workspace path and sandbox name baked in at sandbox start
   startup:
     - command: ["sh", "-c", "nohup /home/agent/.local/bin/start-code-server.sh > /tmp/code-server.log 2>&1 &"]
       user: "1000"


### PR DESCRIPTION
## Summary

Every code-server tab was titled `<workspace> - code-server`, so a user with
several code-server sandboxes open at once could not tell the tabs apart. The
startup wrapper now passes the sandbox name to `code-server --app-name`, so the
tab reads `<workspace> - <sandbox name>`.

```sh
name=$SANDBOX_VM_ID
[ -n "$name" ] || name=$(hostname)
exec code-server --bind-addr 0.0.0.0:8080 --auth none \
  --app-name "$name" "${WORKDIR}"
```

`--app-name` replaces VS Code's branding string (`nameShort`/`nameLong`) and the
default `window.title` template ends in the app name, so nothing in the shipped
`settings.json` changes.

## Origin

In-repo kit; no new upstream source.

## Test plan

- [x] `sbx kit validate ./code-server/`
- [x] `./scripts/test-kit.sh code-server` passes (the TCK).
- [ ] `./scripts/test-kit-e2e.sh code-server`
- [x] Manual smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)
