### PR TITLE
docs(spec): make LoadFromBytes v1-only scope explicit and its failure actionable

### DIFF
--- a/spec/artifact.go
+++ b/spec/artifact.go
@@ -225,9 +225,23 @@ func LoadArtifactFromBytes(yamlBytes []byte) (*Artifact, error) {
 	return parseArtifactBytes(yamlBytes)
 }
 
-// LoadFromBytes parses spec.yaml bytes into a normalized SpecFile.
-// Normalization (v1 sugar folding, legacy field removal, and canonical
-// v2 shaping for marshal) happens inside this call, mirroring LoadArtifactFromBytes.
+// LoadFromBytes parses spec.yaml bytes into a normalized SpecFile using the
+// **v1 grammar only**. Normalization (v1 sugar folding, legacy field removal)
+// happens inside this call. Unlike LoadArtifactFromBytes it does not fork on
+// schemaVersion: a `schemaVersion: "2"` document is rejected, because the v2
+// grammar's field names do not exist on SpecFile.
+//
+// For v2 (or version-agnostic) input, load the artifact and project it back to
+// the v2 grammar instead:
+//
+//	art, err := spec.LoadArtifactFromBytes(data)
+//	view := spec.NewV2View(art)
+//
+// V2View is the flat, YAML-shaped struct SpecFile consumers usually want — the
+// spec keys an author writes, with no nested Manifest.
+//
+// Deprecated: LoadFromBytes only understands the frozen v1 grammar. Use
+// LoadArtifactFromBytes with NewV2View.
 func LoadFromBytes(yamlBytes []byte) (*SpecFile, error) {
 	return parseSpecFileBytes(yamlBytes)
 }
@@ -312,9 +326,18 @@ func decodeSpecFile(data []byte) (SpecFile, error) {
 	return spec, nil
 }
 
+// parseSpecFileBytes decodes spec.yaml bytes with the frozen v1 grammar and
+// normalizes them. There is deliberately no schemaVersion fork here — SpecFile
+// is the v1 shape — but a v2 document failing strict decoding produces a raw
+// unknown-field error naming an internal Go type, which tells the author
+// nothing. Detect that case and say what actually happened, keeping the
+// underlying error wrapped.
 func parseSpecFileBytes(data []byte) (*SpecFile, error) {
 	spec, err := decodeSpecFile(data)
 	if err != nil {
+		if peekSchemaVersion(data) == "2" {
+			return nil, fmt.Errorf("spec: %s declares schemaVersion \"2\", which this loader does not decode — it understands the v1 grammar only; use LoadArtifactFromBytes (then NewV2View for the v2 grammar shape): %w", specFileName, err)
+		}
 		return nil, fmt.Errorf("spec: invalid %s: %w", specFileName, err)
 	}
 	w := &warnings{}

--- a/spec/artifact.go
+++ b/spec/artifact.go
@@ -225,11 +225,17 @@ func LoadArtifactFromBytes(yamlBytes []byte) (*Artifact, error) {
 	return parseArtifactBytes(yamlBytes)
 }
 
-// LoadFromBytes parses spec.yaml bytes into a normalized SpecFile using the
-// **v1 grammar only**. Normalization (v1 sugar folding, legacy field removal)
-// happens inside this call. Unlike LoadArtifactFromBytes it does not fork on
-// schemaVersion: a `schemaVersion: "2"` document is rejected, because the v2
-// grammar's field names do not exist on SpecFile.
+// LoadFromBytes parses spec.yaml bytes into a normalized SpecFile using the v1
+// grammar only. Normalization (v1 sugar folding, legacy field removal) happens
+// inside this call.
+//
+// Unlike LoadArtifactFromBytes it does not fork on schemaVersion, so what happens
+// to a schemaVersion: "2" document depends on which keys it uses. Names the v1
+// grammar does not have (permissions, setup, agentInstructions) fail the strict
+// decode and return an error naming this limitation. Names v1 also has
+// (environment, credentials, sandbox) decode under the v1 shape instead, as does
+// a document carrying none of them — so a v2 spec can appear to load here. Treat
+// neither outcome as a contract: this entry point is not version-aware.
 //
 // For v2 (or version-agnostic) input, load the artifact and project it back to
 // the v2 grammar instead:

--- a/spec/normalize_test.go
+++ b/spec/normalize_test.go
@@ -374,4 +374,31 @@ displayName: Normalize Kit
 		require.Equal(t, fromBytes.Manifest.Name, sf.Name)
 		require.Equal(t, fromBytes.Manifest.Kind, sf.Kind)
 	})
+
+	// LoadFromBytes decodes the v1 grammar only. A v2 spec must fail with an
+	// error that says so and names the API that does handle v2, rather than a
+	// raw unknown-field error about an internal Go type.
+	t.Run("v2_input_is_actionable_error", func(t *testing.T) {
+		in := []byte(`schemaVersion: "2"
+kind: mixin
+name: cloudflare-dns
+permissions:
+  network:
+    allow:
+      - api.cloudflare.com
+`)
+		// The v2 artifact loader handles this input fine.
+		_, err := LoadArtifactFromBytes(in)
+		require.NoError(t, err)
+
+		sf, err := LoadFromBytes(in)
+		require.Nil(t, sf)
+		require.Error(t, err)
+		require.ErrorContains(t, err, `schemaVersion "2"`)
+		require.ErrorContains(t, err, "v1 grammar only")
+		require.ErrorContains(t, err, "LoadArtifactFromBytes")
+		require.ErrorContains(t, err, "NewV2View")
+		// The underlying decode error is still wrapped, not swallowed.
+		require.ErrorContains(t, err, "field permissions not found")
+	})
 }


### PR DESCRIPTION
## Summary

`LoadFromBytes` silently rejects every `schemaVersion: "2"` spec, and its doc
comment claims otherwise. This corrects the documented scope and makes the failure
self-explanatory. **No behaviour change** — what the loader accepts is untouched.

Found while investigating why a third-party kit
([`mikesir87/sbx-kit-cloudflare-dns`](https://github.com/mikesir87/sbx-kit-cloudflare-dns))
appeared to fail parsing. The kit is correct; the caller had reached for the v1-only
entry point.

## The problem

`parseArtifactBytes` forks on `schemaVersion` into the v2 grammar. Its sibling
`parseSpecFileBytes` has no such fork and always uses the frozen v1 decoder. So the
public `LoadFromBytes` fails on any v2 input, with an error naming an internal type:

```
spec: invalid spec.yaml: yaml: unmarshal errors:
  line 13: field permissions not found in type spec.SpecFile
```

Nothing in that message suggests the real cause — the input is a v2 spec and this
loader only understands v1 — so it reads as "the spec is malformed" or "`permissions`
isn't a real field". Both wrong. Its doc comment made it worse by claiming the call
mirrors `LoadArtifactFromBytes`, which stopped being true when the v2 grammar landed.

## The change

- Doc comment states the **v1-grammar-only** scope, and points at
  `LoadArtifactFromBytes` + `NewV2View` — that pair returns a flat, YAML-shaped
  struct with no nested `Manifest`, which is what callers reaching for `SpecFile`
  actually want.
- A `// Deprecated:` marker, so editors and linters surface it at the call site.
- On the decode-failure path only, when the input carries `schemaVersion: "2"`, an
  actionable error naming the version, the limitation, and the right API. The
  original error stays `%w`-wrapped:

```
spec: spec.yaml declares schemaVersion "2", which this loader does not decode —
it understands the v1 grammar only; use LoadArtifactFromBytes (then NewV2View for
the v2 grammar shape): yaml: unmarshal errors: line 13: field permissions not
found in type spec.SpecFile
```

## Deliberately out of scope

**Whether `LoadFromBytes` should gain v2 support is a design decision for the
package owner**, not something to smuggle into an error-message fix. `SpecFile` is
the v1 grammar struct, so teaching it v2 would mean projecting v2 back into a v1
shape — which is what `NewV2View` already does from the other direction. This PR
only stops the current behaviour from being surprising.

Known limitation, stated rather than fixed: a *minimal* v2 document (only
`schemaVersion`/`kind`/`name`) still decodes successfully under the v1 shape, since
nothing v2-specific is present to trip the strict decoder. Erroring on it would
change what the loader accepts — same reason as above.

## Test plan

- [x] `go test ./...` passes and `go vet ./...` is clean **on this branch alone**
      (re-verified after narrowing, not just on the original combined branch).
- [x] `TestLoadFromBytes/v2_input_is_actionable_error` asserts the new message and
      that the wrapped decode error survives.
- [x] Verified against the real third-party kit, not just fixtures.
- n/a — kit e2e / `sbx kit validate` / manual smoke: no kit changes. Note that
      touching `spec/` makes `tck.yml` run the TCK **and** e2e for every kit, so the
      matrix is exercised broadly anyway.

## Related

Split out of the original combined PR so each piece is one idea:

- **#179** — `fix(spec)`: `scheme: bearer` must set the `Authorization` header. The
  only behaviour change of the set, and the one worth landing first.
- Branch `spec-doc-corrections` (no PR yet) — the remaining doc/code mismatches:
  enforcement ownership, and `sandbox.image` vs `sandbox.build`. Held back because it
  also carried the `sshAgent` correction, which needs rewording: agent forwarding
  *is* implemented in sbx, it is the `hosts`/`identities` scoping that is not, and
  "declared only" alone would imply SSH forwarding is unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
