### PR TITLE
fix(spec): derive v1 deprecation field paths from the v2 grammar

### DIFF
--- a/spec/fieldpath.go
+++ b/spec/fieldpath.go
@@ -7,9 +7,14 @@ import (
 )
 
 // specFileV2Type and specFileType are the reflect roots v2Field and v1Field
-// descend from. Computed once at package init so a typo'd field name in a
-// v1Field/v2Field call panics at program startup (and therefore in any test
-// run), not silently at some later call site.
+// descend from.
+//
+// Resolution is lazy: a bad field name panics when the enclosing v1Field /
+// v2Field call actually runs, not at package init. Since those calls sit
+// inside individual normalize branches, TestFieldPaths (fieldpath_test.go)
+// is what guarantees the drift alarm actually fires — it exercises every
+// path used in this package, so a rename or retag breaks the test suite
+// rather than waiting for a kit that happens to hit that branch.
 var (
 	specFileV2Type = reflect.TypeOf(specFileV2{})
 	specFileType   = reflect.TypeOf(SpecFile{})
@@ -38,6 +43,12 @@ func fieldPath(root reflect.Type, names ...string) string {
 		for t.Kind() == reflect.Ptr {
 			t = t.Elem()
 		}
+		// Guard before FieldByName: reflect panics on a non-struct with its
+		// own opaque message ("FieldByName of non-struct type ..."), which
+		// would defeat the point of the targeted panics below.
+		if t.Kind() != reflect.Struct {
+			panic(fmt.Sprintf("spec: fieldPath: cannot descend into %s to reach %q (chain %v)", t, name, names))
+		}
 		f, ok := t.FieldByName(name)
 		if !ok {
 			panic(fmt.Sprintf("spec: fieldPath: type %s has no field %q (chain %v)", t, name, names))
@@ -52,8 +63,12 @@ func fieldPath(root reflect.Type, names ...string) string {
 		}
 		parts = append(parts, tag)
 
+		// Descend to the type the NEXT name resolves against: unwrap
+		// pointers, and step slices/maps to their element type so a chain
+		// may continue through a collection (consistent with the "[]"
+		// suffix added above).
 		ft := f.Type
-		for ft.Kind() == reflect.Ptr || ft.Kind() == reflect.Slice {
+		for ft.Kind() == reflect.Ptr || ft.Kind() == reflect.Slice || ft.Kind() == reflect.Map {
 			ft = ft.Elem()
 		}
 		t = ft

--- a/spec/fieldpath.go
+++ b/spec/fieldpath.go
@@ -1,0 +1,87 @@
+package spec
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// specFileV2Type and specFileType are the reflect roots v2Field and v1Field
+// descend from. Computed once at package init so a typo'd field name in a
+// v1Field/v2Field call panics at program startup (and therefore in any test
+// run), not silently at some later call site.
+var (
+	specFileV2Type = reflect.TypeOf(specFileV2{})
+	specFileType   = reflect.TypeOf(SpecFile{})
+)
+
+// fieldPath walks a chain of Go struct field names starting at root and
+// returns the dotted YAML path those fields decode from, read directly off
+// each field's `yaml` struct tag. A field is suffixed with "[]" when its Go
+// type is a slice or map AND it is not the last name in the chain — i.e. the
+// chain descends into one of its elements next (matching the established
+// "credentials[].apiKey.inject[].domain" style); a trailing list field (e.g.
+// "setup.startup", "ports") is not decorated, since nothing indexes into it.
+//
+// This exists so deprecation/migration messages can reference the grammar
+// itself instead of a hand-typed literal. A hand-typed path silently drifts
+// when a field is renamed (this is exactly how a deprecation notice once
+// told kit authors to write 'caps.network.allow', an internal field name
+// that was never valid v2 YAML — the real grammar had already moved to
+// 'permissions.network.allow'). fieldPath instead panics loudly the moment
+// the named Go field stops existing, so a rename breaks the build/tests
+// instead of quietly shipping stale guidance.
+func fieldPath(root reflect.Type, names ...string) string {
+	t := root
+	parts := make([]string, 0, len(names))
+	for i, name := range names {
+		for t.Kind() == reflect.Ptr {
+			t = t.Elem()
+		}
+		f, ok := t.FieldByName(name)
+		if !ok {
+			panic(fmt.Sprintf("spec: fieldPath: type %s has no field %q (chain %v)", t, name, names))
+		}
+		tag := strings.Split(f.Tag.Get("yaml"), ",")[0]
+		if tag == "" || tag == "-" {
+			panic(fmt.Sprintf("spec: fieldPath: field %q on %s has no yaml tag (chain %v)", name, t, names))
+		}
+		isList := f.Type.Kind() == reflect.Slice || f.Type.Kind() == reflect.Map
+		if isList && i < len(names)-1 {
+			tag += "[]"
+		}
+		parts = append(parts, tag)
+
+		ft := f.Type
+		for ft.Kind() == reflect.Ptr || ft.Kind() == reflect.Slice {
+			ft = ft.Elem()
+		}
+		t = ft
+	}
+	return strings.Join(parts, ".")
+}
+
+// v2Field returns the dotted v2 grammar path for a chain of Go field names
+// rooted at specFileV2 (the schemaVersion "2" decode target).
+func v2Field(names ...string) string {
+	return fieldPath(specFileV2Type, names...)
+}
+
+// v1Field is the v1-grammar analogue of v2Field, rooted at SpecFile (the
+// schemaVersion "1" decode target — Manifest is embedded inline, so
+// Manifest field names like "Kind" resolve directly against SpecFile too).
+func v1Field(names ...string) string {
+	return fieldPath(specFileType, names...)
+}
+
+// splitLeaf splits a dotted field path into its prefix and final segment,
+// for composing "prefix.a/b"-style messages that reference two sibling
+// leaf fields sharing the same parent (e.g. "credentials[].apiKey.inject[].
+// header/format"). Returns ("", path) if path has no '.'.
+func splitLeaf(path string) (prefix, leaf string) {
+	i := strings.LastIndex(path, ".")
+	if i < 0 {
+		return "", path
+	}
+	return path[:i], path[i+1:]
+}

--- a/spec/fieldpath_test.go
+++ b/spec/fieldpath_test.go
@@ -1,0 +1,122 @@
+package spec
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestFieldPaths pins every v1Field / v2Field chain used in this package to
+// the YAML path it must produce.
+//
+// This is the drift alarm the helpers exist for. v1Field/v2Field resolve
+// lazily — each call sits inside a normalize branch that only runs for specs
+// exercising that legacy surface — so without this test a renamed field or a
+// changed yaml tag could ship and only surface as a panic on some user's kit.
+// Here, the same rename breaks the build (unknown Go field) or this test (a
+// changed tag), whichever applies.
+//
+// The expected values are the grammar as documented in spec/SPEC-v2.md and
+// skills/kit-author/topics/v1-migration.md. Update them only alongside a
+// deliberate, documented grammar change.
+func TestFieldPaths(t *testing.T) {
+	t.Run("v2", func(t *testing.T) {
+		for _, tc := range []struct {
+			want  string
+			names []string
+		}{
+			{"permissions", []string{"Permissions"}},
+			{"permissions.network.allow", []string{"Permissions", "Network", "Allow"}},
+			{"permissions.network.deny", []string{"Permissions", "Network", "Deny"}},
+			{"agentInstructions.content", []string{"AgentInstructions", "Content"}},
+			{"sandbox", []string{"Sandbox"}},
+			{"setup.files", []string{"Setup", "Files"}},
+			{"setup.startup", []string{"Setup", "Startup"}},
+			{"ports", []string{"PublishedPorts"}},
+			{"volumes", []string{"Volumes"}},
+			{"credentials", []string{"Credentials"}},
+			{"credentials[].apiKey", []string{"Credentials", "ApiKey"}},
+			{"credentials[].apiKey.name", []string{"Credentials", "ApiKey", "Name"}},
+			{"credentials[].apiKey.proxyManaged", []string{"Credentials", "ApiKey", "ProxyManaged"}},
+			{"credentials[].apiKey.inject[].domain", []string{"Credentials", "ApiKey", "Inject", "Domain"}},
+			{"credentials[].apiKey.inject[].header", []string{"Credentials", "ApiKey", "Inject", "Header"}},
+			{"credentials[].apiKey.inject[].format", []string{"Credentials", "ApiKey", "Inject", "Format"}},
+			{"credentials[].oauth", []string{"Credentials", "OAuth"}},
+		} {
+			require.Equal(t, tc.want, v2Field(tc.names...), "v2Field(%v)", tc.names)
+		}
+	})
+
+	t.Run("v1", func(t *testing.T) {
+		for _, tc := range []struct {
+			want  string
+			names []string
+		}{
+			{"kind", []string{"Kind"}},
+			{"agent", []string{"LegacyAgent"}},
+			{"memory", []string{"LegacyMemory"}},
+			{"agentContext", []string{"AgentContext"}},
+			{"settings", []string{"LegacySettings"}},
+			{"persistence", []string{"LegacyPersistence"}},
+			{"kitDir", []string{"LegacyKitDir"}},
+			{"tmpfs", []string{"LegacyTmpfs"}},
+			{"caps", []string{"Caps"}},
+			{"oauth", []string{"LegacyOAuth"}},
+			{"commands.initFiles", []string{"Commands", "InitFiles"}},
+			{"commands.startup", []string{"Commands", "Startup"}},
+			{"sandbox.image", []string{"Sandbox", "Image"}},
+			{"sandbox.build", []string{"Sandbox", "Build"}},
+			{"sandbox.persistence", []string{"Sandbox", "LegacyPersistence"}},
+			{"network.allowedDomains", []string{"LegacyNetwork", "AllowedDomains"}},
+			{"network.deniedDomains", []string{"LegacyNetwork", "DeniedDomains"}},
+			{"network.publishedPorts", []string{"LegacyNetwork", "PublishedPorts"}},
+			{"network.serviceAuth", []string{"LegacyNetwork", "ServiceAuth"}},
+			{"network.serviceDomains", []string{"LegacyNetwork", "ServiceDomains"}},
+			{"environment.proxyManaged", []string{"Environment", "ProxyManaged"}},
+		} {
+			require.Equal(t, tc.want, v1Field(tc.names...), "v1Field(%v)", tc.names)
+		}
+	})
+
+	// A collection is only suffixed when the chain continues into an element:
+	// "credentials[].apiKey" indexes, a trailing "ports" does not.
+	t.Run("collection_suffix_only_when_traversed", func(t *testing.T) {
+		require.Equal(t, "ports", v2Field("PublishedPorts"))
+		require.Equal(t, "credentials", v2Field("Credentials"))
+		require.Equal(t, "credentials[].service", v2Field("Credentials", "Service"))
+	})
+
+	// Chains may pass through a map's element type, matching the "[]" suffix
+	// emitted for maps.
+	t.Run("descends_through_map_element", func(t *testing.T) {
+		require.Equal(t, "network.serviceAuth[].headerName",
+			v1Field("LegacyNetwork", "ServiceAuth", "HeaderName"))
+	})
+
+	t.Run("panics", func(t *testing.T) {
+		require.PanicsWithValue(t,
+			`spec: fieldPath: type spec.specFileV2 has no field "Nope" (chain [Nope])`,
+			func() { v2Field("Nope") })
+
+		// Descending past a scalar must give our targeted message, not
+		// reflect's opaque "FieldByName of non-struct type".
+		require.PanicsWithValue(t,
+			`spec: fieldPath: cannot descend into string to reach "Nope" (chain [Kind Nope])`,
+			func() { v1Field("Kind", "Nope") })
+
+		// Manifest.Volumes is yaml:"-" (the volumesField wrapper owns the
+		// decode), so it has no addressable YAML path.
+		require.Panics(t, func() { fieldPath(reflect.TypeOf(Manifest{}), "Volumes") })
+	})
+}
+
+func TestSplitLeaf(t *testing.T) {
+	prefix, leaf := splitLeaf("credentials[].apiKey.inject[].header")
+	require.Equal(t, "credentials[].apiKey.inject[]", prefix)
+	require.Equal(t, "header", leaf)
+
+	prefix, leaf = splitLeaf("ports")
+	require.Empty(t, prefix)
+	require.Equal(t, "ports", leaf)
+}

--- a/spec/normalize.go
+++ b/spec/normalize.go
@@ -119,7 +119,11 @@ func (s *SpecFile) normalizeLegacySettings(w *warnings) {
 		return
 	}
 	s.LegacySettings = nil
-	w.deprecate("settings", "container settings are now lifted into kit commands.startup; remove this block (kit-spec v2)")
+	w.deprecate(v1Field("LegacySettings"), fmt.Sprintf(
+		"container settings are now lifted into kit %s/%s (schemaVersion 1) or %s/%s (kit-spec v2); remove this block",
+		v1Field("Commands", "InitFiles"), v1Field("Commands", "Startup"),
+		v2Field("Setup", "Files"), v2Field("Setup", "Startup"),
+	))
 }
 
 // normalizeVolumes folds the SpecFile-level volumes wrapper into the
@@ -174,7 +178,7 @@ func (s *SpecFile) normalizeLegacyTmpfs(w *warnings) {
 			Size: s.LegacyTmpfs[p],
 		})
 	}
-	w.deprecate("tmpfs", "use 'volumes:' entries with 'type: tmpfs' instead (kit-spec v2)")
+	w.deprecate("tmpfs", fmt.Sprintf("use '%s:' entries with 'type: tmpfs' instead (kit-spec v2)", v2Field("Volumes")))
 	s.LegacyTmpfs = nil
 }
 
@@ -187,7 +191,7 @@ func (s *SpecFile) normalizeLegacyPersistence(w *warnings) {
 	if s.LegacyPersistence == "" {
 		return
 	}
-	w.deprecate("persistence", "field has no effect and is removed in kit-spec v2; safe to delete")
+	w.deprecate(v1Field("LegacyPersistence"), "field has no effect and is removed in kit-spec v2; safe to delete")
 	s.LegacyPersistence = ""
 }
 
@@ -199,7 +203,7 @@ func (s *SpecFile) normalizeLegacyKitDir(w *warnings) {
 	if s.LegacyKitDir == "" {
 		return
 	}
-	w.deprecate("kitDir", "field has no effect and is removed in kit-spec v2; safe to delete")
+	w.deprecate(v1Field("LegacyKitDir"), "field has no effect and is removed in kit-spec v2; safe to delete")
 	s.LegacyKitDir = ""
 }
 
@@ -213,7 +217,8 @@ func (s *SpecFile) normalizePublishedPorts(w *warnings) {
 	}
 	s.PublishedPorts = append(s.PublishedPorts, s.LegacyNetwork.PublishedPorts...)
 	s.LegacyNetwork.PublishedPorts = nil
-	w.deprecate("network.publishedPorts", "use the top-level 'ports' field instead (kit-spec v2)")
+	w.deprecate(v1Field("LegacyNetwork", "PublishedPorts"), fmt.Sprintf(
+		"use the top-level '%s' field instead (kit-spec v2)", v2Field("PublishedPorts")))
 }
 
 // normalizeKind maps the v1 `kind: agent` value to `sandbox`. The v2 value
@@ -221,7 +226,8 @@ func (s *SpecFile) normalizePublishedPorts(w *warnings) {
 func (s *SpecFile) normalizeKind(w *warnings) {
 	if s.Manifest.Kind == KindAgent {
 		s.Manifest.Kind = KindSandbox
-		w.deprecate("kind: agent", "use 'kind: sandbox' instead (kit-spec v2)")
+		w.deprecate(fmt.Sprintf("%s: %s", v1Field("Kind"), KindAgent),
+			fmt.Sprintf("use '%s: %s' instead (kit-spec v2)", v1Field("Kind"), KindSandbox))
 	}
 }
 
@@ -247,7 +253,9 @@ func (s *SpecFile) normalizeAgentContext(w *warnings) {
 	if s.AgentContext == "" {
 		s.AgentContext = s.LegacyMemory
 	}
-	w.deprecate("memory", "use 'agentContext' instead (kit-spec v2)")
+	w.deprecate(v1Field("LegacyMemory"), fmt.Sprintf(
+		"use '%s' (schemaVersion 1) or '%s' (kit-spec v2) instead",
+		v1Field("AgentContext"), v2Field("AgentInstructions", "Content")))
 	s.LegacyMemory = ""
 }
 
@@ -260,7 +268,7 @@ func (s *SpecFile) normalizeSandbox(w *warnings) error {
 		if s.Sandbox == nil {
 			s.Sandbox = s.LegacyAgent
 		}
-		w.deprecate("agent:", "use 'sandbox:' block instead (kit-spec v2)")
+		w.deprecate(v1Field("LegacyAgent")+":", fmt.Sprintf("use '%s:' block instead (kit-spec v2)", v2Field("Sandbox")))
 		s.LegacyAgent = nil
 	}
 	// `persistence:` lived both at the spec root (handled by
@@ -269,7 +277,7 @@ func (s *SpecFile) normalizeSandbox(w *warnings) error {
 	// warning here rather than letting strict decode reject Andre's
 	// kit shape.
 	if s.Sandbox != nil && s.Sandbox.LegacyPersistence != "" {
-		w.deprecate("sandbox.persistence", "field has no effect and is removed in kit-spec v2; safe to delete")
+		w.deprecate(v1Field("Sandbox", "LegacyPersistence"), "field has no effect and is removed in kit-spec v2; safe to delete")
 		s.Sandbox.LegacyPersistence = ""
 	}
 
@@ -309,7 +317,9 @@ func (s *SpecFile) normalizeSandbox(w *warnings) error {
 	// still required this release, so a kit that supplies only `build:` would
 	// otherwise fail later with the generic "template is required" error.
 	if s.Build != nil {
-		w.notImplemented("sandbox.build", "Dockerfile builds are accepted in the schema but not yet built by the runtime; the image is taken from sandbox.image")
+		w.notImplemented(v1Field("Sandbox", "Build"), fmt.Sprintf(
+			"Dockerfile builds are accepted in the schema but not yet built by the runtime; the image is taken from %s",
+			v1Field("Sandbox", "Image")))
 		if s.Sandbox.Image == "" {
 			return fmt.Errorf("sandbox.build is accepted in the schema but not yet implemented — specify sandbox.image")
 		}
@@ -559,16 +569,30 @@ func (s *SpecFile) normalizeLegacyCredentials(w *warnings) error {
 	}
 
 	if sawSources {
-		w.deprecate("credentials.sources", "use the top-level credentials: list with apiKey: sub-blocks (kit-spec v2)")
+		// credentialsField.LegacySources has no yaml tag of its own — the v1
+		// mapping shape is decoded via a locally-scoped anonymous struct
+		// inside credentialsField.UnmarshalYAML (see types.go), which isn't
+		// reachable through reflection off a named field. "credentials.sources"
+		// is hand-typed for that reason; the v2 side is still grammar-derived.
+		_, apiKeyLeaf := splitLeaf(v2Field("Credentials", "ApiKey"))
+		w.deprecate("credentials.sources", fmt.Sprintf(
+			"use the top-level '%s:' list with '%s:' sub-blocks (kit-spec v2)", v2Field("Credentials"), apiKeyLeaf))
 	}
 	if sawServiceAuth {
-		w.deprecate("network.serviceAuth", "use credentials[].apiKey.inject[].header/format (kit-spec v2)")
+		prefix, headerLeaf := splitLeaf(v2Field("Credentials", "ApiKey", "Inject", "Header"))
+		_, formatLeaf := splitLeaf(v2Field("Credentials", "ApiKey", "Inject", "Format"))
+		w.deprecate(v1Field("LegacyNetwork", "ServiceAuth"), fmt.Sprintf(
+			"use %s.%s/%s (kit-spec v2)", prefix, headerLeaf, formatLeaf))
 	}
 	if sawServiceDomains {
-		w.deprecate("network.serviceDomains", "use credentials[].apiKey.inject[].domain (kit-spec v2)")
+		w.deprecate(v1Field("LegacyNetwork", "ServiceDomains"), fmt.Sprintf(
+			"use %s (kit-spec v2)", v2Field("Credentials", "ApiKey", "Inject", "Domain")))
 	}
 	if sawProxyManaged {
-		w.deprecate("environment.proxyManaged", "use credentials[].apiKey.name (kit-spec v2)")
+		prefix, nameLeaf := splitLeaf(v2Field("Credentials", "ApiKey", "Name"))
+		_, proxyManagedLeaf := splitLeaf(v2Field("Credentials", "ApiKey", "ProxyManaged"))
+		w.deprecate(v1Field("Environment", "ProxyManaged"), fmt.Sprintf(
+			"use %s.%s with %s.%s: true (kit-spec v2)", prefix, nameLeaf, prefix, proxyManagedLeaf))
 	}
 
 	return nil
@@ -627,7 +651,7 @@ func (s *SpecFile) normalizeLegacyOAuthBlock(w *warnings) error {
 				sort.Strings(target.ResourceHosts)
 				target.ResourceHosts = slices.Compact(target.ResourceHosts)
 			}
-			w.deprecate("oauth: (standalone block)", "use credentials[].oauth (kit-spec v2)")
+			w.deprecate(v1Field("LegacyOAuth")+": (standalone block)", fmt.Sprintf("use %s (kit-spec v2)", v2Field("Credentials", "OAuth")))
 			return nil
 		}
 	}
@@ -660,11 +684,13 @@ func (s *SpecFile) normalizeCapsNetwork(w *warnings) error {
 
 	if hasV1Allow {
 		s.Caps.Network.Allow = append(s.Caps.Network.Allow, s.LegacyNetwork.AllowedDomains...)
-		w.deprecate("network.allowedDomains", "use 'caps.network.allow' instead (kit-spec v2)")
+		w.deprecate(v1Field("LegacyNetwork", "AllowedDomains"), fmt.Sprintf(
+			"use '%s' instead (kit-spec v2)", v2Field("Permissions", "Network", "Allow")))
 	}
 	if hasV1Deny {
 		s.Caps.Network.Deny = append(s.Caps.Network.Deny, s.LegacyNetwork.DeniedDomains...)
-		w.deprecate("network.deniedDomains", "use 'caps.network.deny' instead (kit-spec v2)")
+		w.deprecate(v1Field("LegacyNetwork", "DeniedDomains"), fmt.Sprintf(
+			"use '%s' instead (kit-spec v2)", v2Field("Permissions", "Network", "Deny")))
 	}
 
 	return nil

--- a/spec/normalize.go
+++ b/spec/normalize.go
@@ -178,7 +178,8 @@ func (s *SpecFile) normalizeLegacyTmpfs(w *warnings) {
 			Size: s.LegacyTmpfs[p],
 		})
 	}
-	w.deprecate("tmpfs", fmt.Sprintf("use '%s:' entries with 'type: tmpfs' instead (kit-spec v2)", v2Field("Volumes")))
+	w.deprecate(v1Field("LegacyTmpfs"), fmt.Sprintf(
+		"use '%s:' entries with 'type: %s' instead (kit-spec v2)", v2Field("Volumes"), MountTypeTmpfs))
 	s.LegacyTmpfs = nil
 }
 

--- a/spec/normalize.go
+++ b/spec/normalize.go
@@ -667,9 +667,21 @@ func (s *SpecFile) normalizeLegacyOAuthBlock(w *warnings) error {
 }
 
 // normalizeCapsNetwork promotes v1 network.allowedDomains/deniedDomains
-// (LegacyNetwork) into the canonical Caps.Network.Allow/Deny lists.
-// Emits one deprecation warning per legacy field touched.
+// (LegacyNetwork) into the canonical Caps.Network.Allow/Deny lists, and
+// warns on direct `caps:` usage. Emits one deprecation warning per legacy
+// surface touched.
 func (s *SpecFile) normalizeCapsNetwork(w *warnings) error {
+	// `caps:` decodes directly in the v1 grammar (SpecFile.Caps) — it predates
+	// the current v2 grammar's `permissions:` block (an earlier v2 draft used
+	// this exact spelling; see skills/kit-author/topics/v1-migration.md).
+	// Nothing else in normalize() touches s.Caps before this point, so seeing
+	// it non-nil here means the author wrote `caps:` directly rather than
+	// relying on the allowedDomains/deniedDomains fold below — warn either way,
+	// same as every other legacy surface in this file.
+	if s.Caps != nil {
+		w.deprecate(v1Field("Caps"), fmt.Sprintf("use '%s:' block instead (kit-spec v2)", v2Field("Permissions")))
+	}
+
 	hasV1Allow := s.LegacyNetwork != nil && len(s.LegacyNetwork.AllowedDomains) > 0
 	hasV1Deny := s.LegacyNetwork != nil && len(s.LegacyNetwork.DeniedDomains) > 0
 	if !hasV1Allow && !hasV1Deny {

--- a/spec/v1_compat_test.go
+++ b/spec/v1_compat_test.go
@@ -718,6 +718,40 @@ permissions:
 	require.ElementsMatch(t, []string{"malware.example.com"}, art.Caps.Network.Deny)
 }
 
+// TestV1DirectCaps_Deprecated exercises a v1 spec that writes the `caps:`
+// block directly — an earlier v2 draft's spelling for what the current v2
+// grammar calls `permissions:` — rather than the still-live
+// network.allowedDomains/deniedDomains fold. It must load, keep working
+// (caps: is still a decodable v1-grammar field), and warn, same as every
+// other legacy surface in normalize.go.
+func TestV1DirectCaps_Deprecated(t *testing.T) {
+	dir := t.TempDir()
+	specYAML := `schemaVersion: "1"
+kind: sandbox
+name: caps-v1
+sandbox:
+  image: docker/sandbox-templates:shell-docker
+caps:
+  network:
+    allow: [api.anthropic.com]
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "spec.yaml"), []byte(specYAML), 0o644))
+	art, err := LoadFromDirectory(dir)
+	require.NoError(t, err)
+
+	require.NotNil(t, art.Caps)
+	require.NotNil(t, art.Caps.Network)
+	require.Contains(t, art.Caps.Network.Allow, "api.anthropic.com")
+
+	var capsWarn bool
+	for _, w := range art.Warnings {
+		if strings.Contains(w, `"caps"`) {
+			capsWarn = true
+		}
+	}
+	require.True(t, capsWarn, "expected a deprecation warning for direct 'caps:' usage, got %v", art.Warnings)
+}
+
 // TestV1NetworkAllowedDomains_RoundTripsToCapsNetwork exercises the
 // parallel-load contract for the network -> caps.network rename: a v1
 // spec with network.allowedDomains / network.deniedDomains loads


### PR DESCRIPTION
## Summary

A v1 kit's deprecation warnings told authors to write field names that **are not valid kit-spec v2 YAML at all**. `network.allowedDomains` pointed at `caps.network.allow` — an internal Go field name; the grammar has used `permissions.network.allow` since the `caps` → `permissions` rename. Anyone following that advice in a `schemaVersion: "2"` spec hits a hard decode error, because the v2 decoder is strict.

Root cause: the paths were hand-typed string literals, so they silently went stale when the grammar moved.

## What changed

- **`spec/fieldpath.go`** — `v1Field()` / `v2Field()` read the dotted YAML path directly off the v1/v2 struct tags via reflection. Every hand-typed field path in `normalize.go`'s `deprecate()` / `notImplemented()` calls now goes through them, so a rename breaks the build and a retag breaks the tests instead of shipping stale guidance.
- **Corrected messages**: `caps.network.allow/deny` → `permissions.network.allow/deny`; `memory` now distinguishes `agentContext` (v1) from `agentInstructions.content` (v2); `settings` distinguishes `commands.startup` (v1) from `setup.startup` (v2); `environment.proxyManaged` notes `apiKey.proxyManaged: true` is also required.
- **`caps:` now warns.** Every other legacy surface warns when used, but a kit writing `caps:` directly got nothing — even though it is itself a superseded spelling. Two kits in this repo (`nanoclaw`, `playwright`) are affected.

One literal remains, with the reason recorded in-code: `credentials.sources` is decoded through a locally-scoped anonymous struct inside `credentialsField.UnmarshalYAML`, which reflection cannot reach off a named field. Its v2 side is still derived.

## Test plan

- `TestFieldPaths` pins all 38 v1/v2 chains used in this package to their documented paths (`spec/SPEC-v2.md`, `skills/kit-author/topics/v1-migration.md`). Verified the alarm actually fires by retagging `permissions` → `grants` and confirming the test fails.
- `go test ./...`, `go vet ./...`, `gofmt` clean.
- **No regressions across real kits**: dumped every warning for all 45 kits in this repo plus the engine's embedded agents, before and after. Every `caps.network.*` became `permissions.network.*`, no warning was lost, and the only additions are the two intended new `caps:` warnings (96 → 98 lines).
- **Migration stays lossless** for the two kits the new `caps:` warning flips from no-op to rewrite: `nanoclaw` and `playwright` produce a byte-identical canonical `Artifact` before vs after `scripts/migrate-v1-to-v2.go`.

## Notes for reviewers

- Independent of #171 (oauth validation) and #172 (V2View) — no file overlap; all three merge cleanly in any order.
- The new `caps:` warning means `migrate-v1-to-v2.go` now rewrites `nanoclaw`/`playwright` instead of treating them as already-clean. That is intended (they should declare `permissions:`), and proven lossless above.
