### PR TITLE
Add pulumi kit

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,3 +7,4 @@
 
 /junie/ @preigile @AlexanderPrendota
 /nanoclaw/ @gavrielc @gabi-simons
+/pulumi/ @dirien

--- a/pulumi/README.md
+++ b/pulumi/README.md
@@ -1,0 +1,73 @@
+# pulumi — Pulumi CLI
+
+A mixin kit that installs the [Pulumi](https://www.pulumi.com/) CLI (version and SHA256 pinned) and wires the Pulumi Cloud access token through the sandbox proxy. `pulumi login`, `pulumi up` and `pulumi env` (Pulumi ESC) work without the token ever entering the container. Pairs with any base agent (claude, codex, gemini, ...).
+
+The kit installs Pulumi only. Cloud CLIs, Terraform and OpenTofu are separate kits, so a sandbox composes just what a project needs.
+
+## Usage
+
+Store your Pulumi Cloud access token once on the host (optional; Pulumi with a local or self-managed backend works without it):
+
+```console
+printf '%s\n' "$PULUMI_ACCESS_TOKEN" | sbx secret set -g pulumi
+```
+
+Then create a sandbox with the kit:
+
+```console
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=pulumi" claude
+```
+
+Verify inside the sandbox:
+
+```console
+pulumi version
+pulumi whoami          # with a bound token
+```
+
+A credential-free starter lands in `~/runbooks/pulumi-random-ts`:
+
+```console
+cd ~/runbooks/pulumi-random-ts
+npm install
+pulumi stack init dev   # or `pulumi login --local` first, without a bound token
+pulumi preview
+```
+
+## How auth works
+
+- The kit declares a `pulumi` credential with `proxyManaged: true`. Inside the container, `PULUMI_ACCESS_TOKEN` is set to a placeholder, which is enough for the CLI to consider itself logged in to Pulumi Cloud.
+- On any request to `api.pulumi.com`, the sandbox proxy replaces the `Authorization` header with `token <your-real-PAT>`. The real token never enters the sandbox filesystem or environment.
+- The credential is `required: false`. Without a bound token, run `pulumi login --local` (or point `pulumi login` at an S3/Azure Blob/GCS backend you have allowed in the network policy).
+
+## Pulumi ESC
+
+`pulumi env` is part of the CLI, so ESC environments (`pulumi env open`, `pulumi env run -- <cmd>`) work through the same proxy-injected token. This is the intended way to hand cloud credentials to a Pulumi program in the sandbox without baking them into a kit.
+
+## Pulumi MCP (optional)
+
+`mcp.ai.pulumi.com` is on the allow-list. To give Claude Code the hosted Pulumi MCP server (registry lookups, resource-schema and code validation, Pulumi Neo), run once inside the sandbox:
+
+```console
+claude mcp add --transport http -s user pulumi https://mcp.ai.pulumi.com/mcp
+```
+
+Other agents register it through their own MCP configuration.
+
+## Network policy
+
+Beyond the install and Pulumi Cloud hosts, the kit allows the package registries a Pulumi program pulls SDKs from (npm, PyPI, the Go module proxy). Cloud control-plane endpoints for the providers you deploy to are not included; add them per provider and region, for example `sbx policy allow network sts.amazonaws.com`.
+
+## Why the install is pinned
+
+The install hook downloads a specific Pulumi release tarball from GitHub and verifies its SHA256 against a checksum recorded in this spec (same pattern as the `trivy` and `glab` kits) rather than piping `get.pulumi.com` to a shell. To bump the version, update `PULUMI_VERSION` and both per-arch checksums from `https://get.pulumi.com/releases/sdk/pulumi-<version>-checksums.txt`.
+
+## Cleanup
+
+```console
+sbx secret rm -g pulumi
+```
+
+## Upstream
+
+Maintained at [dirien/infrastructure-sandbox-kit](https://github.com/dirien/infrastructure-sandbox-kit), which also carries a `kind: sandbox` bundle with a prebuilt image and longer notes on [network policy](https://github.com/dirien/infrastructure-sandbox-kit/blob/main/docs/network.md) and [credentials](https://github.com/dirien/infrastructure-sandbox-kit/blob/main/docs/credentials.md).

--- a/pulumi/files/home/runbooks/README.md
+++ b/pulumi/files/home/runbooks/README.md
@@ -1,0 +1,15 @@
+# Runbooks
+
+A credential-free Pulumi starter, dropped into `~/runbooks/` by the `pulumi`
+kit. It uses the `random` provider, so it previews without a cloud account
+and smoke-tests the toolchain the moment the sandbox is up.
+
+```console
+cd ~/runbooks/pulumi-random-ts
+npm install
+pulumi stack init dev
+pulumi preview
+```
+
+With a bound Pulumi token (`PULUMI_ACCESS_TOKEN` is proxy-managed) the stack
+lives in Pulumi Cloud; otherwise run `pulumi login --local` first.

--- a/pulumi/files/home/runbooks/pulumi-random-ts/Pulumi.yaml
+++ b/pulumi/files/home/runbooks/pulumi-random-ts/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: pulumi-random-ts
+runtime: nodejs
+description: A credential-free Pulumi starter using the random provider.

--- a/pulumi/files/home/runbooks/pulumi-random-ts/index.ts
+++ b/pulumi/files/home/runbooks/pulumi-random-ts/index.ts
@@ -1,0 +1,12 @@
+import * as random from "@pulumi/random";
+
+// Credential-free demo resources — no cloud account required.
+const pet = new random.RandomPet("pet", { length: 2 });
+
+const password = new random.RandomPassword("password", {
+    length: 16,
+    special: true,
+});
+
+export const petName = pet.id;
+export const password_ = password.result; // marked secret by the provider

--- a/pulumi/files/home/runbooks/pulumi-random-ts/package.json
+++ b/pulumi/files/home/runbooks/pulumi-random-ts/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "pulumi-random-ts",
+  "main": "index.ts",
+  "devDependencies": {
+    "@types/node": "^22"
+  },
+  "dependencies": {
+    "@pulumi/pulumi": "^3.0.0",
+    "@pulumi/random": "^4.0.0"
+  }
+}

--- a/pulumi/files/home/runbooks/pulumi-random-ts/tsconfig.json
+++ b/pulumi/files/home/runbooks/pulumi-random-ts/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "outDir": "bin",
+    "target": "es2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "experimentalDecorators": true,
+    "pretty": true,
+    "noFallthroughCasesInSwitch": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true
+  },
+  "files": ["index.ts"]
+}

--- a/pulumi/spec.yaml
+++ b/pulumi/spec.yaml
@@ -1,0 +1,121 @@
+schemaVersion: "2"
+kind: mixin
+name: pulumi
+displayName: Pulumi CLI
+description: Installs the Pulumi CLI (version and SHA256 pinned) and wires the Pulumi Cloud access token through the sandbox proxy, so `pulumi login`, `pulumi up` and `pulumi env` (ESC) work without the token ever entering the container. Pairs with any base agent.
+sourceURL: https://github.com/dirien/infrastructure-sandbox-kit
+licenses:
+  - MIT
+
+permissions:
+  network:
+    allow:
+      # Pulumi Cloud: state/service API (login, up, ESC via `pulumi env`).
+      # Also the credential injection target below.
+      - api.pulumi.com
+      # Resource/language plugin downloads at runtime (`pulumi up` fetches
+      # pulumi-resource-<provider> on first use); redirects to GitHub releases.
+      - get.pulumi.com
+      # The pinned CLI tarball (install time) and the plugin redirect targets.
+      # github.com 302-redirects release assets to objects.githubusercontent.com;
+      # release-assets.githubusercontent.com is kept alongside since that isn't
+      # guaranteed to be the same host for every asset.
+      - github.com
+      - objects.githubusercontent.com
+      - release-assets.githubusercontent.com
+      # Hosted Pulumi MCP server (registry lookups, schema and code validation,
+      # Pulumi Neo). Optional; see the README for the one-line registration.
+      - mcp.ai.pulumi.com
+      # SDK packages a Pulumi program pulls on `npm install` / `pip install` /
+      # `go mod download` for the three most common Pulumi languages.
+      - registry.npmjs.org
+      - pypi.org
+      - files.pythonhosted.org
+      - proxy.golang.org
+      - sum.golang.org
+
+# Pulumi Cloud access token. The kit only declares the credential; the value is
+# bound once on the host (`sbx secret set -g pulumi`). The proxy injects
+# `Authorization: token <PAT>` on api.pulumi.com; inside the container
+# PULUMI_ACCESS_TOKEN only ever holds the proxy-managed placeholder. Declared
+# optional: Pulumi with a local or self-managed backend works without it.
+credentials:
+  - service: pulumi
+    description: "Pulumi Cloud access token (pulumi login/up + ESC via pulumi env)"
+    required: false
+    apiKey:
+      name: PULUMI_ACCESS_TOKEN
+      proxyManaged: true
+      inject:
+        - domain: api.pulumi.com
+          header: Authorization
+          format: "token %s"
+
+environment:
+  variables:
+    PULUMI_SKIP_UPDATE_CHECK: "true"
+
+agentInstructions:
+  content: |
+    ## Pulumi CLI
+
+    `pulumi` is installed system-wide with its bundled language hosts. When a
+    Pulumi Cloud token is bound on the host, `PULUMI_ACCESS_TOKEN` holds a
+    proxy-managed placeholder and the proxy injects the real token on
+    `api.pulumi.com`, so `pulumi login`, `pulumi up` and `pulumi env` (ESC)
+    just work. Without a bound token, run `pulumi login --local` first.
+
+    - Run `pulumi preview` before `pulumi up`; non-interactive runs want
+      `--non-interactive` and an explicit `--stack <name>`.
+    - Resource plugins download on first use from get.pulumi.com (allowed).
+    - Cloud credentials (AWS/Azure/GCP) are not part of this kit. Supply them
+      at run time or through Pulumi ESC; never hardcode them in code.
+    - A credential-free starter lives in `~/runbooks/pulumi-random-ts`:
+      `npm install && pulumi stack init dev && pulumi preview`.
+
+setup:
+  install:
+    # Install the Pulumi CLI from a pinned, digest-verified GitHub release
+    # (same pattern as the trivy and glab kits: no curl|sh, version AND
+    # per-arch SHA256 pinned in git). To bump: change PULUMI_VERSION plus both
+    # checksums below, sourced from
+    # https://get.pulumi.com/releases/sdk/pulumi-<version>-checksums.txt
+    - command: |
+        set -eu
+        PULUMI_VERSION=3.260.0
+        if command -v pulumi >/dev/null 2>&1 \
+           && [ "$(PULUMI_SKIP_UPDATE_CHECK=true pulumi version 2>/dev/null)" = "v${PULUMI_VERSION}" ]; then
+          echo "pulumi v${PULUMI_VERSION} already installed"
+          exit 0
+        fi
+        DEB_ARCH=$(dpkg --print-architecture)
+        case "$DEB_ARCH" in
+          amd64)
+            ARCH=x64
+            SHA256="d7b2936f986e82fd5fa2025bafe27f74d4a50cb6ba6785a16884fd5f270453fe"
+            ;;
+          arm64)
+            ARCH=arm64
+            SHA256="1e7176d55274be10778b5ec7ebb0ae24be4061ad78e9ebfd0e9c1d874927617a"
+            ;;
+          *)
+            echo "unsupported sandbox arch: $DEB_ARCH (expected amd64 or arm64)" >&2
+            exit 1
+            ;;
+        esac
+        TARBALL="pulumi-v${PULUMI_VERSION}-linux-${ARCH}.tar.gz"
+        URL="https://github.com/pulumi/pulumi/releases/download/v${PULUMI_VERSION}/${TARBALL}"
+        curl --proto '=https' --tlsv1.2 -fsSL --retry 3 -o /tmp/pulumi.tgz "$URL"
+        echo "${SHA256}  /tmp/pulumi.tgz" | sha256sum -c -
+        rm -rf /opt/pulumi
+        mkdir -p /opt/pulumi
+        tar -C /opt/pulumi --strip-components=1 -xzf /tmp/pulumi.tgz
+        rm -f /tmp/pulumi.tgz
+        # Every binary is named pulumi*; link them all so the CLI finds its
+        # language hosts (pulumi-language-*) by PATH lookup of its siblings.
+        for f in /opt/pulumi/pulumi*; do
+          ln -sf "$f" "/usr/local/bin/$(basename "$f")"
+        done
+        PULUMI_SKIP_UPDATE_CHECK=true /usr/local/bin/pulumi version
+      user: "0"
+      description: "Install Pulumi CLI v3.260.0, version+digest pinned"


### PR DESCRIPTION
## Summary

A `kind: mixin` kit that installs the [Pulumi](https://www.pulumi.com/) CLI and wires the Pulumi Cloud access token through the sandbox proxy, so `pulumi login`, `pulumi up` and `pulumi env` (Pulumi ESC) work without the token ever entering the container. Pairs with any base agent.

This PR was opened as an all-in-one `infrastructure` kit (Pulumi + Terraform + OpenTofu + kubectl/Helm + AWS/Azure/gcloud CLIs + an APM setup). Per the review, it is now narrowed to Pulumi only; the branch is rebased on `main` as a single commit. Cloud CLIs, OpenTofu and friends will follow as separate mixins so they compose at runtime (`--kit pulumi --kit aws-cli ...`). Terraform is left to #98, kubectl/Helm to #137.

## What the kit declares

- `setup.install` — Pulumi CLI v3.260.0 from a pinned GitHub release, per-arch SHA256 verified (amd64 + arm64), no `curl | sh`. Same pattern as the `trivy` and `glab` kits. Idempotent (skips when the pinned version is already present).
- `credentials` — service `pulumi`, `proxyManaged` API key injected as `Authorization: token <PAT>` on `api.pulumi.com` only; `required: false` (local/self-managed backends work without it).
- `permissions.network.allow` — Pulumi Cloud API, `get.pulumi.com` (runtime plugin downloads), the GitHub release hosts, the hosted Pulumi MCP (`mcp.ai.pulumi.com`, optional), and the SDK registries a Pulumi program pulls from (npm, PyPI, Go proxy).
- `environment` — `PULUMI_SKIP_UPDATE_CHECK=true`.
- `files/home/runbooks/pulumi-random-ts` — a credential-free starter (`random` provider) to smoke-test the toolchain.
- `agentInstructions` — short workflow guidance (preview before up, non-interactive flags, where credentials come from).

Spec choices worth flagging:

- The install runs as root and links every `pulumi*` binary from `/opt/pulumi` into `/usr/local/bin`: the CLI finds its language hosts (`pulumi-language-*`) by PATH lookup of its siblings.
- Bumping is a three-line edit: `PULUMI_VERSION` plus both checksums from `https://get.pulumi.com/releases/sdk/pulumi-<version>-checksums.txt`.
- Cloud credentials are deliberately out of scope; ESC (`pulumi env`) is the documented way to hand them to a program.

## Test plan

- [x] `./scripts/test-kit.sh pulumi` — TCK PASS, including `container/install_execution` (real install in a container, 19.6s) and the `files/` assertions.
- [x] The install command run by hand on linux/arm64 under `sh` (dash) as root with `pulumi` removed from PATH: checksum OK, 13 binaries linked, `pulumi version` → `v3.260.0`. `shellcheck -s sh` clean.
- [x] `sbx kit validate ./pulumi` → VALID; `./scripts/test-kit-e2e.sh pulumi` → PASS on the host (macOS arm64, sbx v0.39.0) under `deny-all`: real `sbx create`, install 23.2s, no blocked requests, env/files/tmpfs/agentContext assertions green (63.6s total).
