### PR TITLE
feat(spec): add V2View, the single internal -> v2 grammar projection

### DIFF
--- a/scripts/migrate-v1-to-v2.go
+++ b/scripts/migrate-v1-to-v2.go
@@ -190,172 +190,36 @@ func migrateSpec(data []byte) ([]byte, []string, error) {
 }
 
 // buildV2 assembles the canonical v2 output spec from a normalized Artifact.
-// The credentials/network/publishedPorts/kind values come from the normalized
-// Artifact (where the v1 → v2 consolidation already happened); the sandbox
-// entrypoint comes from srcSandbox (the raw source block) so the v1
-// run/args/ttyArgs split can be re-expressed as the v2 entrypoint + command
-// grammar. The v1 pipeMode has no v2 equivalent and is dropped.
-func buildV2(a *spec.Artifact, srcSandbox *rawSandbox) *outSpec {
-	out := &outSpec{
-		// Always emit the v2 schema version: a migrated kit is a fully-declared
-		// v2 spec. This is reached only when there were v1 constructs to migrate
-		// (callers gate on a non-empty change list), so a clean v2 spec is never
-		// rewritten just to touch this field.
-		SchemaVersion:  "2",
-		Kind:           a.Manifest.Kind,
-		Name:           a.Manifest.Name,
-		Version:        a.Manifest.Version,
-		DisplayName:    a.Manifest.DisplayName,
-		Description:    a.Manifest.Description,
-		SourceURL:      a.Manifest.SourceURL,
-		Extends:        a.Extends,
-		Requires:       a.Requires,
-		Locked:         a.Locked,
-		Volumes:        a.Manifest.Volumes,
-		Security:       a.Manifest.Security,
-		PublishedPorts: a.PublishedPorts,
-		Credentials:    a.Credentials,
-	}
+//
+// The internal → v2 grammar mapping itself lives in spec.NewV2View, which the
+// engine's `sbx kit inspect --json` renders from too — this tool used to keep
+// a second copy of that mapping, which is how it came to silently drop
+// `licenses:` and `mixins:` (neither had a field in the old local emit
+// struct, so a kit declaring them lost them on migration with no warning;
+// the re-parse safety net below only proves the output parses, not that it
+// preserved anything).
+//
+// Two things stay this tool's own concern:
+//
+//   - schemaVersion is forced to "2": a migrated kit is a fully-declared v2
+//     spec. This is reached only when there were v1 constructs to migrate
+//     (callers gate on a non-empty change list), so a clean v2 spec is never
+//     rewritten just to touch this field.
+//   - the sandbox entrypoint is restored from srcSandbox (the raw source
+//     block), so the v1 run/args/ttyArgs split is re-expressed faithfully as
+//     the v2 entrypoint + command grammar. NewV2View cannot recover that
+//     split from the canonical model — the loader folds the entrypoint tail
+//     into RunOptions — so having the source YAML here is what makes the
+//     migration lossless. The v1 pipeMode has no v2 equivalent and is dropped.
+func buildV2(a *spec.Artifact, srcSandbox *rawSandbox) *spec.V2View {
+	out := spec.NewV2View(a)
+	out.SchemaVersion = "2"
 
-	// agentInstructions: block — filename (was sandbox.aiFilename) +
-	// content (was top-level agentContext / v1 memory).
-	if a.Manifest.AIFilename != "" || a.AgentContext != "" {
-		out.AgentInstructions = &outAgentInstructions{
-			Filename: a.Manifest.AIFilename,
-			Content:  a.AgentContext,
-		}
-	}
-
-	// permissions.network block — allow/deny (was caps.network).
-	if a.Caps != nil && a.Caps.Network != nil &&
-		(len(a.Caps.Network.Allow) > 0 || len(a.Caps.Network.Deny) > 0) {
-		out.Permissions = &outPermissions{
-			Network: &outNetwork{Allow: a.Caps.Network.Allow, Deny: a.Caps.Network.Deny},
-		}
-	}
-
-	// setup: block — install/startup + files (was commands, with initFiles
-	// renamed to files).
-	if a.Commands != nil &&
-		(len(a.Commands.Install) > 0 || len(a.Commands.Startup) > 0 || len(a.Commands.InitFiles) > 0) {
-		out.Setup = &outSetup{
-			Install: a.Commands.Install,
-			Startup: a.Commands.Startup,
-			Files:   a.Commands.InitFiles,
-		}
-	}
-
-	srcEntry := v1Entrypoint(srcSandbox)
-	if a.Manifest.Template != "" || a.Manifest.Resources != nil || srcEntry != nil {
-		sb := &outSandbox{Image: a.Manifest.Template}
-		if srcEntry != nil {
-			sb.Entrypoint = srcEntry.Run
-			if len(srcEntry.Args) > 0 || len(srcEntry.TtyArgs) > 0 {
-				sb.Command = &outCommand{Default: srcEntry.Args, Interactive: srcEntry.TtyArgs}
-			}
-		}
-		if r := a.Manifest.Resources; r != nil {
-			or := &outResources{CPU: r.CPU, GPU: r.GPU}
-			if r.MemoryMB > 0 {
-				// MemoryMB is whole megabytes; emit the byte-size string the
-				// v2 grammar expects (round-trips through units.RAMInBytes).
-				or.Memory = fmt.Sprintf("%dm", r.MemoryMB)
-			}
-			sb.Resources = or
-		}
-		out.Sandbox = sb
-	}
-
-	if a.Environment != nil && len(a.Environment.Variables) > 0 {
-		out.Environment = &outEnv{Variables: a.Environment.Variables}
+	if srcEntry := v1Entrypoint(srcSandbox); srcEntry != nil {
+		out.SetSandboxEntrypoint(srcEntry.Run, srcEntry.Args, srcEntry.TtyArgs)
 	}
 
 	return out
-}
-
-// outSpec is the canonical v2 spec.yaml emit shape. Field order here is the
-// emit order; yaml.Marshal writes struct fields in declaration order. Folded
-// and removed v1 blocks (v1 network:, oauth:, settings:, credentials.sources,
-// environment.proxyManaged) deliberately have no field here, so they never
-// appear in the output.
-type outSpec struct {
-	SchemaVersion     string                `yaml:"schemaVersion"`
-	Kind              string                `yaml:"kind"`
-	Name              string                `yaml:"name"`
-	Version           string                `yaml:"version,omitempty"`
-	DisplayName       string                `yaml:"displayName,omitempty"`
-	Description       string                `yaml:"description,omitempty"`
-	SourceURL         string                `yaml:"sourceURL,omitempty"`
-	Extends           string                `yaml:"extends,omitempty"`
-  Requires          *spec.Requires        `yaml:"requires,omitempty"`
-	Locked            []string              `yaml:"locked,omitempty"`
-	Sandbox           *outSandbox           `yaml:"sandbox,omitempty"`
-	AgentInstructions *outAgentInstructions `yaml:"agentInstructions,omitempty"`
-	Permissions       *outPermissions       `yaml:"permissions,omitempty"`
-	Volumes           []spec.MountSpec      `yaml:"volumes,omitempty"`
-	Security          *spec.Security        `yaml:"security,omitempty"`
-	PublishedPorts    []spec.PublishedPort  `yaml:"ports,omitempty"`
-	Credentials       []spec.Credential     `yaml:"credentials,omitempty"`
-	Environment       *outEnv               `yaml:"environment,omitempty"`
-	Setup             *outSetup             `yaml:"setup,omitempty"`
-}
-
-// outSandbox is the v2 sandbox: block emit shape. entrypoint is the flat
-// process prefix; command carries the detached/interactive arg split.
-type outSandbox struct {
-	Image      string        `yaml:"image,omitempty"`
-	Entrypoint []string      `yaml:"entrypoint,omitempty"`
-	Command    *outCommand   `yaml:"command,omitempty"`
-	Resources  *outResources `yaml:"resources,omitempty"`
-}
-
-// outCommand is the sandbox.command emit shape (always the structured form;
-// the migrator does not collapse to the shorthand list).
-type outCommand struct {
-	Default     []string `yaml:"default,omitempty"`
-	Interactive []string `yaml:"interactive,omitempty"`
-}
-
-// outResources is the sandbox.resources emit shape with memory as a byte-size
-// string.
-type outResources struct {
-	CPU    float64 `yaml:"cpu,omitempty"`
-	Memory string  `yaml:"memory,omitempty"`
-	GPU    string  `yaml:"gpu,omitempty"`
-}
-
-// outAgentInstructions is the v2 top-level agentInstructions: block emit
-// shape. filename is only meaningful for a sandbox kit; for a mixin it is
-// empty (mixins carry no AIFilename) so it is omitted.
-type outAgentInstructions struct {
-	Filename string `yaml:"filename,omitempty"`
-	Content  string `yaml:"content,omitempty"`
-}
-
-// outPermissions is the v2 permissions: block emit shape; today it wraps only
-// the network egress policy.
-type outPermissions struct {
-	Network *outNetwork `yaml:"network,omitempty"`
-}
-
-// outNetwork is the v2 permissions.network block emit shape.
-type outNetwork struct {
-	Allow []string `yaml:"allow,omitempty"`
-	Deny  []string `yaml:"deny,omitempty"`
-}
-
-// outSetup is the v2 setup: block emit shape (install/startup + files).
-type outSetup struct {
-	Install []spec.InstallCommand `yaml:"install,omitempty"`
-	Startup []spec.StartupCommand `yaml:"startup,omitempty"`
-	Files   []spec.InitFile       `yaml:"files,omitempty"`
-}
-
-// outEnv is the environment: block emit shape, restricted to the canonical v2
-// variables: map (the removed proxyManaged list has no field and so is never
-// emitted).
-type outEnv struct {
-	Variables map[string]string `yaml:"variables,omitempty"`
 }
 
 // rawSpec / rawSandbox capture only the entrypoint node from the source

--- a/scripts/migrate_v1_to_v2_test.go
+++ b/scripts/migrate_v1_to_v2_test.go
@@ -4,8 +4,11 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
+
+	"github.com/docker/sbx-kits-contrib/spec"
 )
 
 // TestMigrateSpec_FullShape exercises a v1 spec.yaml that uses every v1 → v2
@@ -276,5 +279,46 @@ credentials: {sources: {openai: {env: [OPENAI_API_KEY]}}}
 	}
 	if !strings.Contains(string(out), "requires:") || !strings.Contains(string(out), "agent: claude") {
 		t.Fatalf("migrated output dropped 'requires.agent: claude':\n%s", out)
+	}
+}
+
+// TestMigrateSpec_PreservesLicensesAndMixins is a regression test for silent
+// data loss: the emitter used to be a hand-maintained struct local to this
+// tool, and it had no licenses/mixins fields — so a kit declaring either lost
+// it on migration, with no warning. The re-parse safety net did not catch it
+// because the output still parsed fine. The emit shape now comes from
+// spec.NewV2View, which covers the whole grammar.
+func TestMigrateSpec_PreservesLicensesAndMixins(t *testing.T) {
+	src := []byte(`schemaVersion: "1"
+kind: agent
+name: preserve
+licenses:
+  - MIT
+  - Apache-2.0
+mixins:
+  - some-mixin
+agent:
+  image: test/img:latest
+memory: |
+  ctx
+`)
+
+	out, changes, err := migrateSpec(src)
+	if err != nil {
+		t.Fatalf("migrateSpec: %v", err)
+	}
+	if len(changes) == 0 {
+		t.Fatal("expected v1 constructs to be migrated")
+	}
+
+	got, err := spec.LoadArtifactFromBytes(out)
+	if err != nil {
+		t.Fatalf("migrated spec failed to load: %v\n%s", err, out)
+	}
+	if want := []string{"MIT", "Apache-2.0"}; !slices.Equal(got.Licenses, want) {
+		t.Errorf("licenses: got %v, want %v\nmigrated spec:\n%s", got.Licenses, want, out)
+	}
+	if want := []string{"some-mixin"}; !slices.Equal(got.Mixins, want) {
+		t.Errorf("mixins: got %v, want %v\nmigrated spec:\n%s", got.Mixins, want, out)
 	}
 }

--- a/spec/v2view.go
+++ b/spec/v2view.go
@@ -1,0 +1,218 @@
+package spec
+
+import "fmt"
+
+// V2View is a loaded Artifact re-expressed in the canonical kit-spec v2
+// grammar (spec/SPEC-v2.md): the shape an author writes in a
+// `schemaVersion: "2"` spec.yaml.
+//
+// It exists because the canonical Artifact/Manifest field names are the
+// engine's internal vocabulary, and several are not valid v2 YAML keys at
+// all — `caps`, `commands.initFiles`, `agentContext`, `template`,
+// `resources.memoryMB`, `publishedPorts`. Anything that renders a kit back
+// out for a human (or back to disk) therefore needs this mapping, and two
+// consumers had grown their own copy of it: scripts/migrate-v1-to-v2.go and
+// the engine's `sbx kit inspect --json`. This is the single implementation
+// they share.
+//
+// Scope is deliberately the grammar only — the fields a spec.yaml can
+// contain. Load-time output (Artifact.Warnings) and artifact payload
+// (Artifact.Files) are not spec keys, so consumers that want to report them
+// embed V2View and add their own fields rather than having them appear here.
+//
+// Both `json` and `yaml` tags are set: the migrator emits YAML, `kit inspect`
+// emits JSON, and they must not drift.
+//
+// Field order is the emit order for YAML (yaml.Marshal writes fields in
+// declaration order) and matches the ordering the migrator has always
+// produced, so re-emitting an existing kit is byte-stable.
+type V2View struct {
+	SchemaVersion string `json:"schemaVersion" yaml:"schemaVersion"`
+	Kind          string `json:"kind" yaml:"kind"`
+	Name          string `json:"name" yaml:"name"`
+	Version       string `json:"version,omitempty" yaml:"version,omitempty"`
+	DisplayName   string `json:"displayName,omitempty" yaml:"displayName,omitempty"`
+	Description   string `json:"description,omitempty" yaml:"description,omitempty"`
+	SourceURL     string `json:"sourceURL,omitempty" yaml:"sourceURL,omitempty"`
+
+	Extends  string    `json:"extends,omitempty" yaml:"extends,omitempty"`
+	Mixins   []string  `json:"mixins,omitempty" yaml:"mixins,omitempty"`
+	Requires *Requires `json:"requires,omitempty" yaml:"requires,omitempty"`
+	Locked   []string  `json:"locked,omitempty" yaml:"locked,omitempty"`
+	Licenses []string  `json:"licenses,omitempty" yaml:"licenses,omitempty"`
+
+	Sandbox           *V2Sandbox           `json:"sandbox,omitempty" yaml:"sandbox,omitempty"`
+	AgentInstructions *V2AgentInstructions `json:"agentInstructions,omitempty" yaml:"agentInstructions,omitempty"`
+	Permissions       *V2Permissions       `json:"permissions,omitempty" yaml:"permissions,omitempty"`
+	Volumes           []MountSpec          `json:"volumes,omitempty" yaml:"volumes,omitempty"`
+	Security          *Security            `json:"security,omitempty" yaml:"security,omitempty"`
+	Ports             []PublishedPort      `json:"ports,omitempty" yaml:"ports,omitempty"`
+	Credentials       []Credential         `json:"credentials,omitempty" yaml:"credentials,omitempty"`
+	Environment       *V2Environment       `json:"environment,omitempty" yaml:"environment,omitempty"`
+	Setup             *V2Setup             `json:"setup,omitempty" yaml:"setup,omitempty"`
+}
+
+// V2Sandbox is the `sandbox:` block (SPEC-v2 §3.2). Image is the canonical
+// Manifest.Template.
+type V2Sandbox struct {
+	Image      string       `json:"image,omitempty" yaml:"image,omitempty"`
+	Build      *BuildConfig `json:"build,omitempty" yaml:"build,omitempty"`
+	Entrypoint []string     `json:"entrypoint,omitempty" yaml:"entrypoint,omitempty"`
+	Command    *V2Command   `json:"command,omitempty" yaml:"command,omitempty"`
+	Resources  *V2Resources `json:"resources,omitempty" yaml:"resources,omitempty"`
+}
+
+// V2Command is the structured `sandbox.command` form (SPEC-v2 §3.2.3). The
+// list shorthand is never emitted; the structured form is always valid.
+type V2Command struct {
+	Default     []string `json:"default,omitempty" yaml:"default,omitempty"`
+	Interactive []string `json:"interactive,omitempty" yaml:"interactive,omitempty"`
+}
+
+// V2Resources mirrors `sandbox.resources` with memory as the byte-size string
+// the v2 grammar uses, rather than the internal memoryMB integer.
+type V2Resources struct {
+	CPU    float64 `json:"cpu,omitempty" yaml:"cpu,omitempty"`
+	Memory string  `json:"memory,omitempty" yaml:"memory,omitempty"`
+	GPU    string  `json:"gpu,omitempty" yaml:"gpu,omitempty"`
+}
+
+// V2AgentInstructions is the `agentInstructions:` block (SPEC-v2 §5.1):
+// Filename was Manifest.AIFilename, Content was the top-level agentContext
+// (v1 `memory:`).
+type V2AgentInstructions struct {
+	Filename string `json:"filename,omitempty" yaml:"filename,omitempty"`
+	Content  string `json:"content,omitempty" yaml:"content,omitempty"`
+}
+
+// V2Permissions is the `permissions:` block (SPEC-v2 §5.2) — the v2 home of
+// the internal caps.
+type V2Permissions struct {
+	Network *V2Network `json:"network,omitempty" yaml:"network,omitempty"`
+}
+
+// V2Network is the `permissions.network` egress policy.
+type V2Network struct {
+	Allow []string `json:"allow,omitempty" yaml:"allow,omitempty"`
+	Deny  []string `json:"deny,omitempty" yaml:"deny,omitempty"`
+}
+
+// V2Environment is `environment:` (SPEC-v2 §5.5), restricted to the canonical
+// variables map. The internal EnvironmentPolicy also carries the removed v1
+// proxyManaged list; spelling the shape out here keeps it out of the output
+// rather than relying on that field's tags.
+type V2Environment struct {
+	Variables map[string]string `json:"variables,omitempty" yaml:"variables,omitempty"`
+}
+
+// V2Setup is the `setup:` block (SPEC-v2 §5.6) — the v2 home of the internal
+// commands, with initFiles spelled files.
+type V2Setup struct {
+	Install []InstallCommand `json:"install,omitempty" yaml:"install,omitempty"`
+	Startup []StartupCommand `json:"startup,omitempty" yaml:"startup,omitempty"`
+	Files   []InitFile       `json:"files,omitempty" yaml:"files,omitempty"`
+}
+
+// NewV2View projects a normalized Artifact into the v2 grammar. Empty blocks
+// are omitted entirely, so the result reads like a spec.yaml an author could
+// have written rather than a struct dump with zero values.
+//
+// SchemaVersion is carried through as-is; a caller that is rewriting a kit to
+// v2 (the migrator) sets it to "2" itself, so this stays a faithful
+// projection rather than silently claiming a version the input did not have.
+//
+// The sandbox entrypoint is reconstructed best-effort from
+// Manifest.Binary/RunOptions/InteractiveOptions. That recovers the effective
+// argv per mode exactly, but not the author's original
+// entrypoint-vs-command split: the loader folds a v2 entrypoint tail into
+// RunOptions/InteractiveOptions and the split is not retained anywhere. A
+// caller with access to the source YAML can restore the true split with
+// SetSandboxEntrypoint.
+func NewV2View(a *Artifact) *V2View {
+	m := &a.Manifest
+
+	v := &V2View{
+		SchemaVersion: m.SchemaVersion,
+		Kind:          m.Kind,
+		Name:          m.Name,
+		Version:       m.Version,
+		DisplayName:   m.DisplayName,
+		Description:   m.Description,
+		SourceURL:     m.SourceURL,
+		Extends:       a.Extends,
+		Mixins:        a.Mixins,
+		Requires:      a.Requires,
+		Locked:        a.Locked,
+		Licenses:      a.Licenses,
+		Volumes:       m.Volumes,
+		Security:      m.Security,
+		Ports:         a.PublishedPorts,
+		Credentials:   a.Credentials,
+	}
+
+	if m.AIFilename != "" || a.AgentContext != "" {
+		v.AgentInstructions = &V2AgentInstructions{
+			Filename: m.AIFilename,
+			Content:  a.AgentContext,
+		}
+	}
+
+	if a.Caps != nil && a.Caps.Network != nil &&
+		(len(a.Caps.Network.Allow) > 0 || len(a.Caps.Network.Deny) > 0) {
+		v.Permissions = &V2Permissions{
+			Network: &V2Network{Allow: a.Caps.Network.Allow, Deny: a.Caps.Network.Deny},
+		}
+	}
+
+	if a.Environment != nil && len(a.Environment.Variables) > 0 {
+		v.Environment = &V2Environment{Variables: a.Environment.Variables}
+	}
+
+	if c := a.Commands; c != nil &&
+		(len(c.Install) > 0 || len(c.Startup) > 0 || len(c.InitFiles) > 0) {
+		v.Setup = &V2Setup{Install: c.Install, Startup: c.Startup, Files: c.InitFiles}
+	}
+
+	hasEntrypoint := m.Binary != "" || len(m.RunOptions) > 0 || len(m.InteractiveOptions) > 0
+	if m.Template != "" || m.Build != nil || m.Resources != nil || hasEntrypoint {
+		sb := &V2Sandbox{Image: m.Template, Build: m.Build}
+		if m.Binary != "" {
+			sb.Entrypoint = []string{m.Binary}
+		}
+		if len(m.RunOptions) > 0 || len(m.InteractiveOptions) > 0 {
+			sb.Command = &V2Command{Default: m.RunOptions, Interactive: m.InteractiveOptions}
+		}
+		if r := m.Resources; r != nil {
+			rv := &V2Resources{CPU: r.CPU, GPU: r.GPU}
+			if r.MemoryMB > 0 {
+				// MemoryMB is whole megabytes; emit the byte-size string the
+				// v2 grammar expects (round-trips through units.RAMInBytes).
+				rv.Memory = fmt.Sprintf("%dm", r.MemoryMB)
+			}
+			sb.Resources = rv
+		}
+		v.Sandbox = sb
+	}
+
+	return v
+}
+
+// SetSandboxEntrypoint replaces the reconstructed entrypoint/command split
+// with an explicit one, for callers that can read the author's original
+// split from the source YAML (see NewV2View's note on why it cannot be
+// recovered from the canonical model). The sandbox block is created if the
+// projection did not produce one.
+//
+// A command block is emitted only when there is a mode-specific tail, so a
+// kit whose entrypoint carries everything stays free of an empty `command:`.
+func (v *V2View) SetSandboxEntrypoint(entrypoint, defaultArgs, interactiveArgs []string) {
+	if v.Sandbox == nil {
+		v.Sandbox = &V2Sandbox{}
+	}
+	v.Sandbox.Entrypoint = entrypoint
+	if len(defaultArgs) > 0 || len(interactiveArgs) > 0 {
+		v.Sandbox.Command = &V2Command{Default: defaultArgs, Interactive: interactiveArgs}
+		return
+	}
+	v.Sandbox.Command = nil
+}

--- a/spec/v2view_test.go
+++ b/spec/v2view_test.go
@@ -1,0 +1,166 @@
+package spec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
+)
+
+// TestNewV2View_RendersV2Grammar checks the internal → v2 block renames that
+// are the whole point of the projection: the canonical field names are the
+// engine's internal vocabulary and several are not valid v2 YAML keys.
+func TestNewV2View_RendersV2Grammar(t *testing.T) {
+	a := &Artifact{
+		Manifest: Manifest{
+			SchemaVersion: "1",
+			Kind:          KindSandbox,
+			Name:          "kit",
+			Template:      "img:latest",
+			AIFilename:    "AGENT.md",
+			Binary:        "agentbin",
+			RunOptions:    []string{"-l"},
+			Resources:     &Resources{CPU: 2, MemoryMB: 4096, GPU: "1"},
+		},
+		AgentContext: "ctx",
+		Caps:         &Caps{Network: &CapsNetwork{Allow: []string{"a.example.com"}}},
+		Environment:  &EnvironmentPolicy{Variables: map[string]string{"K": "v"}},
+		Commands:     &CommandsPolicy{InitFiles: []InitFile{{Path: "/p", Content: "c"}}},
+	}
+
+	v := NewV2View(a)
+
+	// template -> sandbox.image, memoryMB -> byte-size memory.
+	require.NotNil(t, v.Sandbox)
+	require.Equal(t, "img:latest", v.Sandbox.Image)
+	require.Equal(t, "4096m", v.Sandbox.Resources.Memory)
+	// aiFilename + agentContext -> agentInstructions.
+	require.Equal(t, "AGENT.md", v.AgentInstructions.Filename)
+	require.Equal(t, "ctx", v.AgentInstructions.Content)
+	// caps -> permissions.
+	require.Equal(t, []string{"a.example.com"}, v.Permissions.Network.Allow)
+	// commands.initFiles -> setup.files.
+	require.Len(t, v.Setup.Files, 1)
+	require.Equal(t, map[string]string{"K": "v"}, v.Environment.Variables)
+
+	// SchemaVersion is carried through, not silently promoted: only a caller
+	// rewriting the kit (the migrator) may claim "2".
+	require.Equal(t, "1", v.SchemaVersion)
+}
+
+// Empty blocks must be omitted so the output reads like an authored
+// spec.yaml rather than a struct dump.
+func TestNewV2View_OmitsEmptyBlocks(t *testing.T) {
+	v := NewV2View(&Artifact{
+		Manifest: Manifest{SchemaVersion: "2", Kind: KindMixin, Name: "m"},
+	})
+	require.Nil(t, v.Sandbox)
+	require.Nil(t, v.AgentInstructions)
+	require.Nil(t, v.Permissions)
+	require.Nil(t, v.Environment)
+	require.Nil(t, v.Setup)
+
+	out, err := yaml.Marshal(v)
+	require.NoError(t, err)
+	require.Equal(t, "schemaVersion: \"2\"\nkind: mixin\nname: m\n", string(out))
+}
+
+// A mixin must never gain a sandbox: block (SPEC-v2 §4.1 makes it a hard
+// error), so an artifact carrying nothing sandbox-shaped must not produce one.
+func TestNewV2View_NoSandboxBlockWithoutSandboxFields(t *testing.T) {
+	v := NewV2View(&Artifact{
+		Manifest:    Manifest{SchemaVersion: "2", Kind: KindMixin, Name: "m"},
+		Credentials: []Credential{{Service: "svc"}},
+	})
+	require.Nil(t, v.Sandbox)
+}
+
+func TestSetSandboxEntrypoint(t *testing.T) {
+	t.Run("restores_the_authors_split", func(t *testing.T) {
+		// The loader folds an entrypoint tail into RunOptions, so the
+		// projection alone cannot tell "entrypoint: [bin, --always]" from
+		// "entrypoint: [bin]" + "command.default: [--always]".
+		a := &Artifact{Manifest: Manifest{
+			SchemaVersion: "2", Kind: KindSandbox, Name: "k", Template: "img",
+			Binary: "bin", RunOptions: []string{"--always", "-l"},
+		}}
+		v := NewV2View(a)
+		require.Equal(t, []string{"bin"}, v.Sandbox.Entrypoint)
+		require.Equal(t, []string{"--always", "-l"}, v.Sandbox.Command.Default)
+
+		v.SetSandboxEntrypoint([]string{"bin", "--always"}, []string{"-l"}, nil)
+		require.Equal(t, []string{"bin", "--always"}, v.Sandbox.Entrypoint)
+		require.Equal(t, []string{"-l"}, v.Sandbox.Command.Default)
+	})
+
+	t.Run("no_command_block_when_no_tail", func(t *testing.T) {
+		v := NewV2View(&Artifact{Manifest: Manifest{
+			SchemaVersion: "2", Kind: KindSandbox, Name: "k", Template: "img",
+			Binary: "bin", RunOptions: []string{"-l"},
+		}})
+		v.SetSandboxEntrypoint([]string{"bin", "-l"}, nil, nil)
+		require.Nil(t, v.Sandbox.Command, "an empty command: block must not be emitted")
+	})
+
+	t.Run("creates_sandbox_block_if_absent", func(t *testing.T) {
+		v := NewV2View(&Artifact{Manifest: Manifest{SchemaVersion: "2", Kind: KindSandbox, Name: "k"}})
+		require.Nil(t, v.Sandbox)
+		v.SetSandboxEntrypoint([]string{"bin"}, nil, nil)
+		require.NotNil(t, v.Sandbox)
+		require.Equal(t, []string{"bin"}, v.Sandbox.Entrypoint)
+	})
+}
+
+// The emitted YAML must load back through the v2 grammar. This is what makes
+// the view safe to write to disk: a projection that emitted an internal name
+// would fail the v2 decoder's strict field check.
+func TestNewV2View_RoundTripsThroughV2Loader(t *testing.T) {
+	a := &Artifact{
+		Manifest: Manifest{
+			SchemaVersion: "2", Kind: KindSandbox, Name: "round", Template: "img:1",
+			Binary: "bin", RunOptions: []string{"-l"}, AIFilename: "A.md",
+			Resources: &Resources{MemoryMB: 2048},
+		},
+		AgentContext:   "ctx",
+		Licenses:       []string{"MIT"},
+		Caps:           &Caps{Network: &CapsNetwork{Allow: []string{"h.example.com"}, Deny: []string{"bad.example.com"}}},
+		PublishedPorts: []PublishedPort{{Container: 8080, Name: "web"}},
+		Environment:    &EnvironmentPolicy{Variables: map[string]string{"A": "b"}},
+		Commands:       &CommandsPolicy{Install: []InstallCommand{{Command: "echo hi"}}},
+	}
+
+	out, err := yaml.Marshal(NewV2View(a))
+	require.NoError(t, err)
+
+	got, err := LoadArtifactFromBytes(out)
+	require.NoError(t, err, "emitted v2 spec must load through the v2 grammar:\n%s", out)
+	require.Empty(t, got.Warnings, "a canonical v2 emit must not trigger deprecation warnings")
+
+	require.Equal(t, "img:1", got.Manifest.Template)
+	require.Equal(t, "A.md", got.Manifest.AIFilename)
+	require.Equal(t, "ctx", got.AgentContext)
+	require.Equal(t, []string{"MIT"}, got.Licenses)
+	require.Equal(t, []string{"h.example.com"}, got.Caps.Network.Allow)
+	require.Equal(t, []string{"bad.example.com"}, got.Caps.Network.Deny)
+	require.Len(t, got.PublishedPorts, 1)
+	require.Equal(t, int64(2048), got.Manifest.Resources.MemoryMB)
+	require.Len(t, got.Commands.Install, 1)
+}
+
+// Regression: licenses and mixins have no home in a hand-maintained emit
+// struct unless someone remembers to add them. They were both silently
+// dropped before this projection became the single implementation.
+func TestNewV2View_PreservesLicensesAndMixins(t *testing.T) {
+	v := NewV2View(&Artifact{
+		Manifest: Manifest{SchemaVersion: "2", Kind: KindSandbox, Name: "k", Template: "img"},
+		Licenses: []string{"MIT", "Apache-2.0"},
+		Mixins:   []string{"some-mixin"},
+	})
+	require.Equal(t, []string{"MIT", "Apache-2.0"}, v.Licenses)
+	require.Equal(t, []string{"some-mixin"}, v.Mixins)
+
+	out, err := yaml.Marshal(v)
+	require.NoError(t, err)
+	require.Contains(t, string(out), "licenses:")
+	require.Contains(t, string(out), "mixins:")
+}


### PR DESCRIPTION
## Summary

The canonical `Artifact`/`Manifest` field names are the engine's internal vocabulary, and several are **not valid kit-spec v2 YAML keys**: `caps`, `commands.initFiles`, `agentContext`, `template`, `resources.memoryMB`, `publishedPorts`. Anything that renders a kit back out — to disk, or to a human — needs that mapping, and two consumers had each grown their own copy:

- `scripts/migrate-v1-to-v2.go`'s local emit structs
- the engine's `sbx kit inspect --json` (in flight, `docker/sandboxes`)

`spec.NewV2View` becomes the single implementation, carrying **both `json` and `yaml` tags** so the migrator (YAML) and `inspect` (JSON) cannot drift.

Scope is the grammar only — the fields a `spec.yaml` can contain. `Artifact.Warnings` and `Artifact.Files` are not spec keys, so consumers that report them embed the view and add their own fields.

## 🐛 Fixes silent data loss

Found while consolidating: the migrator's hand-maintained emit struct had **no `licenses` or `mixins` field**, so a kit declaring either **lost it on migration, with no warning**. Reproduced on `main` — input with `licenses: [MIT]` + `mixins: [some-mixin]` produced output containing neither. The existing re-parse safety net could not catch it, because dropped output still parses fine.

`licenses` is legally meaningful (SPDX identifiers governing the kit, SPEC-v2 §2).

## What stays local to the migrator

Two concerns are deliberately not in the shared view:

1. **Forcing `schemaVersion: "2"`** — a migrated kit is a fully-declared v2 spec. `NewV2View` carries the version through as-is, so it stays a faithful projection rather than claiming a version the input did not have.
2. **Restoring the author's `entrypoint`/`command` split** from the raw source YAML, via `SetSandboxEntrypoint`. The loader folds a v2 entrypoint tail into `RunOptions`/`InteractiveOptions`, so the split cannot be recovered from the canonical model — having the source YAML is what makes the migration lossless. A consumer without it (e.g. `inspect` on an OCI ref) gets exact per-mode argv but not the author's chosen split.

## Test plan

- **Behaviour-preserving**: the `scripts/testdata/v2-expected` golden fixture is **byte-identical** — I kept `V2View`'s field order matching the old emitter specifically so this is provable rather than asserted.
- **Round-trip test**: the emitted YAML loads back through the v2 grammar with **zero deprecation warnings** — a projection leaking an internal name would fail strict decoding.
- Regression tests for the licenses/mixins loss at both levels (`spec` and `scripts`).
- All 45 kits in this repo plus the engine's embedded agents still load; `go test ./...`, `go vet ./...`, `gofmt` clean.
- Net −85 lines of duplicated emit structs.

## Notes for reviewers

- Independent of the other two open spec PRs — no file overlap; all three merge cleanly in any order.
- The second copy of this mapping disappears when `docker/sandboxes` bumps to the release containing this, which is the plan for the `kit inspect` PR there.