### PR TITLE
fix(ci): use a real Hub PAT for sbx login, not the OIDC token

### DIFF
--- a/.github/workflows/publish-artifact.yml
+++ b/.github/workflows/publish-artifact.yml
@@ -65,7 +65,9 @@ env:
   DRY_RUN: >-
     ${{ (github.event_name == 'pull_request'
       || github.repository != 'docker/sbx-kits-contrib'
-      || secrets.DOCKERHUB_OIDC_CONNECTIONID == '') && '1' || '' }}
+      || secrets.DOCKERHUB_OIDC_CONNECTIONID == ''
+      || secrets.DOCKERPUBLICBOT_WRITE_PAT == ''
+      || vars.DOCKERPUBLICBOT_USERNAME == '') && '1' || '' }}
 
 jobs:
   publish:
@@ -121,13 +123,26 @@ jobs:
         # above populates. Skipping this makes `sbx kit push --sign` fail
         # with "user is not authenticated to Docker" — only after the
         # (unsigned) manifest push has already landed, since the push itself
-        # doesn't need this login. No Secret Service setup needed first: sbx
-        # falls back to an encrypted on-disk store when none is reachable
-        # ("No keychain detected - this secret will be stored in an
-        # encrypted file on disk").
-        run: printf '%s' "$TOKEN" | sbx login --username sbx --password-stdin
+        # doesn't need this login.
+        #
+        # This needs a real Hub password/PAT: the OIDC-exchanged token that
+        # satisfies `docker login` above is rejected by `sbx login` ("docker
+        # token is invalid") — the two authenticate differently. Hence the
+        # org bot's static credential here instead of the OIDC token, the
+        # only static secret in this job.
+        #
+        # Defensive trim: GH preserves whitespace pasted into a secret's
+        # value, and sbx's password-stdin reader only strips a trailing
+        # newline. Hub usernames and PATs are alphanumeric plus hyphens, so
+        # stripping all whitespace cannot corrupt a legitimate value.
+        run: |
+          set -euo pipefail
+          USER_CLEAN=$(printf '%s' "$USERNAME" | tr -d '[:space:]')
+          TOKEN_CLEAN=$(printf '%s' "$TOKEN"    | tr -d '[:space:]')
+          printf '%s' "$TOKEN_CLEAN" | sbx login --username "$USER_CLEAN" --password-stdin
         env:
-          TOKEN: ${{ steps.docker_oidc.outputs.token }}
+          USERNAME: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
+          TOKEN: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
 
       - name: Publish
         id: publish

--- a/.github/workflows/publish-artifact.yml
+++ b/.github/workflows/publish-artifact.yml
@@ -130,16 +130,7 @@ jobs:
         # token is invalid") — the two authenticate differently. Hence the
         # org bot's static credential here instead of the OIDC token, the
         # only static secret in this job.
-        #
-        # Defensive trim: GH preserves whitespace pasted into a secret's
-        # value, and sbx's password-stdin reader only strips a trailing
-        # newline. Hub usernames and PATs are alphanumeric plus hyphens, so
-        # stripping all whitespace cannot corrupt a legitimate value.
-        run: |
-          set -euo pipefail
-          USER_CLEAN=$(printf '%s' "$USERNAME" | tr -d '[:space:]')
-          TOKEN_CLEAN=$(printf '%s' "$TOKEN"    | tr -d '[:space:]')
-          printf '%s' "$TOKEN_CLEAN" | sbx login --username "$USER_CLEAN" --password-stdin
+        run: printf '%s' "$TOKEN" | sbx login --username "$USERNAME" --password-stdin
         env:
           USERNAME: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
           TOKEN: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -112,9 +112,11 @@ variable.
 
 ## Docker Hub authentication
 
-Publishing needs **no long-lived credential**. The workflow exchanges its GitHub
-OIDC token for a short-lived Hub token via `docker/oidc-action`, then logs in
-with that token as the `sbx` organisation. There is no PAT to leak or rotate.
+Publishing the **image** needs **no long-lived credential**. The workflow
+exchanges its GitHub OIDC token for a short-lived Hub token via
+`docker/oidc-action`, then logs in with that token as the `sbx` organisation.
+There is no PAT to leak or rotate. (The kit **artifact**'s signing step is the
+one exception — see "The kit artifact" below.)
 
 The only setting required is the **`DOCKERHUB_OIDC_CONNECTIONID` secret**,
 holding the ID of a Hub-side OIDC connection authorised for this repository.
@@ -186,9 +188,15 @@ already does for the plain push. Attaching a signature is an OCI-referrer
 write that resolves credentials from sbx's own session rather than the Docker
 credential store, so without it `--sign` fails with "user is not
 authenticated to Docker" — after the unsigned manifest has already been
-pushed, since the push itself doesn't need this login. No Secret Service
-setup is needed for this on a bare runner: sbx falls back to an encrypted
-on-disk credential store when none is reachable.
+pushed, since the push itself doesn't need this login.
+
+That session needs a real Hub password or PAT: the OIDC-exchanged token that
+satisfies `docker login` is rejected by `sbx login` ("docker token is
+invalid"), since the two authenticate differently. So this is the one step in
+the pipeline holding a static credential — the org bot's
+`DOCKERPUBLICBOT_USERNAME` / `DOCKERPUBLICBOT_WRITE_PAT`, already granted to
+this repo and scoped for exactly this kind of write, rather than a new
+per-repo secret.
 
 **Publication is opt-in**, via the `PUBLISH_KITS` allow-list, because every kit
 in the repo is pushable and discovery would publish all of them.


### PR DESCRIPTION
## Summary
- `sbx login` exchanges the password against Docker Hub's real credential API and rejects the OIDC-exchanged registry token `docker/login-action` accepts fine — every real run since #189 failed at sign-in with `docker token is invalid`, before the push even ran.
- Uses the org bot's `DOCKERPUBLICBOT_USERNAME`/`DOCKERPUBLICBOT_WRITE_PAT` instead (already granted to this repo), and gates `DRY_RUN` on both being set so a repo missing either degrades to dry-run rather than a guaranteed failure.
- Scopes `PUBLISHING.md`'s "no long-lived credential" claim to the image push, since the kit artifact's signing step is now the one exception.

## Test plan
- [ ] Merge and watch `kit (kiro) / artifact / publish` go green on `main`