### PR TITLE
feat(spec): declare kit arguments as a first-class v2 field

### DIFF
--- a/skills/kit-author/SKILL.md
+++ b/skills/kit-author/SKILL.md
@@ -31,7 +31,7 @@ Use this skill when:
 
 Primary topics describe the **v2** spec form (`schemaVersion: "2"`):
 
-- [Spec anatomy](topics/spec-anatomy.md) — `spec.yaml` top-level fields (`mixins`, `licenses`, `extends`, `locked`) and every section (`sandbox` with `image:`/`build:` + `entrypoint`/`command`, `agentInstructions` with `filename`/`content`, `credentials[]` with `apiKey`/`oauth`/`sshAgent` and the `scheme` sugar, `permissions.network`, `ports`, `environment`, `setup` with `install`/`startup`/`files`, `volumes`, `files/`).
+- [Spec anatomy](topics/spec-anatomy.md) — `spec.yaml` top-level fields (`mixins`, `licenses`, `extends`, `locked`, `args`) and every section (`sandbox` with `image:`/`build:` + `entrypoint`/`command`, `agentInstructions` with `filename`/`content`, `credentials[]` with `apiKey`/`oauth`/`sshAgent` and the `scheme` sugar, `permissions.network`, `ports`, `environment`, `setup` with `install`/`startup`/`files`, `volumes`, `files/`).
 - [Lifecycle](topics/lifecycle.md) — Sourcing → load (schemaVersion-forked decode) → normalize → validate → extends → compose → configure → hooks → container → runtime. What happens at each stage as observed by the kit author.
 - [Composition](topics/composition.md) — `extends:` inheritance vs `--kit` composition. Merge strategies per section, conflict rules, what "last wins" means.
 - [Authoring guide](topics/authoring.md) — Step-by-step recipes for a minimal mixin and a full sandbox kit. Where to put files. When to use `files/` vs `setup.files`.

--- a/skills/kit-author/topics/spec-anatomy.md
+++ b/skills/kit-author/topics/spec-anatomy.md
@@ -37,6 +37,9 @@ requires:                   # optional, base-agent affinity (mixins)
 locked:                     # optional (P2), dotted paths child kits may not override
   - sandbox.image
   - credentials[service=anthropic]
+args:                       # optional, arguments the installer supplies
+  version:
+    default: "latest"
 ```
 
 `kind: sandbox` requires the `sandbox:` block. `kind: mixin` must not have a `sandbox:` block. Exactly one `sandbox` is allowed in a composition; mixins stack freely.
@@ -48,6 +51,27 @@ The `name` constraint is exactly: starts and ends with `[a-z0-9]`, may contain `
 ### `licenses`
 
 Optional SPDX license list. Non-empty list of strings if present. Implementations should warn on unrecognized SPDX identifiers. In composition, licenses union across the parent chain and declared mixins.
+
+### `args`
+
+Declares the arguments an installer supplies, referenced anywhere in `spec.yaml` or under `files/` as `${{ kit.args.<name> }}`. Substitution happens before the spec is decoded, so an argument can parameterize any value in the grammar. Every reference must be declared — that is what makes the block a complete list of the kit's inputs.
+
+```yaml
+args:
+  version:
+    default: "latest"                  # optional argument; used when nothing is supplied
+    description: "Tool version"
+    pattern: '^(latest|[0-9]+\.[0-9]+)$'
+  channel:
+    default: "stable"
+    enum: ["stable", "beta"]
+  token:
+    required: true                     # installer must supply a value
+```
+
+Each argument declares exactly one of `default` or `required: true`, and constrains its value with at most one of `enum` or `pattern` (a Go RE2 regexp matched against the whole value). Values are always strings: quote the placeholder in a string-valued field (`VERSION: "${{ kit.args.version }}"`), or a value like `1.20` is read as a float.
+
+`args` is v2-only, and unrelated to `sandbox.build.args` (Docker build arguments). Because the block lives in `spec.yaml`, a signature covers the declarations and defaults; the values an installer supplies do not.
 
 ### `mixins`
 

--- a/spec/SPEC-v2.md
+++ b/spec/SPEC-v2.md
@@ -104,10 +104,66 @@ security:                   # optional. Container security settings.
 | `licenses` | list<string> | optional. Each non-empty; no duplicates. SHOULD be valid SPDX identifiers. |
 | `locked` | list<string> | optional. Each a well-formed dotted path (`^[a-z][a-zA-Z0-9]*(\.[a-z][a-zA-Z0-9]*)*$`); no duplicates. Enforcement of the lock lives in the merge consumer. |
 | `security.privileged` | bool | optional. Runs the container privileged. Immutable at runtime (see [§6](#6-validation-summary)). |
+| `args` | map | optional. The arguments an installer may supply. See [§2.1](#21-args). |
 
 Both kinds also MAY set the shared behavior blocks — `agentInstructions`,
 `permissions`, `ports`, `credentials`, `environment`, `setup`,
 `volumes`, and a `files/` tree — defined in [§5](#5-shared-block-reference).
+
+### 2.1 `args`
+
+A kit MAY declare **arguments** — named values whoever installs the kit
+supplies — and reference them anywhere in `spec.yaml` or under `files/` as
+`${{ kit.args.<name> }}`. Substitution happens *before* the spec is decoded, so
+an argument can parameterize any value in the grammar.
+
+```yaml
+args:
+  version:
+    default: "latest"                       # optional: used when the installer supplies nothing
+    description: "Tool version to install"
+    pattern: '^(latest|[0-9]+\.[0-9]+\.[0-9]+)$'
+  channel:
+    default: "stable"
+    enum: ["stable", "beta", "nightly"]
+  token:
+    required: true                          # the installer MUST supply a value
+    description: "API token"
+
+environment:
+  variables:
+    VERSION: "${{ kit.args.version }}"
+    TOKEN: "${{ kit.args.token }}"
+```
+
+| Field | Type | Rules |
+|---|---|---|
+| *the key* | string | The argument name. MUST match `^[A-Za-z_][A-Za-z0-9_-]*$`. A dot is excluded so a name can never be confused with the dotted reference that selects it. |
+| `default` | string | The value used when the installer supplies none. Exactly one of `default` or `required` MUST be declared. `default: ""` is a real default, not an absent one. |
+| `required` | bool | `true` means the installer MUST supply a value. Mutually exclusive with `default` — an argument with a default is never required. |
+| `description` | string | optional. Human-readable help, shown wherever a kit's inputs are listed. |
+| `enum` | list<string> | optional. The exact set of accepted values; no duplicates. Mutually exclusive with `pattern`. |
+| `pattern` | string | optional. A Go (RE2) regexp matched against the **whole** value, not merely part of it. Mutually exclusive with `enum`. |
+
+- **Values are strings.** There is no `type` keyword: a substituted value's YAML
+  type is decided the ordinary way, by whether the author quoted the
+  placeholder. Quote it in a string-valued field —
+  `VERSION: "${{ kit.args.version }}"` — or a value like `1.20` is read as a
+  float and fails to decode into a string.
+- **Every reference MUST be declared.** A `${{ kit.args.x }}` with no `args.x`
+  declaration is an error. That is what makes the block a complete, trustworthy
+  list of a kit's inputs.
+- **Declarations are signed; values are not.** The block lives in `spec.yaml`,
+  so a signature covers the argument names, defaults, and constraints. The
+  values an installer supplies sit outside it.
+- **v2 only.** The frozen v1 grammar has no `args` block.
+- Not to be confused with [`sandbox.build.args`](#32-the-sandbox-block), which
+  are Docker build arguments passed to a Dockerfile build.
+
+Validating a declaration is the spec library's job. Resolving a value, and
+rejecting one that fails `enum` or `pattern`, belongs to the consumer that
+performs the substitution — which necessarily runs before the spec can be
+decoded.
 
 ---
 
@@ -121,6 +177,7 @@ A sandbox kit is a complete agent. It **MUST** declare a `sandbox:` block and
 | Field | Required | Notes |
 |---|---|---|
 | all [common fields](#2-common-top-level-fields) | `schemaVersion`, `kind`, `name` required | `kind` MUST be `sandbox`. |
+| [`args`](#21-args) | optional | Arguments the installer may supply. |
 | [`sandbox`](#32-the-sandbox-block) | **REQUIRED** | Container image + launch configuration. |
 | [`extends`](#34-extends-single-parent-inheritance) | optional | Single parent to inherit from. Sandbox-only. |
 | [`mixins`](#35-mixins-author-time-composition) | optional | Author-declared mixins. Sandbox-only. Forward-compat. |
@@ -328,6 +385,7 @@ sandbox can carry, a mixin can carry.
 | Field | Allowed | Notes |
 |---|---|---|
 | all [common fields](#2-common-top-level-fields) | yes | `kind` MUST be `mixin`. |
+| [`args`](#21-args) | yes | Arguments the installer may supply. |
 | `sandbox` | **FORBIDDEN** | Declaring it is a hard error. |
 | `extends` | **FORBIDDEN** | Mixins cannot inherit. |
 | `mixins` | **FORBIDDEN** | Mixins cannot compose other mixins. |
@@ -757,6 +815,12 @@ the per-field rules above:
   in `files[].content`.
 - **locked**: each a well-formed dotted path; no duplicates.
 - **licenses**: each non-empty; no duplicates.
+- **args**: each name matches the argument-name pattern; exactly one of
+  `default` / `required` per argument; `enum` and `pattern` mutually exclusive;
+  `enum` free of duplicates; `pattern` a valid RE2 regexp; and a declared
+  `default` satisfies its own `enum` / `pattern`. Whether an *installer's*
+  value satisfies the constraint is checked by the consumer that substitutes
+  it ([§2.1](#21-args)).
 - **files/**: target `home` or `workspace`; relative, non-escaping paths.
 
 Rules stated as **MUST** in this document that are enforced by the engine rather

--- a/spec/args_test.go
+++ b/spec/args_test.go
@@ -1,0 +1,218 @@
+package spec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func strPtr(s string) *string { return &s }
+
+func TestArgs_Decode(t *testing.T) {
+	yaml := []byte(`
+schemaVersion: "2"
+kind: sandbox
+name: arg-kit
+args:
+  version:
+    default: "latest"
+    description: "Tool version to install"
+    pattern: '^(latest|[0-9]+\.[0-9]+)$'
+  channel:
+    default: "stable"
+    enum: ["stable", "beta"]
+  token:
+    required: true
+    description: "API token"
+sandbox:
+  image: my-image
+`)
+	art, err := LoadArtifactFromBytes(yaml)
+	require.NoError(t, err)
+	require.NoError(t, ValidateArtifact(art))
+
+	require.Equal(t, map[string]KitArg{
+		"version": {
+			Default:     strPtr("latest"),
+			Description: "Tool version to install",
+			Pattern:     `^(latest|[0-9]+\.[0-9]+)$`,
+		},
+		"channel": {
+			Default: strPtr("stable"),
+			Enum:    []string{"stable", "beta"},
+		},
+		"token": {
+			Required:    true,
+			Description: "API token",
+		},
+	}, art.Args)
+}
+
+func TestArgs_Absent_LeavesNil(t *testing.T) {
+	yaml := []byte(`
+schemaVersion: "2"
+kind: sandbox
+name: no-args
+sandbox:
+  image: my-image
+`)
+	art, err := LoadArtifactFromBytes(yaml)
+	require.NoError(t, err)
+	require.Nil(t, art.Args, "absent args must leave Artifact.Args nil")
+}
+
+// A repeated argument name is caught by the YAML decoder itself, which is
+// half of why args is a map rather than a list of {name: ...} entries.
+func TestArgs_DuplicateName_Rejected(t *testing.T) {
+	yaml := []byte(`
+schemaVersion: "2"
+kind: sandbox
+name: dup-args
+args:
+  version:
+    default: "a"
+  version:
+    default: "b"
+sandbox:
+  image: my-image
+`)
+	_, err := LoadArtifactFromBytes(yaml)
+	require.ErrorContains(t, err, `already defined`)
+}
+
+// args is v2-only: the v1 decoder is frozen, so the block is an unknown field
+// there rather than a silently ignored one.
+func TestArgs_InV1Spec_Rejected(t *testing.T) {
+	yaml := []byte(`
+schemaVersion: "1"
+kind: sandbox
+name: v1-args
+template: my-image
+args:
+  version:
+    default: "latest"
+`)
+	_, err := LoadArtifactFromBytes(yaml)
+	require.ErrorContains(t, err, "args")
+}
+
+func TestValidateArgs_RequiresExactlyOneOfDefaultOrRequired(t *testing.T) {
+	t.Run("both", func(t *testing.T) {
+		err := ValidateArgs(map[string]KitArg{
+			"version": {Default: strPtr("latest"), Required: true},
+		})
+		require.ErrorContains(t, err, "never required")
+	})
+
+	t.Run("neither", func(t *testing.T) {
+		err := ValidateArgs(map[string]KitArg{
+			"version": {Description: "no default, not required"},
+		})
+		require.ErrorContains(t, err, "must declare either a default or required: true")
+	})
+}
+
+// An empty default is a real default: the argument is optional and expands to
+// nothing, which is distinct from having declared no default at all.
+func TestValidateArgs_EmptyStringDefaultIsADefault(t *testing.T) {
+	require.NoError(t, ValidateArgs(map[string]KitArg{
+		"extra_flags": {Default: strPtr("")},
+	}))
+}
+
+func TestValidateArgs_EnumAndPatternMutuallyExclusive(t *testing.T) {
+	err := ValidateArgs(map[string]KitArg{
+		"channel": {Default: strPtr("stable"), Enum: []string{"stable"}, Pattern: "^s.*$"},
+	})
+	require.ErrorContains(t, err, "redundant")
+}
+
+func TestValidateArgs_InvalidName(t *testing.T) {
+	err := ValidateArgs(map[string]KitArg{
+		"kit.args.version": {Required: true},
+	})
+	require.ErrorContains(t, err, "not a valid argument name")
+}
+
+func TestValidateArgs_InvalidPattern(t *testing.T) {
+	err := ValidateArgs(map[string]KitArg{
+		"version": {Required: true, Pattern: "([0-9]+"},
+	})
+	require.ErrorContains(t, err, "not a valid regexp")
+}
+
+func TestValidateArgs_DuplicateEnumMember(t *testing.T) {
+	err := ValidateArgs(map[string]KitArg{
+		"channel": {Default: strPtr("stable"), Enum: []string{"stable", "beta", "stable"}},
+	})
+	require.ErrorContains(t, err, "duplicated")
+}
+
+func TestValidateArgs_DefaultMustSatisfyItsOwnConstraint(t *testing.T) {
+	t.Run("enum", func(t *testing.T) {
+		err := ValidateArgs(map[string]KitArg{
+			"channel": {Default: strPtr("nightly"), Enum: []string{"stable", "beta"}},
+		})
+		require.ErrorContains(t, err, `args["channel"].default`)
+		require.ErrorContains(t, err, `is not one of "stable", "beta"`)
+	})
+
+	t.Run("pattern", func(t *testing.T) {
+		err := ValidateArgs(map[string]KitArg{
+			"version": {Default: strPtr("v1"), Pattern: `^[0-9]+$`},
+		})
+		require.ErrorContains(t, err, `args["version"].default`)
+		require.ErrorContains(t, err, "does not match pattern")
+	})
+}
+
+func TestValidateArgs_ReportsTheSameArgumentEveryTime(t *testing.T) {
+	args := map[string]KitArg{
+		"aaa": {Required: true, Pattern: "([0-9]+"},
+		"zzz": {Required: true, Pattern: "([0-9]+"},
+	}
+	for range 10 {
+		require.ErrorContains(t, ValidateArgs(args), `args["aaa"]`)
+	}
+}
+
+func TestKitArgValidateValue_PatternMatchesWholeValue(t *testing.T) {
+	digits := KitArg{Required: true, Pattern: `[0-9]+`}
+
+	require.NoError(t, digits.ValidateValue("123"))
+	require.ErrorContains(t, digits.ValidateValue("v123"), "does not match pattern")
+	require.ErrorContains(t, digits.ValidateValue("123v"), "does not match pattern")
+
+	// Anchoring is applied by the engine rather than by measuring the first
+	// match, so an alternation still gets to try its longer branch.
+	alt := KitArg{Required: true, Pattern: `a|ab`}
+	require.NoError(t, alt.ValidateValue("ab"))
+}
+
+func TestKitArgValidateValue_Enum(t *testing.T) {
+	channel := KitArg{Required: true, Enum: []string{"stable", "beta"}}
+
+	require.NoError(t, channel.ValidateValue("beta"))
+	require.ErrorContains(t, channel.ValidateValue("nightly"), `is not one of "stable", "beta"`)
+}
+
+func TestKitArgValidateValue_Unconstrained(t *testing.T) {
+	require.NoError(t, KitArg{Required: true}.ValidateValue("anything at all"))
+}
+
+func TestValidateArtifact_RejectsBadArgs(t *testing.T) {
+	yaml := []byte(`
+schemaVersion: "2"
+kind: sandbox
+name: bad-args
+args:
+  version:
+    default: "latest"
+    required: true
+sandbox:
+  image: my-image
+`)
+	art, err := LoadArtifactFromBytes(yaml)
+	require.NoError(t, err)
+	require.ErrorContains(t, ValidateArtifact(art), `args["version"]`)
+}

--- a/spec/types.go
+++ b/spec/types.go
@@ -487,6 +487,49 @@ type Requires struct {
 	Agent string `json:"agent,omitempty" yaml:"agent,omitempty"`
 }
 
+// KitArg declares one caller-supplied argument the kit accepts. A
+// `${{ kit.args.<name> }}` placeholder anywhere in spec.yaml or under files/
+// is replaced with the argument's value before the spec is decoded, which is
+// how an argument can parameterize any value in the grammar without the
+// schema knowing which one.
+//
+// Declaring arguments is what makes them discoverable: the block names the
+// kit's inputs, their meaning, and the values they accept, so a reader, a
+// `kit inspect`, and a registry UI all see the same contract. Because the
+// block lives in spec.yaml it is covered by the kit's signature — the
+// declaration and its defaults are signed, while a caller's substituted
+// values are not.
+//
+// Exactly one of Default or Required is declared: an argument either has a
+// fallback and is optional, or has none and must be supplied. The spec
+// library validates the declaration's well-formedness only; resolving a
+// value and rejecting one that fails Enum or Pattern lives in the consumer
+// that performs the substitution.
+type KitArg struct {
+	// Default is the value substituted when the caller supplies none. A nil
+	// default means the argument is required; an empty-string default is a
+	// real default and is honored as one.
+	Default *string `json:"default,omitempty" yaml:"default,omitempty"`
+
+	// Required marks an argument the caller must supply. It is the explicit
+	// spelling of "no default", and declaring it alongside Default is an
+	// error.
+	Required bool `json:"required,omitempty" yaml:"required,omitempty"`
+
+	// Description is the human-readable explanation shown wherever a kit's
+	// inputs are listed.
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	// Enum restricts the value to an exact set. Mutually exclusive with
+	// Pattern, which an exact set makes redundant.
+	Enum []string `json:"enum,omitempty" yaml:"enum,omitempty"`
+
+	// Pattern restricts the value to a Go (RE2) regexp matched against the
+	// whole value, not merely a substring of it. Mutually exclusive with
+	// Enum.
+	Pattern string `json:"pattern,omitempty" yaml:"pattern,omitempty"`
+}
+
 // EnvironmentPolicy defines environment variables to set in the container.
 type EnvironmentPolicy struct {
 	// Variables are static environment variables to set in the container.
@@ -648,6 +691,13 @@ type Artifact struct {
 	// (union of parent/mixin licenses) lives in the consumer that performs
 	// the merge. Declarative metadata with no runtime effect.
 	Licenses []string `json:"licenses,omitempty"`
+
+	// Args declares the caller-supplied arguments the kit accepts, keyed by
+	// argument name (see KitArg). A map rather than a list because the name
+	// is the key a `${{ kit.args.<name> }}` placeholder selects. The spec
+	// library validates the declarations; substitution happens in the
+	// consumer, before the spec is decoded.
+	Args map[string]KitArg `json:"args,omitempty"`
 
 	// PublishedPorts lists in-container ports the kit wants the runtime to
 	// publish on the host when the sandbox starts. It is a top-level

--- a/spec/v2.go
+++ b/spec/v2.go
@@ -31,6 +31,8 @@ type specFileV2 struct {
 	Locked   []string  `yaml:"locked,omitempty"`
 	Licenses []string  `yaml:"licenses,omitempty"`
 
+	Args map[string]KitArg `yaml:"args,omitempty"`
+
 	Sandbox           *sandboxBlockV2           `yaml:"sandbox,omitempty"`
 	AgentInstructions *agentInstructionsBlockV2 `yaml:"agentInstructions,omitempty"`
 
@@ -242,6 +244,7 @@ func (s *specFileV2) toArtifact(w *warnings) (*Artifact, error) {
 		Requires:       s.Requires,
 		Locked:         s.Locked,
 		Licenses:       s.Licenses,
+		Args:           s.Args,
 		PublishedPorts: s.PublishedPorts,
 		Environment:    s.Environment,
 	}

--- a/spec/v2view.go
+++ b/spec/v2view.go
@@ -41,6 +41,8 @@ type V2View struct {
 	Locked   []string  `json:"locked,omitempty" yaml:"locked,omitempty"`
 	Licenses []string  `json:"licenses,omitempty" yaml:"licenses,omitempty"`
 
+	Args map[string]KitArg `json:"args,omitempty" yaml:"args,omitempty"`
+
 	Sandbox           *V2Sandbox           `json:"sandbox,omitempty" yaml:"sandbox,omitempty"`
 	AgentInstructions *V2AgentInstructions `json:"agentInstructions,omitempty" yaml:"agentInstructions,omitempty"`
 	Permissions       *V2Permissions       `json:"permissions,omitempty" yaml:"permissions,omitempty"`
@@ -144,6 +146,7 @@ func NewV2View(a *Artifact) *V2View {
 		Requires:      a.Requires,
 		Locked:        a.Locked,
 		Licenses:      a.Licenses,
+		Args:          a.Args,
 		Volumes:       m.Volumes,
 		Security:      m.Security,
 		Ports:         a.PublishedPorts,

--- a/spec/v2view_test.go
+++ b/spec/v2view_test.go
@@ -123,6 +123,7 @@ func TestNewV2View_RoundTripsThroughV2Loader(t *testing.T) {
 		},
 		AgentContext:   "ctx",
 		Licenses:       []string{"MIT"},
+		Args:           map[string]KitArg{"version": {Default: strPtr("latest"), Description: "which version"}},
 		Caps:           &Caps{Network: &CapsNetwork{Allow: []string{"h.example.com"}, Deny: []string{"bad.example.com"}}},
 		PublishedPorts: []PublishedPort{{Container: 8080, Name: "web"}},
 		Environment:    &EnvironmentPolicy{Variables: map[string]string{"A": "b"}},
@@ -140,6 +141,7 @@ func TestNewV2View_RoundTripsThroughV2Loader(t *testing.T) {
 	require.Equal(t, "A.md", got.Manifest.AIFilename)
 	require.Equal(t, "ctx", got.AgentContext)
 	require.Equal(t, []string{"MIT"}, got.Licenses)
+	require.Equal(t, map[string]KitArg{"version": {Default: strPtr("latest"), Description: "which version"}}, got.Args)
 	require.Equal(t, []string{"h.example.com"}, got.Caps.Network.Allow)
 	require.Equal(t, []string{"bad.example.com"}, got.Caps.Network.Deny)
 	require.Len(t, got.PublishedPorts, 1)

--- a/spec/validate.go
+++ b/spec/validate.go
@@ -2,6 +2,7 @@ package spec
 
 import (
 	"fmt"
+	"maps"
 	"path"
 	"regexp"
 	"slices"
@@ -30,6 +31,12 @@ var lockedPathPattern = regexp.MustCompile(`^[a-z][a-zA-Z0-9]*(\.[a-z][a-zA-Z0-9
 // octalModePattern matches file mode strings: 3 or 4 octal digits, with an
 // optional leading "0". Accepts "755", "0755", "1777", "01777".
 var octalModePattern = regexp.MustCompile(`^0?[0-7]{3,4}$`)
+
+// argNamePattern matches a kit-argument name. Hyphens are admitted because
+// authors reach for them in multi-word names; a dot is not, so a name can
+// never be confused with the dotted ${{ kit.args.<name> }} reference that
+// selects it.
+var argNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_-]*$`)
 
 // supportedPlaceholders lists the placeholders allowed in initFiles content.
 var supportedPlaceholders = map[string]bool{
@@ -309,6 +316,9 @@ func ValidateArtifact(a *Artifact) error {
 	if err := ValidateLicenses(a.Licenses); err != nil {
 		return err
 	}
+	if err := ValidateArgs(a.Args); err != nil {
+		return err
+	}
 	if err := ValidatePublishedPorts(a.PublishedPorts); err != nil {
 		return err
 	}
@@ -412,6 +422,99 @@ func ValidateLicenses(licenses []string) error {
 		seen[l] = struct{}{}
 	}
 	return nil
+}
+
+// ValidateArgs validates the well-formedness of a kit's argument
+// declarations (see KitArg). Each argument declares exactly one of default or
+// required: an argument with neither would silently substitute an empty
+// string for a value nobody chose, and one with both contradicts itself. A
+// declared default must satisfy the argument's own enum or pattern, so an
+// author's mistake surfaces at kit validate time rather than at someone
+// else's install.
+//
+// Whether a caller-supplied value satisfies the constraint is checked by the
+// consumer that performs the substitution, which necessarily runs before this
+// does — placeholders are replaced before the spec can be decoded.
+//
+// Names are visited in sorted order so a spec with several bad declarations
+// always reports the same one.
+func ValidateArgs(args map[string]KitArg) error {
+	for _, name := range slices.Sorted(maps.Keys(args)) {
+		a := args[name]
+		if !argNamePattern.MatchString(name) {
+			return fmt.Errorf("args[%q] is not a valid argument name (must start with a letter or underscore, followed by letters, digits, underscores, or hyphens)", name)
+		}
+		switch {
+		case a.Default != nil && a.Required:
+			return fmt.Errorf("args[%q] declares both a default and required: true; an argument with a default is never required", name)
+		case a.Default == nil && !a.Required:
+			return fmt.Errorf("args[%q] must declare either a default or required: true", name)
+		}
+		if len(a.Enum) > 0 && a.Pattern != "" {
+			return fmt.Errorf("args[%q] declares both enum and pattern; an exact set of values makes a pattern redundant", name)
+		}
+
+		seen := make(map[string]struct{}, len(a.Enum))
+		for i, v := range a.Enum {
+			if _, dup := seen[v]; dup {
+				return fmt.Errorf("args[%q].enum[%d] %q is duplicated", name, i, v)
+			}
+			seen[v] = struct{}{}
+		}
+		if a.Pattern != "" {
+			if _, err := compileArgPattern(a.Pattern); err != nil {
+				return fmt.Errorf("args[%q].pattern is not a valid regexp: %w", name, err)
+			}
+		}
+
+		if a.Default != nil {
+			if err := a.ValidateValue(*a.Default); err != nil {
+				return fmt.Errorf("args[%q].default: %w", name, err)
+			}
+		}
+	}
+	return nil
+}
+
+// ValidateValue reports whether v is an acceptable value for the argument,
+// enforcing enum membership or a whole-value pattern match. Consumers call it
+// on a caller-supplied value; ValidateArgs applies it to a declared default.
+//
+// A pattern constrains the whole value: an author writing `[0-9]+` means the
+// value is digits, not that it contains digits somewhere.
+func (a KitArg) ValidateValue(v string) error {
+	if len(a.Enum) > 0 && !slices.Contains(a.Enum, v) {
+		quoted := make([]string, len(a.Enum))
+		for i, e := range a.Enum {
+			quoted[i] = fmt.Sprintf("%q", e)
+		}
+		return fmt.Errorf("%q is not one of %s", v, strings.Join(quoted, ", "))
+	}
+	if a.Pattern == "" {
+		return nil
+	}
+	re, err := compileArgPattern(a.Pattern)
+	if err != nil {
+		return fmt.Errorf("pattern %q is not a valid regexp: %w", a.Pattern, err)
+	}
+	if !re.MatchString(v) {
+		return fmt.Errorf("%q does not match pattern %q", v, a.Pattern)
+	}
+	return nil
+}
+
+// compileArgPattern compiles pat into a whole-value matcher. It compiles pat
+// on its own first so a syntax error is reported against what the author
+// actually wrote, then wraps it in \A(?:...)\z. Anchoring through the engine
+// rather than by inspecting match offsets is what lets an alternation like
+// "a|ab" match the whole value instead of settling for its first branch.
+// Wrapping is safe precisely because pat already compiled: its groups balance,
+// so it cannot escape the wrapper.
+func compileArgPattern(pat string) (*regexp.Regexp, error) {
+	if _, err := regexp.Compile(pat); err != nil {
+		return nil, err
+	}
+	return regexp.Compile(`\A(?:` + pat + `)\z`)
 }
 
 // ValidateOAuthPolicy validates the oauth policy if present.


### PR DESCRIPTION
## Summary

Kit arguments are substituted into a spec before it is decoded, so a kit can
already be parameterized — but nothing in the file said which arguments it
accepts. The inputs were discoverable only by grepping for placeholders.

This adds a top-level `args:` block to the `schemaVersion: "2"` grammar so a
kit declares its own inputs, their meaning, and the values they accept:

```yaml
args:
  version:
    default: "latest"
    description: "Tool version to install"
    pattern: '^(latest|[0-9]+\.[0-9]+\.[0-9]+)$'
  channel:
    default: "stable"
    enum: ["stable", "beta", "nightly"]
  token:
    required: true
    description: "API token"

environment:
  variables:
    VERSION: "${{ kit.args.version }}"
    TOKEN: "${{ kit.args.token }}"
```

The declaration is readable in the file, reportable by `sbx kit inspect`
(it flows through `V2View` automatically), and renderable by a registry UI.
Because the block lives in `spec.yaml`, a kit signature covers the argument
names, defaults, and constraints — only the values an installer supplies sit
outside it.

The change is purely additive: `args` is optional, and a spec without it
decodes and validates exactly as before.

## Spec choices worth flagging for review

- **Exactly one of `default` or `required`.** An argument with neither would
  silently substitute an empty string for a value nobody chose; one with both
  contradicts itself, since an argument with a default is never required.
  `Default` is a `*string` so `default: ""` is a real default rather than an
  absent one.
- **A map, not a list of `{name: ...}`.** The name is the key a
  `${{ kit.args.<name> }}` reference selects, which is the same situation as
  `environment.variables`. It also means the YAML decoder rejects duplicate
  argument names for free.
- **No `type:` keyword.** Values are strings. A substituted value's YAML type
  is already decided by whether the author quoted the placeholder, so a
  declared type would be a second control competing with the first. `enum` and
  `pattern` cover validation without that conflict, and `type:` stays additive
  if a UI later wants widget hints.
- **`enum` and `pattern` are mutually exclusive** — an exact set of values
  makes a pattern redundant. Names borrowed from JSON Schema so a registry can
  map the declaration onto a form without a translation layer.
- **Patterns are anchored through the engine** (`\A(?:...)\z`) rather than by
  measuring match offsets, so an alternation like `a|ab` matches the whole
  value instead of settling for its first branch. RE2 is linear-time, so
  running an author's pattern over an installer's input cannot backtrack
  catastrophically.
- **v2 only.** The v1 decoder is frozen, so `args:` in a v1 spec is an unknown
  field there.

Validation covers the declaration only, matching how `locked`, `licenses`, and
`requires` are handled: resolving a value and rejecting one that fails its
constraint belongs to the consumer performing the substitution, which
necessarily runs before the spec can be decoded. `KitArg.ValidateValue` is
exported so that consumer enforces exactly the same rule this library applies
to a declared default.

## Test plan

This touches the spec library rather than a kit, so the kit checklist in the
template does not apply.

- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./...` — spec, bindings, scripts, and TCK all pass
- [x] New `spec/args_test.go` covers decode, absence, duplicate names, v1
      rejection, every validation rule, and whole-value pattern matching
      (including the `a|ab` alternation case)
- [x] `TestNewV2View_RoundTripsThroughV2Loader` extended, so an emitted view
      carrying `args` still loads through the v2 grammar
- [x] `gofmt` clean (the pre-existing `tck/e2e_test.go` formatting is untouched)