### PR TITLE
feat(docker): add docker mixin kit; start dockerd in nanoclaw for sbx

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,46 @@
+# docker
+
+Starts Docker Engine (`dockerd`) inside the sandbox, so the agent can build
+and run nested containers. The sandbox is a microVM, so this is ordinary
+Docker on a VM, not privileged-container DinD.
+
+## Usage
+
+Compose with any agent kit:
+
+```console
+$ sbx run --kit <agent-kit> --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=docker" <agent>
+```
+
+Works on `sbx --cloud` too. On cloud this mixin is what starts the daemon.
+On local sbx the runtime usually starts it first and this mixin is a no-op.
+
+## Requirements
+
+- The image must ship `dockerd` (any `-docker` template does). The mixin
+  starts Docker, it does not install it. If `dockerd` is missing, the
+  startup command fails with a message saying so.
+- `curl` must be present (all `-docker` templates ship it). It is the
+  socket probe.
+- On local sbx, the base image must carry the
+  `com.docker.sandboxes.start-docker` label (`-docker` templates do).
+  Privileged mode and the `/var/lib/docker` volume come from that label,
+  not from this mixin.
+
+## How it works
+
+The startup command is idempotent. It pings `/var/run/docker.sock` and
+exits 0 if a daemon already answers. Otherwise it launches `dockerd`
+detached, logging to `/var/log/dockerd.log`, and polls the socket for up
+to 30 seconds. On timeout it fails and prints the log tail.
+
+When `HTTP_PROXY` is set and `/etc/docker/daemon.json` does not exist, the
+script writes a daemon.json with a `proxies` block so inner `docker pull`
+traverses the sandbox egress proxy. An existing daemon.json is never
+modified.
+
+## Network policy
+
+The kit allows the Docker Hub registry domains. If your inner containers
+pull from other registries (ghcr.io, quay.io, ...), add those domains to
+your own kit or sandbox policy.

--- a/docker/README.md
+++ b/docker/README.md
@@ -12,9 +12,6 @@ Compose with any agent kit:
 $ sbx run --kit <agent-kit> --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=docker" <agent>
 ```
 
-Works on `sbx --cloud` too. On cloud this mixin is what starts the daemon.
-On local sbx the runtime usually starts it first and this mixin is a no-op.
-
 ## Requirements
 
 - The image must ship `dockerd` (any `-docker` template does). The mixin

--- a/docker/README.md
+++ b/docker/README.md
@@ -44,3 +44,4 @@ modified.
 The kit allows the Docker Hub registry domains. If your inner containers
 pull from other registries (ghcr.io, quay.io, ...), add those domains to
 your own kit or sandbox policy.
+

--- a/docker/spec.yaml
+++ b/docker/spec.yaml
@@ -1,0 +1,60 @@
+schemaVersion: "1"
+kind: mixin
+name: docker
+displayName: Docker
+description: "Starts Docker Engine inside the sandbox for kits and agents that run nested containers. Requires an image that ships dockerd (any -docker template). Routes inner registry pulls through the sandbox egress proxy."
+
+caps:
+  network:
+    allow:
+      # Inner `docker pull` from Docker Hub. Other registries are the
+      # consuming kit's responsibility.
+      - "auth.docker.io:443"
+      - "index.docker.io:443"
+      - "production.cloudflare.docker.com:443"
+      - "registry-1.docker.io:443"
+
+commands:
+  startup:
+    - command:
+        - sh
+        - -c
+        - |
+          set -eu
+          # Success is keyed on "the Docker socket answers", never on "this
+          # script's dockerd survived". Local sbx's EnsureDockerd may already
+          # have started the daemon, and re-runs must be no-ops.
+          ping_docker() {
+            curl -sf --unix-socket /var/run/docker.sock http://localhost/_ping >/dev/null 2>&1
+          }
+          if ping_docker; then
+            echo "docker mixin: dockerd already running"
+            exit 0
+          fi
+          if ! command -v dockerd >/dev/null 2>&1; then
+            echo "docker mixin: dockerd not found in this image. Use a -docker template or an image that ships Docker Engine." >&2
+            exit 1
+          fi
+          # Route inner registry pulls through the sandbox egress proxy.
+          # Never touch an existing daemon.json.
+          if [ -n "${HTTP_PROXY:-}" ] && [ ! -f /etc/docker/daemon.json ]; then
+            mkdir -p /etc/docker
+            printf '{\n  "proxies": {\n    "http-proxy": "%s",\n    "https-proxy": "%s",\n    "no-proxy": "%s"\n  }\n}\n' \
+              "$HTTP_PROXY" "${HTTPS_PROXY:-$HTTP_PROXY}" "${NO_PROXY:-}" >/etc/docker/daemon.json
+          fi
+          : >/var/log/dockerd.log
+          nohup dockerd >>/var/log/dockerd.log 2>&1 &
+          i=0
+          while [ "$i" -lt 60 ]; do
+            if ping_docker; then
+              echo "docker mixin: dockerd started"
+              exit 0
+            fi
+            i=$((i + 1))
+            sleep 0.5
+          done
+          echo "docker mixin: dockerd did not become ready within 30s. Log tail:" >&2
+          tail -n 50 /var/log/dockerd.log >&2
+          exit 1
+      user: "0"
+      description: Start dockerd when the image ships it and nothing answers on the Docker socket

--- a/nanoclaw/README.md
+++ b/nanoclaw/README.md
@@ -21,6 +21,15 @@ Or with a local clone of this repository:
 $ sbx run --name nanoclaw --kit ./nanoclaw nanoclaw
 ```
 
+NanoClaw also runs on Docker Sandboxes Cloud:
+
+```console
+$ sbx --cloud run --name nanoclaw --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=nanoclaw" nanoclaw
+```
+
+The kit starts the sandbox's inner Docker daemon itself (see the `docker`
+mixin in this repo), so no local-runtime Docker support is assumed.
+
 The `--name nanoclaw` flag gives the sandbox a stable name for follow-up
 commands such as `sbx exec`, `sbx policy ls`, and `sbx rm`.
 

--- a/nanoclaw/README.md
+++ b/nanoclaw/README.md
@@ -21,15 +21,6 @@ Or with a local clone of this repository:
 $ sbx run --name nanoclaw --kit ./nanoclaw nanoclaw
 ```
 
-NanoClaw also runs on Docker Sandboxes Cloud:
-
-```console
-$ sbx --cloud run --name nanoclaw --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=nanoclaw" nanoclaw
-```
-
-The kit starts the sandbox's inner Docker daemon itself (see the `docker`
-mixin in this repo), so no local-runtime Docker support is assumed.
-
 The `--name nanoclaw` flag gives the sandbox a stable name for follow-up
 commands such as `sbx exec`, `sbx policy ls`, and `sbx rm`.
 

--- a/nanoclaw/spec.yaml
+++ b/nanoclaw/spec.yaml
@@ -65,6 +65,57 @@ environment:
     NO_PROXY: "127.0.0.1,localhost"
     no_proxy: "127.0.0.1,localhost"
 
+commands:
+  startup:
+    # SYNCed with the docker mixin (../docker/spec.yaml): update both
+    # together. Runtime mixin composition is not applied yet; when
+    # `mixins:` goes live, replace this block with `mixins: [docker]`.
+    # On local sbx the runtime starts dockerd anyway and this is a no-op.
+    # On `sbx --cloud` this block is what starts the daemon the seed
+    # script and nested agent containers need.
+    - command:
+        - sh
+        - -c
+        - |
+          set -eu
+          # Success is keyed on "the Docker socket answers", never on "this
+          # script's dockerd survived". Local sbx's EnsureDockerd may already
+          # have started the daemon, and re-runs must be no-ops.
+          ping_docker() {
+            curl -sf --unix-socket /var/run/docker.sock http://localhost/_ping >/dev/null 2>&1
+          }
+          if ping_docker; then
+            echo "docker mixin: dockerd already running"
+            exit 0
+          fi
+          if ! command -v dockerd >/dev/null 2>&1; then
+            echo "docker mixin: dockerd not found in this image. Use a -docker template or an image that ships Docker Engine." >&2
+            exit 1
+          fi
+          # Route inner registry pulls through the sandbox egress proxy.
+          # Never touch an existing daemon.json.
+          if [ -n "${HTTP_PROXY:-}" ] && [ ! -f /etc/docker/daemon.json ]; then
+            mkdir -p /etc/docker
+            printf '{\n  "proxies": {\n    "http-proxy": "%s",\n    "https-proxy": "%s",\n    "no-proxy": "%s"\n  }\n}\n' \
+              "$HTTP_PROXY" "${HTTPS_PROXY:-$HTTP_PROXY}" "${NO_PROXY:-}" >/etc/docker/daemon.json
+          fi
+          : >/var/log/dockerd.log
+          nohup dockerd >>/var/log/dockerd.log 2>&1 &
+          i=0
+          while [ "$i" -lt 60 ]; do
+            if ping_docker; then
+              echo "docker mixin: dockerd started"
+              exit 0
+            fi
+            i=$((i + 1))
+            sleep 0.5
+          done
+          echo "docker mixin: dockerd did not become ready within 30s. Log tail:" >&2
+          tail -n 50 /var/log/dockerd.log >&2
+          exit 1
+      user: "0"
+      description: Start dockerd when the image ships it and nothing answers on the Docker socket
+
 agentContext: |
   ## Sandbox environment
 

--- a/nanoclaw/spec.yaml
+++ b/nanoclaw/spec.yaml
@@ -71,8 +71,6 @@ commands:
     # together. Runtime mixin composition is not applied yet; when
     # `mixins:` goes live, replace this block with `mixins: [docker]`.
     # On local sbx the runtime starts dockerd anyway and this is a no-op.
-    # On `sbx --cloud` this block is what starts the daemon the seed
-    # script and nested agent containers need.
     - command:
         - sh
         - -c


### PR DESCRIPTION
Kits that need Docker inside the sandbox.

The new `docker` mixin's single startup command starts dockerd idempotently. Success is keyed on the Docker socket answering, so it composes with local sbx's own dockerd startup. It writes proxy config from `HTTP_PROXY` only when `/etc/docker/daemon.json` is absent, and it fails clearly when the image ships no dockerd. The nanoclaw kit embeds the identical entry (SYNC comment; runtime `mixins:` composition is not applied yet).

Test plan: TCK green for both kits. Script exercised in privileged `shell-docker` containers through the `sudo -u '#0'` wrapper: cold start plus `hello-world`, idempotent re-run, missing-dockerd guard, proxy file. Draft until a stage run passes.

Generated with [Claude Code](https://claude.com/claude-code)
