### PR TITLE
feat(spec): accept oauth credentialFile with structure and no template

### DIFF
--- a/spec/validate.go
+++ b/spec/validate.go
@@ -417,8 +417,8 @@ func ValidateOAuthPolicy(p *OAuthPolicy) error {
 		if p.CredentialFile.Path == "" {
 			return fmt.Errorf("artifact: oauth: credentialFile.path is required")
 		}
-		if p.CredentialFile.Template == "" {
-			return fmt.Errorf("artifact: oauth: credentialFile.template is required")
+		if p.CredentialFile.Template == "" && len(p.CredentialFile.Structure) == 0 {
+			return fmt.Errorf("artifact: oauth: credentialFile requires either template or structure")
 		}
 	}
 	return nil

--- a/spec/validate_test.go
+++ b/spec/validate_test.go
@@ -459,14 +459,27 @@ func TestValidateOAuthPolicy(t *testing.T) {
 		require.ErrorContains(t, ValidateOAuthPolicy(p), "credentialFile.path is required")
 	})
 
-	t.Run("credential_file_missing_template", func(t *testing.T) {
+	t.Run("credential_file_missing_template_and_structure", func(t *testing.T) {
 		p := &OAuthPolicy{
 			Service:        "svc",
 			TokenEndpoint:  OAuthTokenEndpoint{Host: "h", Path: "/p"},
 			Sentinels:      OAuthSentinels{AccessToken: "at", RefreshToken: "rt"},
 			CredentialFile: &OAuthCredentialFile{Path: "/cred"},
 		}
-		require.ErrorContains(t, ValidateOAuthPolicy(p), "credentialFile.template is required")
+		require.ErrorContains(t, ValidateOAuthPolicy(p), "credentialFile requires either template or structure")
+	})
+
+	t.Run("credential_file_structure_only_valid", func(t *testing.T) {
+		p := &OAuthPolicy{
+			Service:       "svc",
+			TokenEndpoint: OAuthTokenEndpoint{Host: "h", Path: "/p"},
+			Sentinels:     OAuthSentinels{AccessToken: "at", RefreshToken: "rt"},
+			CredentialFile: &OAuthCredentialFile{
+				Path:      "/cred",
+				Structure: map[string]any{"accessToken": "{{.AccessToken}}"},
+			},
+		}
+		require.NoError(t, ValidateOAuthPolicy(p))
 	})
 }
 


### PR DESCRIPTION
## Summary

OAuth `credentialFile` validation currently requires `template` whenever `credentialFile` is set, so a kit cannot declare the declarative `structure` form on its own — a `structure`-only kit fails at load with `credentialFile.template is required`. This relaxes the check to require **either** `template` **or** `structure`, matching the spec's documented direction (`structure` is the preferred, injection-safe form; `template` is deprecated and slated for Phase 6 removal).

`validate.go`: the check is now `template == "" && len(structure) == 0` → `credentialFile requires either template or structure`.

## Sequencing (part of a coordinated chain)

Structure *rendering* lands engine-side (`docker/sandboxes`). This validation relaxation must be **released before** the engine bumps its `sbx-kits-contrib` dependency — otherwise a `structure`-only kit could validate against a spec lib that outruns an engine that can't yet render it, producing an empty credential file. Order: merge + release this → bump the engine dependency → `structure`-only works end-to-end.

## Test plan

- `go test ./spec/...` passes — added `credential_file_structure_only_valid`; updated the former `missing_template` case to `missing_template_and_structure` for the new message.
- `gofmt` / `go vet` clean.

Not a kit change, so the kit `validate` / TCK / e2e checklist does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
