### PR TITLE
fix(ci): sign in with sbx before pushing the kit artifact

### DIFF
--- a/.github/workflows/publish-artifact.yml
+++ b/.github/workflows/publish-artifact.yml
@@ -97,9 +97,10 @@ jobs:
 
       - name: Log in to Docker Hub
         if: env.DRY_RUN == ''
-        # `sbx kit push` and `oras` both authenticate via the Docker credential
-        # store, so this login is the whole auth story — no sbx-side credential,
-        # and none of the Secret Service scaffolding `sbx login` needs.
+        # Covers the plain push and oras's existence probe/digest read-back:
+        # both authenticate via the Docker credential store this populates.
+        # It does NOT cover `sbx kit push --sign` — see the sbx login step
+        # below.
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: sbx
@@ -112,8 +113,28 @@ jobs:
         with:
           version: "1.3.3"
 
+      - name: Sign in to Docker Hub with sbx
+        if: env.DRY_RUN == ''
+        # `--sign` attaches the signature (and the manifest read-back after
+        # push) as sbx's own session, which resolves credentials
+        # independently of the Docker credential store the login-action step
+        # above populates. Skipping this makes `sbx kit push --sign` fail
+        # with "user is not authenticated to Docker" — only after the
+        # (unsigned) manifest push has already landed, since the push itself
+        # doesn't need this login. No Secret Service setup needed first: sbx
+        # falls back to an encrypted on-disk store when none is reachable
+        # ("No keychain detected - this secret will be stored in an
+        # encrypted file on disk").
+        run: printf '%s' "$TOKEN" | sbx login --username sbx --password-stdin
+        env:
+          TOKEN: ${{ steps.docker_oidc.outputs.token }}
+
       - name: Publish
         id: publish
         run: ./scripts/publish-artifact.sh "${{ inputs.kit }}" "${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
         env:
           MOVE_LATEST: ${{ inputs.move-latest }}
+
+      - name: Sign out of Docker Hub via sbx
+        if: always() && env.DRY_RUN == ''
+        run: sbx logout --yes || true

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -181,6 +181,15 @@ a SLSA provenance attestation as an OCI referrer. This requires `sbx kit push
 the latest tagged release — pin it back once a tagged release ships with the
 flag.
 
+`--sign` needs its own `sbx login`, separate from the `docker login` the job
+already does for the plain push. Attaching a signature is an OCI-referrer
+write that resolves credentials from sbx's own session rather than the Docker
+credential store, so without it `--sign` fails with "user is not
+authenticated to Docker" — after the unsigned manifest has already been
+pushed, since the push itself doesn't need this login. No Secret Service
+setup is needed for this on a bare runner: sbx falls back to an encrypted
+on-disk credential store when none is reachable.
+
 **Publication is opt-in**, via the `PUBLISH_KITS` allow-list, because every kit
 in the repo is pushable and discovery would publish all of them.
 


### PR DESCRIPTION
## Summary
- `sbx kit push --sign` attaches its signature through sbx's own login session, not the Docker credential store `docker login` populates — without it the push lands but signing fails with "user is not authenticated to Docker".
- Adds an `sbx login` step before the push and an `sbx logout` after. No Secret Service setup needed: sbx falls back to an encrypted on-disk store when none is reachable.

## Test plan
- [ ] Merge and watch `kit (kiro) / artifact / publish` go green on `main`