### PR TITLE
fix(spec): scheme bearer must set the Authorization header

### DIFF
--- a/skills/kit-author/topics/spec-anatomy.md
+++ b/skills/kit-author/topics/spec-anatomy.md
@@ -226,6 +226,8 @@ credentials:
 
 `scheme` and a raw `format` are **mutually exclusive** — set one or the other, not both. On the normalized artifact `scheme` is expanded away, so consumers only ever read `header` / `format` / `username`. You can still write `header` + `format` directly when you need a header the sugar doesn't cover.
 
+`bearer` supplies `header: Authorization` only when you left `header` empty, so writing an explicit `header:` alongside it still wins. `basic` is username-driven at the proxy rather than a header encoding, so it sets no `header` at all — write one yourself if the service needs a specific one.
+
 **Validation:** every `apiKey.inject[].domain` MUST appear in `permissions.network.allow`. The spec library rejects a kit whose injection domain isn't allow-listed — there is no auto-derived egress from credentials.
 
 ### OAuth shape

--- a/spec/SPEC-v2.md
+++ b/spec/SPEC-v2.md
@@ -566,6 +566,11 @@ credentials:
 | `bearer` | `header: Authorization`, `format: "Bearer %s"` | `username` MUST NOT be set. |
 | `basic` | HTTP Basic Auth (username-driven at the proxy) | `username` is REQUIRED. |
 
+`bearer` fills in `header` only when the author left it empty, so an explicit
+`header:` still wins (Bearer-formatted value, non-standard header). `basic` is
+username-driven at the proxy rather than a header encoding, so it sets no
+`header` — write one explicitly if the service needs a specific one.
+
 #### 5.4.2 `oauth`
 
 ```yaml

--- a/spec/artifact_test.go
+++ b/spec/artifact_test.go
@@ -91,6 +91,18 @@ func TestLoadFromDirectory(t *testing.T) {
 		}
 		require.ElementsMatch(t, []string{"anthropic", "github", "workos"}, services)
 
+		// The github credential exercises the `scheme:` sugar with no explicit
+		// header:, so bearer must supply the Authorization header itself.
+		for _, c := range a.Credentials {
+			if c.Service != "github" {
+				continue
+			}
+			require.Len(t, c.ApiKey.Inject, 2)
+			require.Equal(t, "Authorization", c.ApiKey.Inject[0].Header)
+			require.Equal(t, "Bearer %s", c.ApiKey.Inject[0].Format)
+			require.Empty(t, c.ApiKey.Inject[0].Scheme)
+		}
+
 		require.Len(t, a.Manifest.Volumes, 2)
 		require.NotNil(t, a.Commands)
 		require.NotEmpty(t, a.Commands.Startup)

--- a/spec/testdata/sample-agent-v2/spec.yaml
+++ b/spec/testdata/sample-agent-v2/spec.yaml
@@ -56,8 +56,9 @@ credentials:
     apiKey:
       name: GITHUB_TOKEN
       inject:
+        # scheme: bearer is the whole Authorization header — no header: here,
+        # so the sugar is what fills it in.
         - domain: api.github.com
-          header: Authorization
           scheme: bearer
         - domain: github.com
           header: Authorization

--- a/spec/v2.go
+++ b/spec/v2.go
@@ -276,9 +276,16 @@ func (s *specFileV2) toArtifact(w *warnings) (*Artifact, error) {
 }
 
 // expandCredentialSchemes rewrites the v2 `scheme:` sugar on apiKey inject
-// entries into the canonical Format/Username fields, then clears Scheme so the
-// normalized Artifact carries only the fields consumers already read. scheme
-// and a raw format are mutually exclusive.
+// entries into the canonical Header/Format/Username fields, then clears Scheme
+// so the normalized Artifact carries only the fields consumers already read.
+// scheme and a raw format are mutually exclusive.
+//
+// `scheme: bearer` is sugar for the whole `Authorization: Bearer <token>`
+// header, so it fills in Header as well as Format — Header is the only carrier
+// of the header name on the normalized artifact, and leaving it empty produced
+// an inject entry that validated clean but injected nothing. An explicit
+// `header:` always wins, so an author can point Bearer-formatted values at a
+// non-standard header.
 func expandCredentialSchemes(creds []Credential) ([]Credential, error) {
 	for i := range creds {
 		if creds[i].ApiKey == nil {
@@ -298,6 +305,9 @@ func expandCredentialSchemes(creds []Credential) ([]Credential, error) {
 					return nil, fmt.Errorf("credentials[%d].apiKey.inject[%d]: 'username' is not valid with scheme: bearer", i, j)
 				}
 				inj.Format = "Bearer %s"
+				if inj.Header == "" {
+					inj.Header = "Authorization"
+				}
 			case "basic":
 				if inj.Username == "" {
 					return nil, fmt.Errorf("credentials[%d].apiKey.inject[%d]: scheme: basic requires 'username'", i, j)

--- a/spec/v2_scheme_test.go
+++ b/spec/v2_scheme_test.go
@@ -1,0 +1,91 @@
+package spec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// v2SchemeSpec builds a minimal v2 mixin whose single apiKey inject entry is
+// the block passed in, so each case below is just the inject fields.
+func v2SchemeSpec(inject string) []byte {
+	return []byte(`schemaVersion: "2"
+kind: mixin
+name: scheme-kit
+permissions:
+  network:
+    allow:
+      - api.cloudflare.com
+credentials:
+  - service: cloudflare-api
+    apiKey:
+      name: CLOUDFLARE_API_TOKEN
+      inject:
+        - domain: api.cloudflare.com
+` + inject)
+}
+
+// scheme: bearer is sugar for the complete Authorization header. Header is the
+// only carrier of the header name on the normalized artifact, so the sugar must
+// fill it in; a kit that writes `scheme: bearer` with no `header:` used to load
+// and validate clean while injecting into no header at all.
+func TestSchemeBearer_SetsAuthorizationHeader(t *testing.T) {
+	a, err := LoadArtifactFromBytes(v2SchemeSpec("          scheme: bearer\n"))
+	require.NoError(t, err)
+
+	inj := a.Credentials[0].ApiKey.Inject[0]
+	require.Equal(t, "Authorization", inj.Header)
+	require.Equal(t, "Bearer %s", inj.Format)
+	require.Empty(t, inj.Scheme, "scheme is expanded away on the normalized artifact")
+	require.NoError(t, ValidateArtifact(a))
+}
+
+// An explicit header: wins — Bearer-formatted values can target a
+// non-standard header.
+func TestSchemeBearer_ExplicitHeaderPreserved(t *testing.T) {
+	a, err := LoadArtifactFromBytes(v2SchemeSpec("          header: X-Auth\n          scheme: bearer\n"))
+	require.NoError(t, err)
+
+	inj := a.Credentials[0].ApiKey.Inject[0]
+	require.Equal(t, "X-Auth", inj.Header)
+	require.Equal(t, "Bearer %s", inj.Format)
+}
+
+// scheme: basic is username-driven at the proxy rather than a header
+// encoding, so it sets only the Format placeholder and leaves the header
+// exactly as the author wrote it (including empty).
+func TestSchemeBasic_LeavesHeaderAsWritten(t *testing.T) {
+	a, err := LoadArtifactFromBytes(v2SchemeSpec("          scheme: basic\n          username: x-access-token\n"))
+	require.NoError(t, err)
+
+	inj := a.Credentials[0].ApiKey.Inject[0]
+	require.Empty(t, inj.Header)
+	require.Equal(t, "%s", inj.Format)
+	require.Equal(t, "x-access-token", inj.Username)
+
+	withHeader, err := LoadArtifactFromBytes(v2SchemeSpec("          header: Authorization\n          scheme: basic\n          username: x-access-token\n"))
+	require.NoError(t, err)
+	require.Equal(t, "Authorization", withHeader.Credentials[0].ApiKey.Inject[0].Header)
+}
+
+func TestSchemeErrors(t *testing.T) {
+	t.Run("bearer_rejects_username", func(t *testing.T) {
+		_, err := LoadArtifactFromBytes(v2SchemeSpec("          scheme: bearer\n          username: nope\n"))
+		require.ErrorContains(t, err, "'username' is not valid with scheme: bearer")
+	})
+
+	t.Run("basic_requires_username", func(t *testing.T) {
+		_, err := LoadArtifactFromBytes(v2SchemeSpec("          scheme: basic\n"))
+		require.ErrorContains(t, err, "scheme: basic requires 'username'")
+	})
+
+	t.Run("scheme_and_format_exclusive", func(t *testing.T) {
+		_, err := LoadArtifactFromBytes(v2SchemeSpec("          scheme: bearer\n          format: \"Bearer %s\"\n"))
+		require.ErrorContains(t, err, "mutually exclusive")
+	})
+
+	t.Run("unknown_scheme", func(t *testing.T) {
+		_, err := LoadArtifactFromBytes(v2SchemeSpec("          scheme: digest\n"))
+		require.ErrorContains(t, err, `unknown scheme "digest"`)
+	})
+}


### PR DESCRIPTION
## Summary

`scheme: bearer` never set the header, so a kit using the documented sugar got an
inject entry that **validated clean and injected nothing**.

`SPEC-v2.md` documents `scheme: bearer` as sugar for **both**
`header: Authorization` and `format: "Bearer %s"`. `expandCredentialSchemes` only
ever set `Format`. Since `ApiKeyInject.Header` is the sole carrier of the header
name on the normalized artifact, leaving it empty means the proxy has no header to
inject into.

```
before:  domain="api.cloudflare.com" header=""              format="Bearer %s"
after:   domain="api.cloudflare.com" header="Authorization" format="Bearer %s"
```

An explicit `header:` still wins, so Bearer-formatted values can be pointed at a
non-standard header.

> [!NOTE]
> Split out of #178, which retains the documentation corrections found by the same
> investigation. This PR is the only behaviour change of the two. Both touch
> adjacent lines of one paragraph in `spec-anatomy.md`, so whichever lands second
> needs a one-paragraph rebase.

## Why it was never caught

Two reasons, both addressed here:

1. **There was zero test coverage of the `scheme:` sugar** anywhere in the repo.
2. The fixture `spec/testdata/sample-agent-v2/spec.yaml` redundantly spelled
   `header: Authorization` *alongside* `scheme: bearer`, so the expansion was never
   actually exercised. That line is removed — no existing test asserted on it
   (checked) — and `spec/v2_scheme_test.go` now covers bearer, explicit-header
   precedence, basic, and all four error paths.

## It was also lossy on round-trip

`NewV2View` emitted `header: ""` back to disk, so the two `V2View` consumers —
`scripts/migrate-v1-to-v2.go` and `sbx kit inspect --json` — wrote out a broken
header. Fixed by the same change:

```yaml
# before                          # after
- domain: api.cloudflare.com      - domain: api.cloudflare.com
  header: ""                        header: Authorization
  format: Bearer %s                 format: Bearer %s
```

## `scheme: basic` deliberately left alone

Basic auth is username-driven at the proxy — the `Authorization: Basic
<base64(user:pass)>` value is assembled there from username + credential, not from
`format` — so there is no header name the sugar could infer without guessing.
`Format = "%s"` exists only so `%s`-shape checks pass.

Rather than change it, the current behaviour is pinned by
`TestSchemeBasic_LeavesHeaderAsWritten` and the asymmetry is now documented in
both `SPEC-v2.md` and `spec-anatomy.md`, so it reads as intentional rather than as
the same bug left half-fixed.

## Test plan

- [x] `go test ./...` passes and `go vet ./...` is clean **on this branch alone**
      (verified after splitting, not just on the combined branch).
- [x] New `spec/v2_scheme_test.go`: bearer sets `Authorization`; an explicit
      `header:` is preserved; basic is left as written; four error paths.
- [x] Fixture assertion added in `spec/artifact_test.go` so the de-masked fixture
      is actually checked.
- [x] Verified against the real third-party kit, not just fixtures — it now yields
      `header="Authorization"`, and the `V2View` round-trip emits
      `header: Authorization`.
- n/a — kit e2e / `sbx kit validate` / manual smoke: no kit changes. Note that
      touching `spec/` makes `tck.yml` run the TCK **and** e2e for every kit, so
      the matrix is exercised broadly anyway.

## Not addressed

`ValidateArtifact` performs no `apiKey` validation at all — a `format` with no
`%s`, an `apiKey` with no `name`, and an `inject` entry with an empty `domain` all
validate OK. Adding it would have caught this bug at `sbx kit validate` time rather
than at runtime, but it is a behaviour change for existing kits and belongs in its
own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
