### PR TITLE
fix(ci): sync Hub overviews with the org bot credential

### DIFF
--- a/.github/workflows/hub-overview.yml
+++ b/.github/workflows/hub-overview.yml
@@ -116,11 +116,11 @@ jobs:
             echo "ready=true" >> "$GITHUB_OUTPUT"
           else
             echo "ready=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::DOCKERHUB_TOKEN / DOCKERHUB_USERNAME are not set — Hub overviews are not being synced."
+            echo "::notice::DOCKERPUBLICBOT_DELETE_PAT / DOCKERPUBLICBOT_USERNAME are not set — Hub overviews are not being synced."
           fi
         env:
-          TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-          USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          TOKEN: ${{ secrets.DOCKERPUBLICBOT_DELETE_PAT }}
+          USERNAME: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
 
   overview:
     needs: resolve
@@ -166,8 +166,8 @@ jobs:
           # `if:` above is what keeps it off the pull-request path; this is the
           # habit that keeps it correct if the step ever becomes a `run:`, where
           # inline interpolation would put the value into shell source.
-          HUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          HUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          HUB_USERNAME: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
+          HUB_TOKEN: ${{ secrets.DOCKERPUBLICBOT_DELETE_PAT }}
 
       - name: Is the base image's repository published?
         id: image-repo
@@ -187,8 +187,8 @@ jobs:
           short-description: ${{ steps.meta.outputs.image-short-description }}
           enable-url-completion: true
         env:
-          HUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          HUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          HUB_USERNAME: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
+          HUB_TOKEN: ${{ secrets.DOCKERPUBLICBOT_DELETE_PAT }}
 
       - name: Report what happened
         # Silence would read as "synced". A skipped page is a page still showing

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -258,11 +258,13 @@ surfaces as a failure instead of a silently untouched page.
 
 > **It needs a credential the rest of the pipeline does not.** This is the Hub
 > REST API rather than the registry, so the OIDC-exchanged token cannot
-> authenticate it: it uses the `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`
-> secrets — a Hub account that is a member of the `sbx` org, not the OIDC
-> connection the artifact push uses. Without them the job emits a notice and
-> skips, so a repository that has not configured them is never red over
-> optional infrastructure.
+> authenticate it: it uses the `DOCKERPUBLICBOT_USERNAME` variable and
+> `DOCKERPUBLICBOT_DELETE_PAT` secret — both organisation-level, granted to
+> this repo rather than configured in it, and the same org-wide bot credential
+> other public Docker repos (e.g. `buildkit-syft-scanner`) already use for this
+> exact action, rather than a credential tied to one person's Hub membership.
+> Without them the job emits a notice and skips, so a repository that has not
+> been granted them is never red over optional infrastructure.
 >
 > A pull request never reads that credential **at all** — not merely "does not
 > write with it". A same-repository PR receives secrets *and* supplies the


### PR DESCRIPTION
## Summary
- Hub overview sync used `DOCKERHUB_TOKEN`/`USERNAME`, tied to one person's Hub org membership.
- Switches to `DOCKERPUBLICBOT_USERNAME`/`DOCKERPUBLICBOT_DELETE_PAT` — the org-wide bot credential `buildkit-syft-scanner` already uses for the same `peter-evans/dockerhub-description` action. Confirmed both are already granted to this repo via the GitHub API, not just present at org level.

## Test plan
- [ ] Merge and watch `Sync Docker Hub overviews` go green on `main`