### PR TITLE
fix(spec): validate credentials[].oauth in ValidateArtifact

### DIFF
--- a/spec/SPEC-v2.md
+++ b/spec/SPEC-v2.md
@@ -739,6 +739,19 @@ the per-field rules above:
   byte-size; `mode` octal.
 - **ports**: `container` in 1..65535; `protocol` in `{"", tcp, udp}` (validation error messages spell this `publishedPorts[...]`, the canonical field name).
 - **environment**: variable keys are valid shell identifiers.
+- **credentials**: `service` non-empty on every entry. Its lowercase-kebab
+  charset ([§5.4](#54-credentials)) is **not** enforced here — the v1 fold
+  derives service keys from env-var names and keeps underscores
+  (`SAMPLE_PROXY_TOKEN` → `sample_proxy`), so enforcing it would reject v1
+  kits that load today.
+- **credentials[].oauth** (when present): `tokenEndpoint.host` and
+  `tokenEndpoint.path` non-empty; `sentinels.accessToken` and
+  `sentinels.refreshToken` non-empty **unless** `passthrough: true`;
+  and when `credentialFile` is set, its `path` is non-empty and at least one
+  of `template` / `structure` is present. This mirrors the proxy's own
+  runtime guard, so a kit that validates here will not fail the interceptor
+  later. Placeholder *correctness* inside `structure` is checked by the
+  engine at render time, not here.
 - **setup**: `install[].command` non-empty; `startup[].command` non-empty;
   `files[].path` absolute; `files[].mode` octal; only `${WORKDIR}` placeholder
   in `files[].content`.

--- a/spec/validate.go
+++ b/spec/validate.go
@@ -22,8 +22,9 @@ var placeholderPattern = regexp.MustCompile(`\$\{[^}]+\}`)
 
 // lockedPathPattern matches a dotted YAML path: lowercase letter or digit
 // start, then segments of letters/digits separated by single dots, e.g.
-// "agent.image" or "network.allowedDomains". Used only for well-formedness;
-// the consumer that performs the merge decides which paths are meaningful.
+// "sandbox.image" or "permissions.network.allow". Used only for
+// well-formedness; the consumer that performs the merge decides which paths
+// are meaningful.
 var lockedPathPattern = regexp.MustCompile(`^[a-z][a-zA-Z0-9]*(\.[a-z][a-zA-Z0-9]*)*$`)
 
 // octalModePattern matches file mode strings: 3 or 4 octal digits, with an

--- a/spec/validate.go
+++ b/spec/validate.go
@@ -318,13 +318,20 @@ func ValidateArtifact(a *Artifact) error {
 		return err
 	}
 	for i, c := range a.Credentials {
-		// The service identifier is what carries OAuth's identity in v2 (it
-		// moved off the OAuth block onto the parent Credential), and both
-		// engine entry points reject an empty one at runtime — the proxy's
-		// NewOAuthInterceptorFromConfig and the configure hook's
-		// "oauth service name cannot be empty". Catch it at validate time.
-		if c.OAuth != nil && c.Service == "" {
-			return fmt.Errorf("artifact: credentials[%d]: service is required for an oauth credential", i)
+		// SPEC-v2 §5.4 makes service REQUIRED on every credential entry: it is
+		// the identity the user-side bindings file matches on. For OAuth it
+		// carries what v2 moved off the OAuth block onto the parent
+		// Credential, and both engine entry points reject an empty one at
+		// runtime (the proxy's NewOAuthInterceptorFromConfig, and the
+		// configure hook's "oauth service name cannot be empty").
+		//
+		// §5.4 also specifies a lowercase-kebab charset. That is deliberately
+		// NOT enforced: the v1 fold synthesizes service keys from env-var
+		// names via deriveServiceKey, which keeps underscores for any
+		// multi-word variable (SAMPLE_PROXY_TOKEN -> "sample_proxy"), so
+		// enforcing the pattern would reject v1 kits that load today.
+		if c.Service == "" {
+			return fmt.Errorf("artifact: credentials[%d]: service is required", i)
 		}
 		if err := ValidateOAuth(c.OAuth); err != nil {
 			return fmt.Errorf("artifact: credentials[%d] (service %q): %w", i, c.Service, err)

--- a/spec/validate.go
+++ b/spec/validate.go
@@ -318,6 +318,14 @@ func ValidateArtifact(a *Artifact) error {
 		return err
 	}
 	for i, c := range a.Credentials {
+		// The service identifier is what carries OAuth's identity in v2 (it
+		// moved off the OAuth block onto the parent Credential), and both
+		// engine entry points reject an empty one at runtime — the proxy's
+		// NewOAuthInterceptorFromConfig and the configure hook's
+		// "oauth service name cannot be empty". Catch it at validate time.
+		if c.OAuth != nil && c.Service == "" {
+			return fmt.Errorf("artifact: credentials[%d]: service is required for an oauth credential", i)
+		}
 		if err := ValidateOAuth(c.OAuth); err != nil {
 			return fmt.Errorf("artifact: credentials[%d] (service %q): %w", i, c.Service, err)
 		}

--- a/spec/validate.go
+++ b/spec/validate.go
@@ -317,6 +317,11 @@ func ValidateArtifact(a *Artifact) error {
 	if err := ValidateCommandsPolicy(a.Commands); err != nil {
 		return err
 	}
+	for i, c := range a.Credentials {
+		if err := ValidateOAuth(c.OAuth); err != nil {
+			return fmt.Errorf("artifact: credentials[%d] (service %q): %w", i, c.Service, err)
+		}
+	}
 
 	for i, f := range a.Files {
 		if f.Target != TargetHome && f.Target != TargetWorkspace {
@@ -419,6 +424,50 @@ func ValidateOAuthPolicy(p *OAuthPolicy) error {
 		}
 		if p.CredentialFile.Template == "" && len(p.CredentialFile.Structure) == 0 {
 			return fmt.Errorf("artifact: oauth: credentialFile requires either template or structure")
+		}
+	}
+	return nil
+}
+
+// ValidateOAuth validates a v2 credentials[].oauth block for structural
+// completeness. Same requirements as ValidateOAuthPolicy (its v1
+// counterpart), minus Service — that identity lives on the parent
+// Credential, not on OAuth itself — and with sentinels not required when
+// Passthrough is set: passthrough's whole point is opting out of sentinel
+// masking, so an entry that only routes+refreshes a token without ever
+// substituting a sentinel for it (e.g. resourceHosts-only OAuth routing)
+// legitimately has no sentinels block.
+//
+// Before this existed, neither of these was caught until much later: a
+// missing sentinels block (outside the passthrough case) loads and runs
+// with real OAuth tokens never masked in the sandbox, and a credentialFile
+// with neither template nor structure loads clean and only fails at first
+// `sbx create`, as an opaque engine error with the real cause buried in
+// daemon.log rather than at `sbx kit validate` time.
+func ValidateOAuth(o *OAuth) error {
+	if o == nil {
+		return nil
+	}
+	if o.TokenEndpoint.Host == "" {
+		return fmt.Errorf("oauth: tokenEndpoint.host is required")
+	}
+	if o.TokenEndpoint.Path == "" {
+		return fmt.Errorf("oauth: tokenEndpoint.path is required")
+	}
+	if !o.Passthrough {
+		if o.Sentinels.AccessToken == "" {
+			return fmt.Errorf("oauth: sentinels.accessToken is required")
+		}
+		if o.Sentinels.RefreshToken == "" {
+			return fmt.Errorf("oauth: sentinels.refreshToken is required")
+		}
+	}
+	if o.CredentialFile != nil {
+		if o.CredentialFile.Path == "" {
+			return fmt.Errorf("oauth: credentialFile.path is required")
+		}
+		if o.CredentialFile.Template == "" && len(o.CredentialFile.Structure) == 0 {
+			return fmt.Errorf("oauth: credentialFile requires either template or structure")
 		}
 	}
 	return nil

--- a/spec/validate_test.go
+++ b/spec/validate_test.go
@@ -672,9 +672,10 @@ func TestValidateArtifact(t *testing.T) {
 		require.ErrorContains(t, ValidateArtifact(a), "accessToken is required")
 	})
 
-	// The engine rejects an empty service at runtime in two places
-	// (NewOAuthInterceptorFromConfig, and the configure hook's "oauth service
-	// name cannot be empty"), so validate must catch it first.
+	// SPEC-v2 §5.4 makes service REQUIRED on every credential entry. For
+	// OAuth the engine additionally rejects an empty service at runtime in
+	// two places (NewOAuthInterceptorFromConfig, and the configure hook's
+	// "oauth service name cannot be empty"), so validate must catch it first.
 	t.Run("oauth_without_service_rejected", func(t *testing.T) {
 		a := &Artifact{
 			Manifest: Manifest{SchemaVersion: SchemaVersion, Kind: KindMixin, Name: "ok"},
@@ -685,7 +686,28 @@ func TestValidateArtifact(t *testing.T) {
 				},
 			}},
 		}
-		require.ErrorContains(t, ValidateArtifact(a), "service is required for an oauth credential")
+		require.ErrorContains(t, ValidateArtifact(a), "credentials[0]: service is required")
+	})
+
+	t.Run("apikey_without_service_rejected", func(t *testing.T) {
+		a := &Artifact{
+			Manifest: Manifest{SchemaVersion: SchemaVersion, Kind: KindMixin, Name: "ok"},
+			Credentials: []Credential{{
+				ApiKey: &ApiKey{Name: "SOME_TOKEN"},
+			}},
+		}
+		require.ErrorContains(t, ValidateArtifact(a), "credentials[0]: service is required")
+	})
+
+	// The v1 fold derives service keys from env-var names and keeps
+	// underscores, so §5.4's lowercase-kebab charset is not enforced on the
+	// canonical artifact — such kits must keep loading.
+	t.Run("non_kebab_service_accepted", func(t *testing.T) {
+		a := &Artifact{
+			Manifest:    Manifest{SchemaVersion: SchemaVersion, Kind: KindMixin, Name: "ok"},
+			Credentials: []Credential{{Service: "sample_proxy", ApiKey: &ApiKey{Name: "SAMPLE_PROXY_TOKEN"}}},
+		}
+		require.NoError(t, ValidateArtifact(a))
 	})
 
 	t.Run("oauth_credential_file_structure_only_accepted", func(t *testing.T) {

--- a/spec/validate_test.go
+++ b/spec/validate_test.go
@@ -483,6 +483,75 @@ func TestValidateOAuthPolicy(t *testing.T) {
 	})
 }
 
+func TestValidateOAuth(t *testing.T) {
+	t.Run("nil_is_valid", func(t *testing.T) {
+		require.NoError(t, ValidateOAuth(nil))
+	})
+
+	t.Run("missing_token_endpoint_host", func(t *testing.T) {
+		o := &OAuth{TokenEndpoint: OAuthTokenEndpoint{Path: "/token"}}
+		require.ErrorContains(t, ValidateOAuth(o), "host is required")
+	})
+
+	t.Run("missing_token_endpoint_path", func(t *testing.T) {
+		o := &OAuth{TokenEndpoint: OAuthTokenEndpoint{Host: "auth.example.com"}}
+		require.ErrorContains(t, ValidateOAuth(o), "path is required")
+	})
+
+	t.Run("missing_sentinels", func(t *testing.T) {
+		o := &OAuth{TokenEndpoint: OAuthTokenEndpoint{Host: "h", Path: "/p"}}
+		require.ErrorContains(t, ValidateOAuth(o), "accessToken is required")
+	})
+
+	t.Run("valid_full", func(t *testing.T) {
+		o := &OAuth{
+			TokenEndpoint: OAuthTokenEndpoint{Host: "h", Path: "/p"},
+			Sentinels:     OAuthSentinels{AccessToken: "at", RefreshToken: "rt"},
+		}
+		require.NoError(t, ValidateOAuth(o))
+	})
+
+	t.Run("credential_file_missing_path", func(t *testing.T) {
+		o := &OAuth{
+			TokenEndpoint:  OAuthTokenEndpoint{Host: "h", Path: "/p"},
+			Sentinels:      OAuthSentinels{AccessToken: "at", RefreshToken: "rt"},
+			CredentialFile: &OAuthCredentialFile{Template: "tmpl"},
+		}
+		require.ErrorContains(t, ValidateOAuth(o), "credentialFile.path is required")
+	})
+
+	t.Run("credential_file_missing_template_and_structure", func(t *testing.T) {
+		o := &OAuth{
+			TokenEndpoint:  OAuthTokenEndpoint{Host: "h", Path: "/p"},
+			Sentinels:      OAuthSentinels{AccessToken: "at", RefreshToken: "rt"},
+			CredentialFile: &OAuthCredentialFile{Path: "/cred"},
+		}
+		require.ErrorContains(t, ValidateOAuth(o), "credentialFile requires either template or structure")
+	})
+
+	t.Run("credential_file_structure_only_valid", func(t *testing.T) {
+		o := &OAuth{
+			TokenEndpoint:  OAuthTokenEndpoint{Host: "h", Path: "/p"},
+			Sentinels:      OAuthSentinels{AccessToken: "at", RefreshToken: "rt"},
+			CredentialFile: &OAuthCredentialFile{Path: "/cred", Structure: map[string]interface{}{"k": "{{.AccessToken}}"}},
+		}
+		require.NoError(t, ValidateOAuth(o))
+	})
+
+	t.Run("passthrough_does_not_require_sentinels", func(t *testing.T) {
+		o := &OAuth{
+			TokenEndpoint: OAuthTokenEndpoint{Host: "h", Path: "/p"},
+			Passthrough:   true,
+		}
+		require.NoError(t, ValidateOAuth(o))
+	})
+
+	t.Run("passthrough_still_requires_token_endpoint", func(t *testing.T) {
+		o := &OAuth{Passthrough: true}
+		require.ErrorContains(t, ValidateOAuth(o), "host is required")
+	})
+}
+
 func TestValidateArtifact(t *testing.T) {
 	t.Run("valid_mixin", func(t *testing.T) {
 		a := &Artifact{Manifest: Manifest{SchemaVersion: SchemaVersion, Kind: KindMixin, Name: "ok"}}
@@ -564,6 +633,59 @@ func TestValidateArtifact(t *testing.T) {
 		a := &Artifact{
 			Manifest: Manifest{SchemaVersion: "2", Kind: KindSandbox, Name: "ok"},
 			Extends:  "claude",
+		}
+		require.NoError(t, ValidateArtifact(a))
+	})
+
+	// Regression coverage for https://github.com/docker/sandboxes/issues/4835:
+	// a credentials[].oauth block with neither credentialFile.template nor
+	// .structure, or with no sentinels block at all, used to load as VALID
+	// and only fail much later — at first `sbx create`, as an opaque engine
+	// error, or (for missing sentinels) not at all, silently leaving real
+	// OAuth tokens unmasked in the sandbox.
+	t.Run("oauth_credential_file_neither_template_nor_structure_rejected", func(t *testing.T) {
+		a := &Artifact{
+			Manifest: Manifest{SchemaVersion: SchemaVersion, Kind: KindMixin, Name: "ok"},
+			Credentials: []Credential{{
+				Service: "anthropic",
+				OAuth: &OAuth{
+					TokenEndpoint:  OAuthTokenEndpoint{Host: "h", Path: "/p"},
+					Sentinels:      OAuthSentinels{AccessToken: "at", RefreshToken: "rt"},
+					CredentialFile: &OAuthCredentialFile{Path: "/cred"},
+				},
+			}},
+		}
+		err := ValidateArtifact(a)
+		require.ErrorContains(t, err, "credentials[0]")
+		require.ErrorContains(t, err, `"anthropic"`)
+		require.ErrorContains(t, err, "credentialFile requires either template or structure")
+	})
+
+	t.Run("oauth_missing_sentinels_rejected", func(t *testing.T) {
+		a := &Artifact{
+			Manifest: Manifest{SchemaVersion: SchemaVersion, Kind: KindMixin, Name: "ok"},
+			Credentials: []Credential{{
+				Service: "anthropic",
+				OAuth:   &OAuth{TokenEndpoint: OAuthTokenEndpoint{Host: "h", Path: "/p"}},
+			}},
+		}
+		require.ErrorContains(t, ValidateArtifact(a), "accessToken is required")
+	})
+
+	t.Run("oauth_credential_file_structure_only_accepted", func(t *testing.T) {
+		a := &Artifact{
+			Manifest: Manifest{SchemaVersion: SchemaVersion, Kind: KindMixin, Name: "ok"},
+			Credentials: []Credential{{
+				Service: "anthropic",
+				OAuth: &OAuth{
+					TokenEndpoint: OAuthTokenEndpoint{Host: "h", Path: "/p"},
+					Sentinels:     OAuthSentinels{AccessToken: "at", RefreshToken: "rt"},
+					CredentialFile: &OAuthCredentialFile{
+						Path:      "/cred",
+						Structure: map[string]interface{}{"accessToken": "{{.AccessToken}}"},
+					},
+				},
+			}},
 		}
 		require.NoError(t, ValidateArtifact(a))
 	})

--- a/spec/validate_test.go
+++ b/spec/validate_test.go
@@ -672,6 +672,22 @@ func TestValidateArtifact(t *testing.T) {
 		require.ErrorContains(t, ValidateArtifact(a), "accessToken is required")
 	})
 
+	// The engine rejects an empty service at runtime in two places
+	// (NewOAuthInterceptorFromConfig, and the configure hook's "oauth service
+	// name cannot be empty"), so validate must catch it first.
+	t.Run("oauth_without_service_rejected", func(t *testing.T) {
+		a := &Artifact{
+			Manifest: Manifest{SchemaVersion: SchemaVersion, Kind: KindMixin, Name: "ok"},
+			Credentials: []Credential{{
+				OAuth: &OAuth{
+					TokenEndpoint: OAuthTokenEndpoint{Host: "h", Path: "/p"},
+					Sentinels:     OAuthSentinels{AccessToken: "at", RefreshToken: "rt"},
+				},
+			}},
+		}
+		require.ErrorContains(t, ValidateArtifact(a), "service is required for an oauth credential")
+	})
+
 	t.Run("oauth_credential_file_structure_only_accepted", func(t *testing.T) {
 		a := &Artifact{
 			Manifest: Manifest{SchemaVersion: SchemaVersion, Kind: KindMixin, Name: "ok"},


### PR DESCRIPTION
## Summary

`ValidateArtifact` never validated OAuth credentials at all, so kit authors got no pre-flight signal for a malformed `credentials[].oauth` block. This is the spec-side half (a) of docker/sandboxes#4835.

The only OAuth validator in the package, `ValidateOAuthPolicy`, checks the **pre-normalize v1 `OAuthPolicy` shim** and has **zero callers** — it is exercised only by its own unit tests. The canonical v2 `Credential.OAuth` shape, which both v1 and v2 kits fold onto, had no validator wired in anywhere.

Confirmed reproductions that loaded as `VALID`:

- `credentialFile` with neither `template` nor `structure` → passed validation, then failed at first `sbx create` as an opaque engine error with the real cause buried in `daemon.log`.
- no `sentinels` block → passed validation, and would run with **real OAuth tokens never masked** in the sandbox.
- no `service` on an oauth credential → passed validation, then failed at runtime.

## What changed

- **`ValidateOAuth`** — the v2-shaped analogue of `ValidateOAuthPolicy`, minus `Service` (which v2 moved onto the parent `Credential`). Wired into `ValidateArtifact` over `a.Credentials`.
- **`service` is now required on every credential entry**, per SPEC-v2 §5.4. The engine rejects an empty one at runtime in two places (`NewOAuthInterceptorFromConfig`, and the configure hook's `"oauth service name cannot be empty"`).
- **`SPEC-v2.md` §6** now documents what `ValidateArtifact` checks for credentials — it previously did not mention them at all.
- Drive-by: `lockedPathPattern`'s doc comment used pre-rename example paths (`agent.image`, `network.allowedDomains`).

### Deliberately not enforced

**Sentinels are not required when `passthrough: true`.** SPEC-v2 §5.4.2 states "REQUIRED unless passthrough", and this mirrors the proxy's own runtime guard (`sandboxd/pkg/proxy/oauth_handler.go`) exactly — neither stricter nor looser — so a kit that validates here will not fail the interceptor later. Also required by the existing `v1_compat_test.go` fixture.

**§5.4's lowercase-kebab charset for `service` is not enforced.** The v1 fold derives service keys from env-var names via `deriveServiceKey`, which keeps underscores for any multi-word variable (`SAMPLE_PROXY_TOKEN` → `sample_proxy`, as in `spec/testdata/sample-mixin`). Enforcing it would reject v1 kits that load today. Reason recorded in both the code and §6.

## ⚠️ Behaviour change — worth a minor version bump

This introduces **new hard errors**: a malformed kit that loaded before will now fail `sbx kit validate` and `sbx create`. I verified **none of the 45 kits** in this repo or the engine's embedded agents breaks, and no credential anywhere has an empty `service` — but a third-party kit could. Suggest releasing as **v0.14.0**, not a patch.

## Test plan

- `TestValidateOAuth` (9 subtests) + 4 `ValidateArtifact`-level regression cases tied to #4835, including the passthrough exemption and the non-kebab-service acceptance.
- Verified against the issue's literal repro kits (`neither`, `nosentinel`): both now fail validation with an actionable message instead of reporting `VALID`.
- All 45 kits still load; `go test ./...`, `go vet ./...`, `gofmt` clean.

## Out of scope

- Part (b) of #4835 — placeholder-correctness pre-flight for `credentialFile.structure` (e.g. `{{.AcessToken}}`) — is engine-side, in `docker/sandboxes`.
- `ValidateOAuthPolicy` is left in place as dead-but-exported API rather than removed in this PR.