### PR TITLE
Add sbx-cli mixin: installs the sbx CLI inside a sandbox

### DIFF
--- a/sbx-cli/README.md
+++ b/sbx-cli/README.md
@@ -1,0 +1,40 @@
+# sbx CLI
+
+Installs the [Docker Sandboxes](https://docs.docker.com/ai/sandboxes/) `sbx` CLI inside the
+sandbox, so you can run `sbx kit validate`/`inspect` on a kit spec from within a sandbox. Useful for
+kits that don't live in `sbx-kits-contrib`, where the TCK (`go test`) already covers validation
+without needing `sbx` installed at all.
+
+## Usage
+
+Run it with any agent kit or built-in agent:
+
+```console
+$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=sbx-cli" claude
+```
+
+For local development, point `--kit` at this directory:
+
+```console
+$ sbx run --kit ./sbx-cli/ claude
+```
+
+After the sandbox starts, `sbx` is available on `PATH`:
+
+```console
+$ sbx version
+$ sbx kit validate ./my-kit/
+$ sbx kit inspect ./my-kit/ --output json | jq
+```
+
+## How it works
+
+Resolves the latest `docker/sbx-releases` tag via the `releases/latest` redirect instead of the
+GitHub API, so no `api.github.com` or `GITHUB_TOKEN` is needed. Downloads the arch-specific tarball
+(`DockerSandboxes-linux-{amd64,arm64}.tar.gz`, picked via `dpkg --print-architecture`).
+
+## Scope
+
+`sbx kit validate`/`inspect` are local, no daemon needed, and work on any kit directory, not just
+ones in this repo. `sbx run`/`create`/`ports`/`policy` need `sandboxd` to reach `/dev/kvm`, which
+depends on the sandbox's host template and isn't guaranteed, so don't expect those to work here.

--- a/sbx-cli/spec.yaml
+++ b/sbx-cli/spec.yaml
@@ -1,0 +1,35 @@
+schemaVersion: "1"
+kind: mixin
+name: sbx-cli
+displayName: sbx CLI
+description: "Installs the Docker Sandboxes `sbx` CLI in the sandbox, for local kit-authoring commands like `sbx kit validate` and `sbx kit inspect`."
+
+network:
+  allowedDomains:
+    - github.com
+    - release-assets.githubusercontent.com
+
+commands:
+  install:
+    - command: |
+        set -euo pipefail
+        LATEST_URL=$(curl -fsSLI -o /dev/null -w '%{url_effective}' https://github.com/docker/sbx-releases/releases/latest)
+        VERSION="${LATEST_URL##*/}"
+        echo "Resolved latest sbx version: ${VERSION}"
+        ARCH=$(dpkg --print-architecture)
+        case "$ARCH" in
+          amd64|arm64) TARBALL="DockerSandboxes-linux-${ARCH}.tar.gz" ;;
+          *)
+            echo "unsupported sandbox arch: $ARCH (expected amd64 or arm64)" >&2
+            exit 1
+            ;;
+        esac
+        curl --proto '=https' --tlsv1.2 -fsSL \
+          "https://github.com/docker/sbx-releases/releases/download/${VERSION}/${TARBALL}" \
+          -o /tmp/DockerSandboxes-linux.tar.gz
+        tar xzf /tmp/DockerSandboxes-linux.tar.gz -C /tmp
+        PREFIX=/usr/local /tmp/docker-sbx/install.sh
+        rm -rf /tmp/DockerSandboxes-linux.tar.gz /tmp/docker-sbx
+        sbx version
+      user: "0"
+      description: "Install the sbx CLI from the latest docker/sbx-releases release"


### PR DESCRIPTION
<!--
Thanks for contributing to sbx-kits-contrib!

PRs from forks have CI's `test-kit-e2e` job SKIPPED because GitHub does not
expose `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` to fork-triggered workflows.
The e2e assertions will not run on your PR — your laptop is the only place
they run before merge. See the checklist below.
-->

## Summary

Installs the `sbx` CLI inside a sandbox, mainly for `sbx kit validate`/`sbx kit inspect` on kit
specs that don't live in this repo's own TCK tooling. Tracks the latest `docker/sbx-releases`
build rather than pinning a version.

## Spec choices worth flagging for review

- No checksum or signature verification of the downloaded binary. What's the
  recommended verification mechanism here, if any?
- Deliberately tracks `latest` instead of pinning a version, since `sbx` is the product this repo
  targets and a stale pinned build would drift from what users actually run.

## Origin

New kit, written for this PR.

## Test plan

CI runs `kit validate` and the TCK on every PR. CI does **not** run e2e on
fork PRs (Docker Hub secrets aren't exposed there), so the e2e step below is
required from your side before requesting review.

- [x] `sbx kit validate ./sbx-cli/` passes
- [x] `./scripts/test-kit.sh sbx-cli` passes (the TCK)
- [x] `./scripts/test-kit-e2e.sh sbx-cli` passes. The script applies the same
      `deny-all` baseline CI uses and scopes everything to its own daemon
      (`--app-name sbx-kits-contrib-tck`), so my main sbx state is untouched.
      Every entry I added to `network.allowedDomains` came from
      `sbx --app-name sbx-kits-contrib-tck policy log <tck-e2e-…>`, not a guess.
- [x] Manual smoke: `sbx run shell --kit . --name sbx-cli-smoke .` and verified
      `sbx version` runs inside the container:

One-time setup if you haven't run e2e on this machine before:
`sbx --app-name sbx-kits-contrib-tck login`.

See [CONTRIBUTING.md → Verifying locally](../CONTRIBUTING.md#verifying-locally)
and [README → Declare every domain your kit needs](../README.md#declare-every-domain-your-kit-needs)
for the cross-arch domain gotchas (`archive.ubuntu.com`,
`security.ubuntu.com`, `ports.ubuntu.com`) and the package-manager refresh trap.
