### PR TITLE
fix(ci): use org-member Hub creds, sign with nightly sbx

### DIFF
--- a/.github/workflows/hub-overview.yml
+++ b/.github/workflows/hub-overview.yml
@@ -116,11 +116,11 @@ jobs:
             echo "ready=true" >> "$GITHUB_OUTPUT"
           else
             echo "ready=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::DOCKERHUB_SBX_TOKEN / DOCKERHUB_SBX_USERNAME are not set — Hub overviews are not being synced."
+            echo "::notice::DOCKERHUB_TOKEN / DOCKERHUB_USERNAME are not set — Hub overviews are not being synced."
           fi
         env:
-          TOKEN: ${{ secrets.DOCKERHUB_SBX_TOKEN }}
-          USERNAME: ${{ secrets.DOCKERHUB_SBX_USERNAME }}
+          TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
 
   overview:
     needs: resolve
@@ -166,8 +166,8 @@ jobs:
           # `if:` above is what keeps it off the pull-request path; this is the
           # habit that keeps it correct if the step ever becomes a `run:`, where
           # inline interpolation would put the value into shell source.
-          HUB_USERNAME: ${{ secrets.DOCKERHUB_SBX_USERNAME }}
-          HUB_TOKEN: ${{ secrets.DOCKERHUB_SBX_TOKEN }}
+          HUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          HUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Is the base image's repository published?
         id: image-repo
@@ -187,8 +187,8 @@ jobs:
           short-description: ${{ steps.meta.outputs.image-short-description }}
           enable-url-completion: true
         env:
-          HUB_USERNAME: ${{ secrets.DOCKERHUB_SBX_USERNAME }}
-          HUB_TOKEN: ${{ secrets.DOCKERHUB_SBX_TOKEN }}
+          HUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          HUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Report what happened
         # Silence would read as "synced". A skipped page is a page still showing

--- a/.github/workflows/publish-artifact.yml
+++ b/.github/workflows/publish-artifact.yml
@@ -77,7 +77,11 @@ jobs:
       - name: Install sbx
         # `sbx kit` is daemon-free (only `kit add` needs sandboxd), so no VM and
         # no KVM — a plain runner is enough.
-        run: ./scripts/install-sbx.sh >> "$GITHUB_PATH"
+        #
+        # Pinned to nightly, not the latest tagged release: as of v0.38.0,
+        # `sbx kit push` has no `--sign` flag yet. Move this back to the
+        # default (latest) once a tagged release ships with it.
+        run: ./scripts/install-sbx.sh nightly >> "$GITHUB_PATH"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -176,7 +176,10 @@ Two differences from the image, both deliberate:
   fails there, after the immutable tag has already been published.
 
 Each push is signed keyless via the job's ambient GitHub OIDC token, and carries
-a SLSA provenance attestation as an OCI referrer.
+a SLSA provenance attestation as an OCI referrer. This requires `sbx kit push
+--sign`, which is why the workflow installs the `nightly` sbx build rather than
+the latest tagged release — pin it back once a tagged release ships with the
+flag.
 
 **Publication is opt-in**, via the `PUBLISH_KITS` allow-list, because every kit
 in the repo is pushable and discovery would publish all of them.
@@ -255,9 +258,11 @@ surfaces as a failure instead of a silently untouched page.
 
 > **It needs a credential the rest of the pipeline does not.** This is the Hub
 > REST API rather than the registry, so the OIDC-exchanged token cannot
-> authenticate it: it uses the `DOCKERHUB_SBX_USERNAME` / `DOCKERHUB_SBX_TOKEN`
-> secrets. Without them the job emits a notice and skips, so a repository that
-> has not configured them is never red over optional infrastructure.
+> authenticate it: it uses the `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`
+> secrets — a Hub account that is a member of the `sbx` org, not the OIDC
+> connection the artifact push uses. Without them the job emits a notice and
+> skips, so a repository that has not configured them is never red over
+> optional infrastructure.
 >
 > A pull request never reads that credential **at all** — not merely "does not
 > write with it". A same-repository PR receives secrets *and* supplies the


### PR DESCRIPTION
## Summary
- Hub overview sync 401'd with `DOCKERHUB_SBX_TOKEN`/`USERNAME`; switched to `DOCKERHUB_TOKEN`/`USERNAME`, an account already in the `sbx` org.
- Kit artifact push failed with `unknown flag: --sign` on v0.38.0 (latest); pinned the installer to `nightly`, which has the flag.

## Test plan
- [ ] Merge and watch `Build and publish kits` + `Sync Docker Hub overviews` go green on `main`