### PR TITLE
chore: migrate all contrib kits to spec schemaVersion 2

### DIFF
--- a/.github/workflows/build-and-publish-kits.yml
+++ b/.github/workflows/build-and-publish-kits.yml
@@ -1,22 +1,24 @@
 name: Build and publish kits
 
 # Publishes what a kit needs to be consumable: the base image its sandbox boots
-# from, and the kit artifact itself.
+# from (if it builds one), and the kit artifact itself.
 #
-# Both halves are per-kit and share one discovery pass, which is why they live in
-# one workflow — the artifact references the image, so it must not be published
-# when the image was not.
-#
-#   image     builds <kit>/Dockerfile and pushes <kit>-image
-#   artifact  packages the spec plus files/ and pushes <kit>-kit
+#   image     builds <kit>/Dockerfile and pushes <kit>-image — only for a kit
+#             that ships one; most kits are mixins layered onto someone else's
+#             image and have nothing to build here
+#   artifact  packages the spec plus files/ and pushes <kit>-kit — every
+#             PUBLISH_KITS entry, image or not
 #
 # The Hub repository pages are NOT set here; see hub-overview.yml.
 #
-# Kits are DISCOVERED, not listed: any directory with both a `spec.yaml` and a
-# `Dockerfile` is picked up automatically, so adding a kit that publishes its own
-# image needs no change to this workflow. That mirrors tck.yml, and it is the
-# reason there is no top-level `paths:` filter — all filtering happens in
-# detect-changes, which also decides which kits a given event should rebuild.
+# Kits are DISCOVERED, not listed: any directory with a `spec.yaml` is picked
+# up automatically, so adding a kit needs no change to this workflow. That
+# mirrors tck.yml, and it is the reason there is no top-level `paths:` filter —
+# all filtering happens in detect-changes, which also decides which kits a
+# given event should rebuild. Whether a discovered kit ALSO builds an image is
+# decided per-kit in publish-one-kit.yml, by whether it has a `Dockerfile` —
+# not by anything decided here, so a kit gaining or losing one needs no change
+# to this workflow either.
 #
 # Conventions a discovered kit must follow:
 #
@@ -65,16 +67,17 @@ env:
   IMAGE_NAMESPACE: ${{ vars.IMAGE_NAMESPACE || 'sbx' }}
   IMAGE_TAG_LATEST: ${{ vars.IMAGE_TAG_LATEST || 'latest' }}
   PLATFORMS: ${{ vars.PLATFORMS || 'linux/amd64,linux/arm64' }}
-  # Kits published as OCI artifacts (`<kit>-kit`), space-separated. This is an
-  # allow-list, not discovery: EVERY kit in the repo is pushable, so discovering
-  # them would publish all of them. Widen it with a repository variable once the
-  # distribution story is settled for the rest.
-  #
-  # Constraint worth knowing before widening it: entries are intersected with
-  # the kits this workflow discovers, and it discovers by Dockerfile. A kit that
-  # ships no Dockerfile therefore never appears here however it is spelled —
-  # publishing a mixin's artifact needs the discovery above widened first.
-  PUBLISH_KITS: ${{ vars.PUBLISH_KITS || 'kiro' }}
+  # Kits published as OCI artifacts (`<kit>-kit`), space-separated. Still an
+  # allow-list rather than discovery — so a kit lands here as a deliberate
+  # decision, not automatically the moment it gets a spec.yaml — but every kit
+  # in the repo is now eligible (discovery below is by spec.yaml, not
+  # Dockerfile, and publishing a kit artifact never required an image).
+  PUBLISH_KITS: >-
+    ${{ vars.PUBLISH_KITS || 'amp claude-acp claude-model-runner claude-ollama
+    claude-sbx-statusline code-server codex-acp codex-app-server crush
+    git-ssh-sign github-ssh hermes-agent junie kiro mise nanobot nanoclaw
+    neovim openclaw opencode-model-runner packages-through-sfw pi playwright
+    smolagents task trivy vale' }}
 
 jobs:
   detect-changes:
@@ -83,12 +86,15 @@ jobs:
     outputs:
       # Kits to rebuild for this event.
       kits: ${{ steps.collect.outputs.kits }}
-      # Every image-publishing kit, regardless of what changed — the drift check
+      # Every discovered kit, regardless of what changed — the drift check
       # validates all specs, not just the ones touched.
       all: ${{ steps.collect.outputs.all }}
       # Kits whose ARTIFACT is published this run: the intersection of what
       # changed with the PUBLISH_KITS allow-list.
       artifacts: ${{ steps.collect.outputs.artifacts }}
+      # Which of this run's kits have their own Dockerfile — decides per-kit
+      # whether publish-one-kit.yml's `image` job runs at all.
+      dockerfile-kits: ${{ steps.collect.outputs.dockerfile-kits }}
       # The immutable tag for kit artifacts. Computed here because a job that
       # `uses:` a reusable workflow cannot run steps, so it has nowhere to call
       # `date` — and the tag scheme is documented as <YYYYMMDD>-<sha>.
@@ -98,31 +104,35 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Discover image-publishing kits
+      - name: Discover kits
         id: discover
+        # By spec.yaml, not Dockerfile: whether a kit ALSO builds an image is
+        # decided per-kit in publish-one-kit.yml, not here — see the header
+        # comment. A kit's own Dockerfile presence has no bearing on whether
+        # it's a candidate for artifact publishing.
         run: |
           set -euo pipefail
-          kits=""
-          for f in */Dockerfile; do
-            [ -f "$f" ] || continue
-            kit=$(dirname "$f")
-            # A Dockerfile alone is not a kit; require a spec too.
-            if [ ! -f "$kit/spec.yaml" ] && [ ! -f "$kit/spec.yml" ]; then
-              continue
-            fi
-            kits="${kits} ${kit}"
-          done
-          echo "Discovered image-publishing kits:${kits:-" (none)"}"
-          echo "kits=${kits# }" >> "$GITHUB_OUTPUT"
+          # sort -u: a kit could carry both spec.yaml and spec.yml (mid-migration,
+          # say), which would otherwise list it twice and spawn two matrix legs
+          # racing to push the same tags. Same de-dup tck.yml's own discovery uses.
+          kits=$(
+            for f in */spec.yaml */spec.yml; do
+              [ -f "$f" ] || continue
+              dirname "$f"
+            done | sort -u | tr '\n' ' '
+          )
+          kits="${kits% }"
+          echo "Discovered kits:${kits:+ }${kits:-(none)}"
+          echo "kits=${kits}" >> "$GITHUB_OUTPUT"
 
       - name: Generate filters
         id: filter-setup
         # One filter per discovered kit, matching the whole kit directory minus
-        # what the image cannot depend on. Written as exclusions rather than an
-        # allowlist of sources on purpose: an allowlist silently stops matching
-        # once a Dockerfile starts COPYing a new file, leaving the published
-        # image stale until the next nightly. spec.yaml is deliberately NOT
-        # excluded — the drift check reads it.
+        # docs and test fixtures that never affect what gets published. Written
+        # as exclusions rather than an allowlist of sources on purpose: an
+        # allowlist silently stops matching once a Dockerfile starts COPYing a
+        # new file, leaving a published image stale until the next nightly.
+        # spec.yaml is deliberately NOT excluded — the drift check reads it.
         run: |
           set -euo pipefail
           filters=""
@@ -187,6 +197,25 @@ jobs:
           echo "kits=${kits:-[]}" >> "$GITHUB_OUTPUT"
           echo "Building: ${kits}"
 
+          # Which of this run's kits also build their own image — decides
+          # per-kit, in publish-one-kit.yml, whether its `image` job runs at
+          # all. Computed here (not per-matrix-leg) because it needs the
+          # checkout this job already has; a job's own `if:` can't see repo
+          # content checked out by one of its own later steps.
+          #
+          # `|| continue`, not `&&`: under `set -e`, a while loop's exit status
+          # is its last iteration's — if the LAST kit in the list has no
+          # Dockerfile, `[ -f ... ] && printf` would fail on that iteration,
+          # and pipefail would then fail the whole assignment, killing this
+          # step before it reaches the outputs below. `|| continue` always
+          # exits 0 on a false test, regardless of which iteration it's on.
+          dockerfile_kits=$(echo "${kits:-[]}" | jq -r '.[]' | while read -r k; do
+            [ -f "$k/Dockerfile" ] || continue
+            printf '%s\n' "$k"
+          done | jq -R . | jq -sc .)
+          echo "dockerfile-kits=${dockerfile_kits:-[]}" >> "$GITHUB_OUTPUT"
+          echo "Kits with their own image: ${dockerfile_kits}"
+
           # Kit artifacts are published for the allow-listed kits only, and the
           # list is intersected with what is being built rather than used
           # directly — a kit named here but not rebuilt this run has nothing new
@@ -243,6 +272,7 @@ jobs:
     with:
       kit: ${{ matrix.kit }}
       dated: ${{ needs.detect-changes.outputs.dated }}
+      has-image: ${{ contains(fromJson(needs.detect-changes.outputs.dockerfile-kits), matrix.kit) }}
       # Not every kit that builds an image publishes its artifact: `artifacts` is
       # `kits` intersected with the allow-list. No `schedule` either — a kit's
       # content is a pure function of the commit, so a nightly re-push would only

--- a/.github/workflows/hub-overview.yml
+++ b/.github/workflows/hub-overview.yml
@@ -72,7 +72,10 @@ jobs:
       - name: Resolve the kits to sync
         id: kits
         # Same allow-list as publishing: a kit with no Hub repositories has no
-        # pages to sync.
+        # pages to sync. This default is duplicated (not read from a single
+        # source) in build-and-publish-kits.yml, publish-artifact.yml, and
+        # scripts/publish-artifact.sh's own fallback — keep all four in step
+        # when this list changes.
         run: |
           set -euo pipefail
           if [ -n "${ONE_KIT}" ]; then
@@ -84,7 +87,12 @@ jobs:
           echo "Syncing overviews for: ${list}"
         env:
           ONE_KIT: ${{ inputs.kit }}
-          PUBLISH_KITS: ${{ vars.PUBLISH_KITS || 'kiro' }}
+          PUBLISH_KITS: >-
+            ${{ vars.PUBLISH_KITS || 'amp claude-acp claude-model-runner claude-ollama
+            claude-sbx-statusline code-server codex-acp codex-app-server crush
+            git-ssh-sign github-ssh hermes-agent junie kiro mise nanobot nanoclaw
+            neovim openclaw opencode-model-runner packages-through-sfw pi playwright
+            smolagents task trivy vale' }}
 
       # Two gates, mutually exclusive, so the credential is NEVER referenced on
       # the pull-request path.

--- a/.github/workflows/publish-artifact.yml
+++ b/.github/workflows/publish-artifact.yml
@@ -55,9 +55,20 @@ env:
   # than discovery. Passed to the script, which enforces it — build-and-publish-kits.yml
   # also intersects its matrix with the same variable so it does not spawn jobs
   # that would only refuse, but the release path picks its kit from a git tag and
-  # has nothing to intersect. Both read the same variable; keep the defaults in
-  # step.
-  PUBLISH_KITS: ${{ vars.PUBLISH_KITS || 'kiro' }}
+  # has nothing to intersect. This default is duplicated (not read from a single
+  # source) in build-and-publish-kits.yml, hub-overview.yml, and this script's
+  # own PUBLISH_KITS fallback in scripts/publish-artifact.sh — reusable workflows
+  # don't inherit a caller's env, so each copy is load-bearing. A prior version
+  # of this file kept only 'kiro' here while the other three were widened,
+  # which made every kit's publish step hard-fail with "not in PUBLISH_KITS
+  # (kiro)" despite build-and-publish-kits.yml deciding to run it. Keep all
+  # four in step when this list changes.
+  PUBLISH_KITS: >-
+    ${{ vars.PUBLISH_KITS || 'amp claude-acp claude-model-runner claude-ollama
+    claude-sbx-statusline code-server codex-acp codex-app-server crush
+    git-ssh-sign github-ssh hermes-agent junie kiro mise nanobot nanoclaw
+    neovim openclaw opencode-model-runner packages-through-sfw pi playwright
+    smolagents task trivy vale' }}
   # Publish for real only from this repository, off a pull request, with the Hub
   # connection configured. Otherwise the script resolves and reports without
   # touching the registry, which is what makes the pull-request run meaningful.

--- a/.github/workflows/publish-one-kit.yml
+++ b/.github/workflows/publish-one-kit.yml
@@ -23,6 +23,14 @@ on:
           that `uses:` a reusable workflow cannot run steps to call `date`.
         required: true
         type: string
+      has-image:
+        description: |
+          Whether this kit has its own Dockerfile. Computed by the caller
+          (build-and-publish-kits.yml's detect-changes), not here — a job's own `if:`
+          can't see repo content a step of that same job would check out, so
+          this can't be a `hashFiles()` check inside this workflow.
+        type: boolean
+        default: false
       publish-artifact:
         description: |
           Whether to publish the kit ARTIFACT and sync its Hub pages. False for a
@@ -52,7 +60,10 @@ env:
   PLATFORMS: ${{ vars.PLATFORMS || 'linux/amd64,linux/arm64' }}
 
 jobs:
+  # Most kits are mixins layered onto someone else's image and have nothing to
+  # build here — this job runs only for the ones that do.
   image:
+    if: inputs.has-image
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -296,7 +307,16 @@ jobs:
 
   artifact:
     needs: image
-    if: inputs.publish-artifact
+    # `!cancelled()` overrides GitHub's implicit `&& success()` on this if —
+    # needed because `image` is legitimately skipped for a kit with no
+    # Dockerfile (see `has-image` above), and a skipped need does not satisfy
+    # an implicit success check. `always()` would do the same override but
+    # also run this after the workflow run itself was cancelled; `!cancelled()`
+    # doesn't. The explicit result check below is what still refuses to run
+    # this if `image` genuinely failed.
+    if: >-
+      !cancelled() && inputs.publish-artifact &&
+      (needs.image.result == 'success' || needs.image.result == 'skipped')
     permissions:
       contents: read
       id-token: write

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -49,10 +49,12 @@ kit's image.
 | `workflow_dispatch` | yes | yes |
 | Pull request | yes | **no** |
 
-The workflow **discovers** kits rather than listing them: any directory with
-both a `spec.yaml` and a `Dockerfile` is picked up, so a new image-publishing
-kit needs no workflow change. The build context is the kit directory, with
-`Dockerfile` at its root.
+The workflow **discovers** kits rather than listing them: any directory with a
+`spec.yaml` is a candidate. Whether one also builds an image is a separate,
+per-kit question — decided by `Dockerfile` presence, not by anything the
+workflow is told — so a new image-publishing kit needs no workflow change
+either way. The build context is the kit directory, with `Dockerfile` at its
+root.
 
 The nightly run matters because these images track moving upstreams rather than
 pinned versions — agents are typically installed from a `latest` channel and

--- a/amp/spec.yaml
+++ b/amp/spec.yaml
@@ -1,35 +1,36 @@
-schemaVersion: "1"
-kind: agent
+schemaVersion: "2"
+kind: sandbox
 name: amp
 displayName: Amp
 description: The frontier coding agent.
-
-agent:
-  image: "docker/sandbox-templates:shell-docker"
-  aiFilename: AGENTS.md
+sandbox:
+  image: docker/sandbox-templates:shell-docker
   entrypoint:
-    run: [amp, --dangerously-allow-all]
+    - amp
+    - --dangerously-allow-all
+agentInstructions:
+  filename: AGENTS.md
+  content: |
+    ## Sandbox environment
 
-network:
-  serviceDomains:
-    ampcode.com: amp
-  serviceAuth:
-    amp:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-  allowedDomains:
-    - "ampcode.com:443"
-    - "*.ampcode.com:443"
-
-commands:
+    You are running inside a Docker sandbox. The workspace is mounted at
+    its absolute host path. `sudo` is passwordless; use it for package
+    installs.
+permissions:
+  network:
+    allow:
+      - ampcode.com:443
+      - '*.ampcode.com:443'
+credentials:
+  - service: amp
+    apiKey:
+      name: ""
+      inject:
+        - domain: ampcode.com
+          header: Authorization
+          format: Bearer %s
+setup:
   install:
-    - command: "curl -fsSL https://ampcode.com/install.sh | bash"
+    - command: curl -fsSL https://ampcode.com/install.sh | bash
       user: "1000"
       description: Install Amp
-
-memory: |
-  ## Sandbox environment
-
-  You are running inside a Docker sandbox. The workspace is mounted at
-  its absolute host path. `sudo` is passwordless; use it for package
-  installs.

--- a/claude-model-runner/spec.yaml
+++ b/claude-model-runner/spec.yaml
@@ -1,4 +1,4 @@
-schemaVersion: "1"
+schemaVersion: "2"
 kind: mixin
 name: claude-model-runner
 # Reroutes Claude Code's Anthropic API; only meaningful on the claude base

--- a/claude-ollama/spec.yaml
+++ b/claude-ollama/spec.yaml
@@ -1,28 +1,33 @@
-schemaVersion: "1"
-kind: agent
+schemaVersion: "2"
+kind: sandbox
 name: claude-ollama
 displayName: Claude Code (Ollama)
 description: Claude Code wired to Ollama Anthropic-compatible API, with configurable model.
-
-agent:
-  image: "docker/sandbox-templates:claude-code-docker"
-  aiFilename: CLAUDE.md
+sandbox:
+  image: docker/sandbox-templates:claude-code-docker
   entrypoint:
-    run: [/home/agent/.local/bin/claude-ollama]
+    - /home/agent/.local/bin/claude-ollama
+agentInstructions:
+  filename: CLAUDE.md
+  content: |
+    ## Sandbox environment
 
+    You are running inside a Docker sandbox. All API calls are routed to a local
+    Ollama instance on the host (http://host.docker.internal:11434) — Anthropic's
+    API is not reachable. The workspace is mounted at its absolute host path.
+    `sudo` is passwordless; use it for package installs.
+permissions:
+  network:
+    allow:
+      - localhost:11434
 environment:
   variables:
-    CLAUDE_OLLAMA_MODEL: "gemma4:e4b-it-q4_K_M"
-
-network:
-  allowedDomains:
-    - "localhost:11434"
-
-commands:
+    CLAUDE_OLLAMA_MODEL: gemma4:e4b-it-q4_K_M
+setup:
   # Phase 4 lifts the former `settings: { containerSettings: { claude: true } }`
   # block into the kit. ~/.claude.json carries only the credential-independent
   # bypass flags (static init file, native onlyIfMissing idempotency). The
-  # settings.json is seeded in commands.install below. Content SYNCed with the
+  # settings.json is seeded in setup.install below. Content SYNCed with the
   # claude kit.
   #
   # This kit declares NO credential service (Ollama is a local model; the
@@ -58,9 +63,9 @@ commands:
         " > /home/agent/.claude/settings.json
         fi
         chown -R agent:agent /home/agent/.claude
-      user: "root"
+      user: root
       description: Seed Claude settings.json (none path; no credential service)
-  initFiles:
+  files:
     - path: /home/agent/.claude.json
       content: |
         {
@@ -75,8 +80,6 @@ commands:
       onlyIfMissing: true
       description: Claude bypass flags (mode-independent)
     - path: /home/agent/.local/bin/claude-ollama
-      mode: "0755"
-      description: Wrapper script that routes Claude Code to the local Ollama instance
       content: |
         #!/usr/bin/env bash
         set -euo pipefail
@@ -91,11 +94,5 @@ commands:
         export CLAUDE_CODE_SUBAGENT_MODEL="$CLAUDE_OLLAMA_MODEL"
 
         exec claude "$@"
-
-memory: |
-  ## Sandbox environment
-
-  You are running inside a Docker sandbox. All API calls are routed to a local
-  Ollama instance on the host (http://host.docker.internal:11434) — Anthropic's
-  API is not reachable. The workspace is mounted at its absolute host path.
-  `sudo` is passwordless; use it for package installs.
+      mode: "0755"
+      description: Wrapper script that routes Claude Code to the local Ollama instance

--- a/claude-sbx-statusline/spec.yaml
+++ b/claude-sbx-statusline/spec.yaml
@@ -1,10 +1,17 @@
-schemaVersion: "1"
+schemaVersion: "2"
 kind: mixin
 name: claude-sbx-statusline
 displayName: Claude Code Status Line
 description: Adds a two-line Docker Sandboxes status line to Claude Code (host, cwd, git branch, model, context %, memory, load, cost). Ships ~/.claude/statusline.sh and sets the statusLine key in ~/.claude/settings.json, merging so every other setting is preserved (an existing statusLine is intentionally replaced, since installing this status line is the point of the kit).
+agentInstructions:
+  content: |
+    ## Status line
 
-commands:
+    This sandbox renders a custom Claude Code status line via
+    ~/.claude/statusline.sh, registered under `statusLine` in
+    ~/.claude/settings.json. It shows the sandbox host, working directory, git
+    branch, model, context-window %, memory, load average, and session cost.
+setup:
   install:
     - command: |
         set -e
@@ -20,11 +27,3 @@ commands:
         chown -R agent:agent /home/agent/.claude
       user: "0"
       description: Set the statusLine key in ~/.claude/settings.json to ~/.claude/statusline.sh (jq merge, so all other keys are preserved; any existing statusLine is replaced by design)
-
-agentContext: |
-  ## Status line
-
-  This sandbox renders a custom Claude Code status line via
-  ~/.claude/statusline.sh, registered under `statusLine` in
-  ~/.claude/settings.json. It shows the sandbox host, working directory, git
-  branch, model, context-window %, memory, load average, and session cost.

--- a/code-server/spec.yaml
+++ b/code-server/spec.yaml
@@ -1,4 +1,4 @@
-schemaVersion: "1"
+schemaVersion: "2"
 kind: mixin
 name: code-server
 # Layered onto the claude base agent (the bundled VS Code extension is Claude
@@ -8,46 +8,48 @@ requires:
   agent: claude
 displayName: code-server (web VS Code) with Claude Code
 description: Runs code-server on port 8080, opened on the sandbox workspace, with the Claude Code VS Code extension preinstalled. Pair with the built-in claude agent so the extension inherits the sandbox's Anthropic credentials.
-
-network:
-  publishedPorts:
-    - container: 8080
-      protocol: tcp
-      name: code-server
-  allowedDomains:
-    # `https://code-server.dev/install.sh` is a Cloudflare 302 redirect to
-    # `https://raw.githubusercontent.com/cdr/code-server/main/install.sh` —
-    # the install hook's `curl -fsSL https://code-server.dev/install.sh`
-    # transparently follows the redirect, so the kit needs both hosts
-    # allowed for the install script to even download.
-    - code-server.dev
-    - raw.githubusercontent.com
-    - github.com
-    # The code-server install.sh resolves the latest release via a
-    # `github.com/.../releases/latest` redirect, then follows the
-    # `github.com` release URL to the asset host. GitHub recently
-    # rotated asset downloads from `objects.githubusercontent.com` to
-    # `release-assets.githubusercontent.com`; both must be allowed.
-    - api.github.com
-    - objects.githubusercontent.com
-    - release-assets.githubusercontent.com
-    - open-vsx.org
-    - openvsx.eclipsecontent.org
-
-commands:
+permissions:
+  network:
+    allow:
+      # `https://code-server.dev/install.sh` is a Cloudflare 302 redirect to
+      # `https://raw.githubusercontent.com/cdr/code-server/main/install.sh` —
+      # the install hook's `curl -fsSL https://code-server.dev/install.sh`
+      # transparently follows the redirect, so the kit needs both hosts
+      # allowed for the install script to even download.
+      - code-server.dev
+      - raw.githubusercontent.com
+      - github.com
+      # The code-server install.sh resolves the latest release via a
+      # `github.com/.../releases/latest` redirect, then follows the
+      # `github.com` release URL to the asset host. GitHub recently
+      # rotated asset downloads from `objects.githubusercontent.com` to
+      # `release-assets.githubusercontent.com`; both must be allowed.
+      - api.github.com
+      - objects.githubusercontent.com
+      - release-assets.githubusercontent.com
+      - open-vsx.org
+      - openvsx.eclipsecontent.org
+ports:
+  - container: 8080
+    protocol: tcp
+    name: code-server
+setup:
   install:
-    - command: "curl -fsSL https://code-server.dev/install.sh | sh"
+    - command: curl -fsSL https://code-server.dev/install.sh | sh
       description: Install code-server via the upstream install script
-    - command: "code-server --install-extension anthropic.claude-code"
+    - command: code-server --install-extension anthropic.claude-code
       user: "1000"
       description: Pre-install the Claude Code extension from open-vsx so you have a native chat panel that talks to the claude agent's credentials
-  initFiles:
+  startup:
+    - command:
+        - sh
+        - -c
+        - nohup /home/agent/.local/bin/start-code-server.sh > /tmp/code-server.log 2>&1 &
+      user: "1000"
+      description: Start code-server in the background, opened on the primary workspace
+  files:
     - path: /home/agent/.local/bin/start-code-server.sh
       content: |
         exec code-server --bind-addr 0.0.0.0:8080 --auth none "${WORKDIR}"
       mode: "0755"
       description: Startup wrapper with the workspace path baked in at sandbox start
-  startup:
-    - command: ["sh", "-c", "nohup /home/agent/.local/bin/start-code-server.sh > /tmp/code-server.log 2>&1 &"]
-      user: "1000"
-      description: Start code-server in the background, opened on the primary workspace

--- a/codex-app-server/spec.yaml
+++ b/codex-app-server/spec.yaml
@@ -1,4 +1,4 @@
-schemaVersion: "1"
+schemaVersion: "2"
 kind: mixin
 name: codex-app-server
 # sshd + codex bridge; only meaningful on the codex base agent. Declares
@@ -7,53 +7,46 @@ name: codex-app-server
 requires:
   agent: codex
 displayName: Codex app-server (via SSH)
-description: Runs sshd in the sandbox and pre-populates `authorized_keys` from the host's forwarded SSH agent, so the Codex Mac GUI can add the sandbox as an SSH Connection and drive `codex app-server` remotely. The kit declares port 22 in `network.publishedPorts`, so the runtime exposes sshd on an ephemeral host port at sandbox start.
+description: Runs sshd in the sandbox and pre-populates `authorized_keys` from the host's forwarded SSH agent, so the Codex Mac GUI can add the sandbox as an SSH Connection and drive `codex app-server` remotely. The kit declares port 22 in `ports`, so the runtime exposes sshd on an ephemeral host port at sandbox start.
+agentInstructions:
+  content: |
+    ## Codex app-server over SSH
 
-network:
-  publishedPorts:
-    - container: 22
-      protocol: tcp
-      name: sshd
-  allowedDomains:
-    # `apt-get update` (run by commands.install[0]) refreshes metadata for
-    # every configured apt source. The codex-docker base template
-    # pre-configures Docker's apt repo, so `download.docker.com` must be
-    # allowed even though this kit only installs `openssh-server` from
-    # Ubuntu's main archive — apt-get exits 100 on the first source
-    # metadata fetch that returns non-2xx. Ubuntu hosts amd64 packages on
-    # archive/security and arm64 packages on ports.ubuntu.com, so all
-    # three Ubuntu hosts are listed for cross-arch coverage.
-    - archive.ubuntu.com        # Ubuntu archive (amd64 main)
-    - security.ubuntu.com       # Ubuntu security updates (amd64)
-    - ports.ubuntu.com          # Ubuntu archive/security (arm64)
-    - download.docker.com       # Docker's apt repo, pre-added by codex-docker
+    sshd is running inside the sandbox on port 22, and your host's SSH
+    identities (from the forwarded agent socket) are pre-populated in
+    `/home/agent/.ssh/authorized_keys`. The kit declares port 22 in its
+    `ports`, so the runtime exposes sshd on an ephemeral host
+    port automatically. Discover the assigned port with
+    `sbx ports <sandbox>`, then add an SSH connection in the Codex Mac
+    app:
 
-commands:
-  initFiles:
-    - path: /home/agent/.local/bin/refresh-authorized-keys
-      mode: "0755"
-      description: Refresh /home/agent/.ssh/authorized_keys from the forwarded SSH agent. Invoked by the startup hook; safe to invoke manually too.
-      content: |
-        #!/bin/sh
-        # sbx runs startup hooks with a clean env (no SSH_AUTH_SOCK), so
-        # naïve `ssh-add -L` fails on every wake. Snapshot SSH_AUTH_SOCK
-        # from PID 1's environ — the socket file itself is available at
-        # startup time, just not the env var pointing at it.
-        if [ -z "$SSH_AUTH_SOCK" ]; then
-            SSH_AUTH_SOCK=$(tr '\0' '\n' < /proc/1/environ | grep -m1 '^SSH_AUTH_SOCK=' | cut -d= -f2-)
-            export SSH_AUTH_SOCK
-        fi
-        if [ ! -S "$SSH_AUTH_SOCK" ]; then
-            echo "[sbx-codex] no agent socket; keeping existing authorized_keys" >&2
-            exit 0
-        fi
-        keys=$(ssh-add -L 2>&1)
-        if [ $? -ne 0 ] || [ -z "$keys" ]; then
-            echo "[sbx-codex] ssh-add returned no keys; keeping existing authorized_keys" >&2
-            exit 0
-        fi
-        printf '%s\n' "$keys" > /home/agent/.ssh/authorized_keys
-        chmod 600 /home/agent/.ssh/authorized_keys
+        Host: localhost
+        Port: <host-port from sbx ports>
+        User: agent
+
+    The Codex GUI will SSH in and run `codex app-server` over stdio.
+    Model traffic continues to route through the codex agent's OpenAI
+    credential proxy, so no API key lives in the sandbox.
+permissions:
+  network:
+    allow:
+      # `apt-get update` (run by setup.install[0]) refreshes metadata for
+      # every configured apt source. The codex-docker base template
+      # pre-configures Docker's apt repo, so `download.docker.com` must be
+      # allowed even though this kit only installs `openssh-server` from
+      # Ubuntu's main archive — apt-get exits 100 on the first source
+      # metadata fetch that returns non-2xx. Ubuntu hosts amd64 packages on
+      # archive/security and arm64 packages on ports.ubuntu.com, so all
+      # three Ubuntu hosts are listed for cross-arch coverage.
+      - archive.ubuntu.com        # Ubuntu archive (amd64 main)
+      - security.ubuntu.com       # Ubuntu security updates (amd64)
+      - ports.ubuntu.com          # Ubuntu archive/security (arm64)
+      - download.docker.com       # Docker's apt repo, pre-added by codex-docker
+ports:
+  - container: 22
+    protocol: tcp
+    name: sshd
+setup:
   install:
     - command: apt-get update -qq && apt-get install -y -qq openssh-server
       user: "0"
@@ -91,28 +84,38 @@ commands:
       user: "0"
       description: Shadow `codex` on PATH with a bridge that imports PID 1's proxy env before exec'ing the real binary
   startup:
-    - command: ["/home/agent/.local/bin/refresh-authorized-keys"]
+    - command:
+        - /home/agent/.local/bin/refresh-authorized-keys
       user: "1000"
       description: Refresh authorized_keys from the forwarded SSH agent
-    - command: ["sh", "-c", "pgrep -x sshd >/dev/null || { mkdir -p /var/run/sshd && /usr/sbin/sshd > /tmp/sshd.log 2>&1; }"]
+    - command:
+        - sh
+        - -c
+        - pgrep -x sshd >/dev/null || { mkdir -p /var/run/sshd && /usr/sbin/sshd > /tmp/sshd.log 2>&1; }
       user: "0"
       description: Start sshd if not already running (recreates /var/run/sshd which is tmpfs-cleared on container restart)
-
-memory: |
-  ## Codex app-server over SSH
-
-  sshd is running inside the sandbox on port 22, and your host's SSH
-  identities (from the forwarded agent socket) are pre-populated in
-  `/home/agent/.ssh/authorized_keys`. The kit declares port 22 in its
-  `publishedPorts`, so the runtime exposes sshd on an ephemeral host
-  port automatically. Discover the assigned port with
-  `sbx ports <sandbox>`, then add an SSH connection in the Codex Mac
-  app:
-
-      Host: localhost
-      Port: <host-port from sbx ports>
-      User: agent
-
-  The Codex GUI will SSH in and run `codex app-server` over stdio.
-  Model traffic continues to route through the codex agent's OpenAI
-  credential proxy, so no API key lives in the sandbox.
+  files:
+    - path: /home/agent/.local/bin/refresh-authorized-keys
+      content: |
+        #!/bin/sh
+        # sbx runs startup hooks with a clean env (no SSH_AUTH_SOCK), so
+        # naïve `ssh-add -L` fails on every wake. Snapshot SSH_AUTH_SOCK
+        # from PID 1's environ — the socket file itself is available at
+        # startup time, just not the env var pointing at it.
+        if [ -z "$SSH_AUTH_SOCK" ]; then
+            SSH_AUTH_SOCK=$(tr '\0' '\n' < /proc/1/environ | grep -m1 '^SSH_AUTH_SOCK=' | cut -d= -f2-)
+            export SSH_AUTH_SOCK
+        fi
+        if [ ! -S "$SSH_AUTH_SOCK" ]; then
+            echo "[sbx-codex] no agent socket; keeping existing authorized_keys" >&2
+            exit 0
+        fi
+        keys=$(ssh-add -L 2>&1)
+        if [ $? -ne 0 ] || [ -z "$keys" ]; then
+            echo "[sbx-codex] ssh-add returned no keys; keeping existing authorized_keys" >&2
+            exit 0
+        fi
+        printf '%s\n' "$keys" > /home/agent/.ssh/authorized_keys
+        chmod 600 /home/agent/.ssh/authorized_keys
+      mode: "0755"
+      description: Refresh /home/agent/.ssh/authorized_keys from the forwarded SSH agent. Invoked by the startup hook; safe to invoke manually too.

--- a/crush/README.md
+++ b/crush/README.md
@@ -1,6 +1,6 @@
 # crush
 
-A standalone agent kit (`kind: agent`) for [Crush](https://github.com/charmbracelet/crush),
+A standalone sandbox kit for [Crush](https://github.com/charmbracelet/crush),
 Charm's multi-provider AI coding agent. The kit installs Crush from the
 official Charm apt repository, wires API auth for 15 model providers
 through the sandbox proxy, and runs `crush --yolo` as the entrypoint when
@@ -13,7 +13,7 @@ At least one provider API key exported on your host. Crush supports:
 - Anthropic (`ANTHROPIC_API_KEY`)
 - OpenAI (`OPENAI_API_KEY`)
 - Azure OpenAI (`AZURE_OPENAI_API_KEY`)
-- Google Gemini (`GEMINI_API_KEY` or `GOOGLE_GENERATIVE_AI_API_KEY`)
+- Google Gemini (`GEMINI_API_KEY`)
 - Mistral (`MISTRAL_API_KEY`)
 - Groq (`GROQ_API_KEY`)
 - Cerebras (`CEREBRAS_API_KEY`)
@@ -46,22 +46,21 @@ sandbox.
 
 ## How auth works
 
-The kit's `network` block declares a `serviceDomain` for every supported
-provider's API host and a matching `serviceAuth` entry describing the
-auth header (`Authorization: Bearer …`, `x-api-key: …`, etc). The
-`credentials.sources` block tells the proxy which host env var holds
-each provider's secret.
+The kit's `credentials` list declares an `apiKey` entry for every supported
+provider, each with an `inject` rule describing the target domain and the
+auth header (`Authorization: Bearer …`, `x-api-key: …`, etc) and which host
+env var holds that provider's secret.
 
 When Crush makes a request to (say) `api.openai.com`, the proxy:
 
-1. Looks up the service for the domain (`openai`).
-2. Looks up the credential source for that service (`OPENAI_API_KEY` on
-   the host).
+1. Looks up the credential whose `inject` list matches the domain (`openai`).
+2. Reads that credential's env var (`OPENAI_API_KEY`) on the host.
 3. Injects `Authorization: Bearer <real-key>` on the outbound request.
 
-The real key never enters the sandbox. The `environment.proxyManaged`
-list exposes a placeholder value for each `*_API_KEY` env var inside the
-container so Crush sees the variables it expects to find.
+The real key never enters the sandbox. Each credential sets
+`apiKey.proxyManaged: true`, which exposes a placeholder value for its
+`*_API_KEY` env var inside the container so Crush sees the variables it
+expects to find.
 
-`allowedDomains` covers the install repo (`repo.charm.sh`) and every
-provider API host.
+`permissions.network.allow` covers the install repo (`repo.charm.sh`) and
+every provider API host.

--- a/crush/spec.yaml
+++ b/crush/spec.yaml
@@ -1,170 +1,199 @@
-schemaVersion: "1"
-kind: agent
+schemaVersion: "2"
+kind: sandbox
 name: crush
 displayName: Crush
 description: Multi-provider AI coding agent from Charm, with proxy-mediated auth for 15 model providers.
-
-agent:
-  image: "docker/sandbox-templates:shell-docker"
-  aiFilename: AGENTS.md
+sandbox:
+  image: docker/sandbox-templates:shell-docker
   entrypoint:
-    run: [crush]
-    args: ["--yolo"]
+    - crush
+  command:
+    default:
+      - --yolo
+agentInstructions:
+  filename: AGENTS.md
+  content: |
+    ## Crush
 
-environment:
-  proxyManaged:
-    - ANTHROPIC_API_KEY
-    - AWS_ACCESS_KEY_ID
-    - AZURE_OPENAI_API_KEY
-    - CEREBRAS_API_KEY
-    - GEMINI_API_KEY
-    - GOOGLE_GENERATIVE_AI_API_KEY
-    - GROQ_API_KEY
-    - HF_TOKEN
-    - IONET_API_KEY
-    - MINIMAX_API_KEY
-    - MISTRAL_API_KEY
-    - OPENAI_API_KEY
-    - OPENROUTER_API_KEY
-    - SYNTHETIC_API_KEY
-    - VERCEL_API_KEY
-    - ZAI_API_KEY
+    Crush is a multi-provider AI coding agent from Charm. It is installed
+    as `crush` on `PATH` and started with `--yolo` so it skips interactive
+    permission prompts (the sandbox itself is the safety boundary).
 
+    Set any of the provider API keys on your host (e.g. `ANTHROPIC_API_KEY`,
+    `OPENAI_API_KEY`, `GROQ_API_KEY`) and the sandbox proxy will inject them
+    on outbound requests to the matching provider. See
+    <https://github.com/charmbracelet/crush> for usage.
+permissions:
+  network:
+    allow:
+      - repo.charm.sh
+      # `apt-get update` (run by the install hooks) refreshes metadata for
+      # every configured apt source — failing on any one of them returns
+      # exit 100 even if the kit's package would come from a different
+      # repo. The shell-docker template ships with three sources, so all
+      # three must be allowed for the kit's install to succeed under
+      # `deny-all`. Ubuntu hosts amd64 packages on archive/security and
+      # arm64 packages on ports.ubuntu.com, so all three Ubuntu hosts are
+      # listed to keep the kit working cross-arch.
+      - archive.ubuntu.com        # Ubuntu archive (amd64 main)
+      - security.ubuntu.com       # Ubuntu security updates (amd64)
+      - ports.ubuntu.com          # Ubuntu archive/security (arm64)
+      - download.docker.com       # Docker's apt repo, pre-added by shell-docker
+      # Charm distributes the actual `crush` .deb via Gemfury's S3-accelerated
+      # bucket — `repo.charm.sh` only serves the apt index; package payloads
+      # are signed-URL redirects to this host.
+      - gemfury.s3-accelerate.dualstack.amazonaws.com
+      - api.anthropic.com
+      - api.openai.com
+      - '*.openai.azure.com'
+      - generativelanguage.googleapis.com
+      - api.mistral.ai
+      - api.groq.com
+      - groq.com
+      - api.cerebras.ai
+      - openrouter.ai
+      - api-inference.huggingface.co
+      - api.io.net
+      - api.minimax.chat
+      - api.synthetic.com
+      - api.zai.com
+      - v0.dev
+      - bedrock-runtime.*.amazonaws.com
+      - bedrock.*.amazonaws.com
 credentials:
-  sources:
-    anthropic:
-      env: [ANTHROPIC_API_KEY]
-    aws:
-      env: [AWS_ACCESS_KEY_ID]
-    azure-openai:
-      env: [AZURE_OPENAI_API_KEY]
-    cerebras:
-      env: [CEREBRAS_API_KEY]
-    google:
-      env: [GEMINI_API_KEY, GOOGLE_GENERATIVE_AI_API_KEY]
-    groq:
-      env: [GROQ_API_KEY]
-    huggingface:
-      env: [HF_TOKEN]
-    ionet:
-      env: [IONET_API_KEY]
-    minimax:
-      env: [MINIMAX_API_KEY]
-    mistral:
-      env: [MISTRAL_API_KEY]
-    openai:
-      env: [OPENAI_API_KEY]
-    openrouter:
-      env: [OPENROUTER_API_KEY]
-    synthetic:
-      env: [SYNTHETIC_API_KEY]
-    vercel:
-      env: [VERCEL_API_KEY]
-    zai:
-      env: [ZAI_API_KEY]
-
-network:
-  serviceDomains:
-    api.anthropic.com: anthropic
-    api.openai.com: openai
-    "*.openai.azure.com": azure-openai
-    generativelanguage.googleapis.com: google
-    api.mistral.ai: mistral
-    api.groq.com: groq
-    groq.com: groq
-    api.cerebras.ai: cerebras
-    openrouter.ai: openrouter
-    api-inference.huggingface.co: huggingface
-    api.io.net: ionet
-    api.minimax.chat: minimax
-    api.synthetic.com: synthetic
-    api.zai.com: zai
-    v0.dev: vercel
-    "bedrock-runtime.*.amazonaws.com": aws
-    "bedrock.*.amazonaws.com": aws
-  serviceAuth:
-    anthropic:
-      headerName: x-api-key
-      valueFormat: "%s"
-    openai:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-    azure-openai:
-      headerName: api-key
-      valueFormat: "%s"
-    google:
-      headerName: x-goog-api-key
-      valueFormat: "%s"
-    mistral:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-    groq:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-    cerebras:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-    openrouter:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-    huggingface:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-    ionet:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-    minimax:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-    synthetic:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-    vercel:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-    zai:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-    aws:
-      headerName: Authorization
-      valueFormat: "AWS4-HMAC-SHA256 Credential=%s/"
-  allowedDomains:
-    - repo.charm.sh
-    # `apt-get update` (run by the install hooks) refreshes metadata for
-    # every configured apt source — failing on any one of them returns
-    # exit 100 even if the kit's package would come from a different
-    # repo. The shell-docker template ships with three sources, so all
-    # three must be allowed for the kit's install to succeed under
-    # `deny-all`. Ubuntu hosts amd64 packages on archive/security and
-    # arm64 packages on ports.ubuntu.com, so all three Ubuntu hosts are
-    # listed to keep the kit working cross-arch.
-    - archive.ubuntu.com        # Ubuntu archive (amd64 main)
-    - security.ubuntu.com       # Ubuntu security updates (amd64)
-    - ports.ubuntu.com          # Ubuntu archive/security (arm64)
-    - download.docker.com       # Docker's apt repo, pre-added by shell-docker
-    # Charm distributes the actual `crush` .deb via Gemfury's S3-accelerated
-    # bucket — `repo.charm.sh` only serves the apt index; package payloads
-    # are signed-URL redirects to this host.
-    - gemfury.s3-accelerate.dualstack.amazonaws.com
-    - api.anthropic.com
-    - api.openai.com
-    - "*.openai.azure.com"
-    - generativelanguage.googleapis.com
-    - api.mistral.ai
-    - api.groq.com
-    - groq.com
-    - api.cerebras.ai
-    - openrouter.ai
-    - api-inference.huggingface.co
-    - api.io.net
-    - api.minimax.chat
-    - api.synthetic.com
-    - api.zai.com
-    - v0.dev
-    - "bedrock-runtime.*.amazonaws.com"
-    - "bedrock.*.amazonaws.com"
-
-commands:
+  - service: anthropic
+    apiKey:
+      name: ANTHROPIC_API_KEY
+      proxyManaged: true
+      inject:
+        - domain: api.anthropic.com
+          header: x-api-key
+          format: '%s'
+  - service: aws
+    apiKey:
+      name: AWS_ACCESS_KEY_ID
+      proxyManaged: true
+      inject:
+        - domain: bedrock-runtime.*.amazonaws.com
+          header: Authorization
+          format: AWS4-HMAC-SHA256 Credential=%s/
+        - domain: bedrock.*.amazonaws.com
+          header: Authorization
+          format: AWS4-HMAC-SHA256 Credential=%s/
+  - service: azure-openai
+    apiKey:
+      name: AZURE_OPENAI_API_KEY
+      proxyManaged: true
+      inject:
+        - domain: '*.openai.azure.com'
+          header: api-key
+          format: '%s'
+  - service: cerebras
+    apiKey:
+      name: CEREBRAS_API_KEY
+      proxyManaged: true
+      inject:
+        - domain: api.cerebras.ai
+          header: Authorization
+          format: Bearer %s
+  # v1 also accepted GOOGLE_GENERATIVE_AI_API_KEY as a fallback host env var
+  # name for this credential (credentials.sources.google.env listed both).
+  # v2's apiKey.name is a single string with no alias list, so only one host
+  # env var can be recognized here; GEMINI_API_KEY is Google's current
+  # canonical name for this key, so it's the one kept. A host with only
+  # GOOGLE_GENERATIVE_AI_API_KEY set will no longer be picked up.
+  - service: google
+    apiKey:
+      name: GEMINI_API_KEY
+      proxyManaged: true
+      inject:
+        - domain: generativelanguage.googleapis.com
+          header: x-goog-api-key
+          format: '%s'
+  - service: groq
+    apiKey:
+      name: GROQ_API_KEY
+      proxyManaged: true
+      inject:
+        - domain: api.groq.com
+          header: Authorization
+          format: Bearer %s
+        - domain: groq.com
+          header: Authorization
+          format: Bearer %s
+  - service: huggingface
+    apiKey:
+      name: HF_TOKEN
+      proxyManaged: true
+      inject:
+        - domain: api-inference.huggingface.co
+          header: Authorization
+          format: Bearer %s
+  - service: ionet
+    apiKey:
+      name: IONET_API_KEY
+      proxyManaged: true
+      inject:
+        - domain: api.io.net
+          header: Authorization
+          format: Bearer %s
+  - service: minimax
+    apiKey:
+      name: MINIMAX_API_KEY
+      proxyManaged: true
+      inject:
+        - domain: api.minimax.chat
+          header: Authorization
+          format: Bearer %s
+  - service: mistral
+    apiKey:
+      name: MISTRAL_API_KEY
+      proxyManaged: true
+      inject:
+        - domain: api.mistral.ai
+          header: Authorization
+          format: Bearer %s
+  - service: openai
+    apiKey:
+      name: OPENAI_API_KEY
+      proxyManaged: true
+      inject:
+        - domain: api.openai.com
+          header: Authorization
+          format: Bearer %s
+  - service: openrouter
+    apiKey:
+      name: OPENROUTER_API_KEY
+      proxyManaged: true
+      inject:
+        - domain: openrouter.ai
+          header: Authorization
+          format: Bearer %s
+  - service: synthetic
+    apiKey:
+      name: SYNTHETIC_API_KEY
+      proxyManaged: true
+      inject:
+        - domain: api.synthetic.com
+          header: Authorization
+          format: Bearer %s
+  - service: vercel
+    apiKey:
+      name: VERCEL_API_KEY
+      proxyManaged: true
+      inject:
+        - domain: v0.dev
+          header: Authorization
+          format: Bearer %s
+  - service: zai
+    apiKey:
+      name: ZAI_API_KEY
+      proxyManaged: true
+      inject:
+        - domain: api.zai.com
+          header: Authorization
+          format: Bearer %s
+setup:
   install:
     - command: |
         set -euo pipefail
@@ -180,15 +209,3 @@ commands:
     - command: apt-get update -qq && apt-get install -y -qq crush
       user: "0"
       description: Install Crush from Charm apt repository
-
-memory: |
-  ## Crush
-
-  Crush is a multi-provider AI coding agent from Charm. It is installed
-  as `crush` on `PATH` and started with `--yolo` so it skips interactive
-  permission prompts (the sandbox itself is the safety boundary).
-
-  Set any of the provider API keys on your host (e.g. `ANTHROPIC_API_KEY`,
-  `OPENAI_API_KEY`, `GROQ_API_KEY`) and the sandbox proxy will inject them
-  on outbound requests to the matching provider. See
-  <https://github.com/charmbracelet/crush> for usage.

--- a/git-ssh-sign/spec.yaml
+++ b/git-ssh-sign/spec.yaml
@@ -1,14 +1,31 @@
-schemaVersion: "1"
+schemaVersion: "2"
 kind: mixin
 name: git-ssh-sign
 displayName: Git SSH Commit Signing
 description: Configures git to sign commits using the SSH key forwarded from the host's SSH agent.
+agentInstructions:
+  content: |
+    ## Git commit signing
 
-commands:
-  initFiles:
+    This sandbox is configured to sign git commits with your host's SSH key.
+    Commits and tags are signed automatically. Use `git log --show-signature`
+    to verify signatures on existing commits.
+setup:
+  install:
+    - command: |
+        git config --system gpg.format ssh
+        git config --system --unset-all user.signingKey || true
+        git config --system commit.gpgSign true
+        git config --system tag.gpgSign true
+        git config --system gpg.ssh.defaultKeyCommand /home/agent/.config/git/ssh-signing-key-command
+        git config --system gpg.ssh.allowedSignersFile /home/agent/.config/git/allowed_signers
+        if [ "$(git config --system --get core.hooksPath || true)" = "/home/agent/.config/git/hooks" ]; then
+            git config --system --unset-all core.hooksPath
+        fi
+      user: "0"
+      description: Configure SSH commit signing with a dynamic key command
+  files:
     - path: /home/agent/.config/git/ssh-signing-key-command
-      mode: "0755"
-      description: Resolve the forwarded SSH agent key for Git SSH signing
       content: |
         #!/bin/sh
         set -e
@@ -33,24 +50,5 @@ commands:
         email=$(git config user.email 2>/dev/null || printf '%s' "agent@sandbox.local")
         printf '%s %s\n' "$email" "$key" > "$config_dir/allowed_signers"
         printf 'key::%s\n' "$key"
-
-  install:
-    - command: |
-        git config --system gpg.format ssh
-        git config --system --unset-all user.signingKey || true
-        git config --system commit.gpgSign true
-        git config --system tag.gpgSign true
-        git config --system gpg.ssh.defaultKeyCommand /home/agent/.config/git/ssh-signing-key-command
-        git config --system gpg.ssh.allowedSignersFile /home/agent/.config/git/allowed_signers
-        if [ "$(git config --system --get core.hooksPath || true)" = "/home/agent/.config/git/hooks" ]; then
-            git config --system --unset-all core.hooksPath
-        fi
-      user: "0"
-      description: Configure SSH commit signing with a dynamic key command
-
-memory: |
-  ## Git commit signing
-
-  This sandbox is configured to sign git commits with your host's SSH key.
-  Commits and tags are signed automatically. Use `git log --show-signature`
-  to verify signatures on existing commits.
+      mode: "0755"
+      description: Resolve the forwarded SSH agent key for Git SSH signing

--- a/github-ssh/spec.yaml
+++ b/github-ssh/spec.yaml
@@ -1,15 +1,21 @@
-schemaVersion: "1"
+schemaVersion: "2"
 kind: mixin
 name: github-ssh
 displayName: GitHub SSH
 description: Pre-populates GitHub host keys so SSH operations work without interactive host verification prompts.
+agentInstructions:
+  content: |
+    ## GitHub SSH authentication
 
-network:
-  allowedDomains:
-    - github.com
-    - api.github.com
-
-commands:
+    GitHub's host keys are pre-populated in `~/.ssh/known_hosts`, so SSH
+    operations to GitHub (clone, push, pull) work without interactive host
+    verification prompts.
+permissions:
+  network:
+    allow:
+      - github.com
+      - api.github.com
+setup:
   install:
     - command: |
         mkdir -p /home/agent/.ssh
@@ -22,11 +28,3 @@ commands:
         chown agent:agent /home/agent/.ssh/known_hosts
       user: "0"
       description: Fetch and install GitHub host keys from api.github.com/meta
-
-memory: |
-  ## GitHub SSH authentication
-
-  GitHub's host keys are pre-populated in `~/.ssh/known_hosts`, so SSH
-  operations to GitHub (clone, push, pull) work without interactive host
-  verification prompts.
-

--- a/hermes-agent/spec.yaml
+++ b/hermes-agent/spec.yaml
@@ -1,73 +1,66 @@
-schemaVersion: "1"
-kind: agent
+schemaVersion: "2"
+kind: sandbox
 name: hermes-agent
 displayName: Hermes Agent
-description: "The self-improving AI agent by Nous Research — creates skills from experience, supports 200+ models via OpenRouter, and runs anywhere"
-
-agent:
-  image: "docker/sandbox-templates:shell-docker"
-  aiFilename: AGENTS.md
+description: The self-improving AI agent by Nous Research — creates skills from experience, supports 200+ models via OpenRouter, and runs anywhere
+sandbox:
+  image: docker/sandbox-templates:shell-docker
   entrypoint:
-    run: ["/usr/local/bin/hermes-start"]
-
-network:
-  serviceDomains:
-    api.anthropic.com: anthropic
-    api.openai.com: openai
-    openrouter.ai: openrouter
-  serviceAuth:
-    anthropic:
-      headerName: x-api-key
-      valueFormat: "%s"
-    openai:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-    openrouter:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-  allowedDomains:
-    - github.com
-    - raw.githubusercontent.com
-    - objects.githubusercontent.com
-    - pypi.org
-    - files.pythonhosted.org
-    - astral.sh
-    - openrouter.ai
-    - "*.openrouter.ai"
-    - api.openai.com
-    - api.anthropic.com
-    - portal.nousresearch.com
-    - duckduckgo.com        # install.sh connectivity probe alongside pypi.org
-    - archive.ubuntu.com    # Ubuntu archive (amd64 main)
-    - security.ubuntu.com   # Ubuntu security updates (amd64)
-    - ports.ubuntu.com      # Ubuntu archive/security (arm64)
-    - download.docker.com   # Docker's apt repo
-
+    - /usr/local/bin/hermes-start
+agentInstructions:
+  filename: AGENTS.md
+permissions:
+  network:
+    allow:
+      - github.com
+      - raw.githubusercontent.com
+      - objects.githubusercontent.com
+      - pypi.org
+      - files.pythonhosted.org
+      - astral.sh
+      - openrouter.ai
+      - '*.openrouter.ai'
+      - api.openai.com
+      - api.anthropic.com
+      - portal.nousresearch.com
+      - duckduckgo.com        # install.sh connectivity probe alongside pypi.org
+      - archive.ubuntu.com    # Ubuntu archive (amd64 main)
+      - security.ubuntu.com   # Ubuntu security updates (amd64)
+      - ports.ubuntu.com      # Ubuntu archive/security (arm64)
+      - download.docker.com   # Docker's apt repo
 credentials:
-  sources:
-    anthropic:
-      env:
-        - ANTHROPIC_API_KEY
-    openai:
-      env:
-        - OPENAI_API_KEY
-    openrouter:
-      env:
-        - OPENROUTER_API_KEY
-
+  - service: anthropic
+    apiKey:
+      name: ANTHROPIC_API_KEY
+      proxyManaged: true
+      inject:
+        - domain: api.anthropic.com
+          header: x-api-key
+          format: '%s'
+  - service: openai
+    apiKey:
+      name: OPENAI_API_KEY
+      proxyManaged: true
+      inject:
+        - domain: api.openai.com
+          header: Authorization
+          format: Bearer %s
+  - service: openrouter
+    apiKey:
+      name: OPENROUTER_API_KEY
+      proxyManaged: true
+      inject:
+        - domain: openrouter.ai
+          header: Authorization
+          format: Bearer %s
 environment:
-  proxyManaged:
-    - ANTHROPIC_API_KEY
-    - OPENAI_API_KEY
-    - OPENROUTER_API_KEY
   variables:
     HERMES_HOME: /home/agent/.hermes
-
-commands:
+setup:
   install:
-    - command: "printf '#!/bin/sh\\nif ! [ -f /home/agent/.hermes-installed ]; then\\n  echo \"Waiting for Hermes Agent installation (~3 min)...\" >&2\\n  until [ -f /home/agent/.hermes-installed ]; do sleep 3; done\\nfi\\nexec /home/agent/.local/bin/hermes \"$@\"\\n' > /usr/local/bin/hermes-start && chmod +x /usr/local/bin/hermes-start"
+    - command: printf '#!/bin/sh\nif ! [ -f /home/agent/.hermes-installed ]; then\n  echo "Waiting for Hermes Agent installation (~3 min)..." >&2\n  until [ -f /home/agent/.hermes-installed ]; do sleep 3; done\nfi\nexec /home/agent/.local/bin/hermes "$@"\n' > /usr/local/bin/hermes-start && chmod +x /usr/local/bin/hermes-start
       user: "0"
       description: Create entrypoint wrapper that polls for install completion before launching hermes
-    - command: "printf '#!/bin/bash\\nset -e\\ncurl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --skip-setup\\ntouch /home/agent/.hermes-installed\\n' > /home/agent/hermes-install.sh && chmod +x /home/agent/hermes-install.sh && setsid /home/agent/hermes-install.sh > /home/agent/hermes-install.log 2>&1 &"
+    - command: printf '#!/bin/bash\nset -e\ncurl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --skip-setup\ntouch /home/agent/.hermes-installed\n' > /home/agent/hermes-install.sh && chmod +x /home/agent/hermes-install.sh && setsid /home/agent/hermes-install.sh > /home/agent/hermes-install.log 2>&1 &
       user: "1000"
       description: Install Hermes Agent via official installer in detached background session (~3 minutes; writes .hermes-installed flag on completion)

--- a/junie/README.md
+++ b/junie/README.md
@@ -1,6 +1,6 @@
 # junie
 
-A standalone agent kit (`kind: agent`) for [Junie](https://junie.jetbrains.com/), the AI coding agent by JetBrains. The
+A standalone sandbox kit for [Junie](https://junie.jetbrains.com/), the AI coding agent by JetBrains. The
 kit installs Junie into the sandbox at creation time, wires its API auth through the sandbox proxy, and runs `junie` as
 the entrypoint.
 
@@ -44,12 +44,12 @@ The first launch installs Junie via its official install script. Subsequent laun
 
 ## How auth works
 
-The kit's `network` block declares `serviceDomains` and `serviceAuth` for `junie.jetbrains.com`, `api.anthropic.com`,
+The kit's `credentials` list declares an `apiKey` entry per provider, for `junie.jetbrains.com`, `api.anthropic.com`,
 `api.openai.com`, `generativelanguage.googleapis.com`, `api.x.ai`, and `openrouter.ai`. This tells the proxy to inject
 the correct authentication headers (e.g., `Authorization: Bearer %s`, `x-api-key: %s`, or `x-goog-api-key: %s`) on
 outbound requests.
 
-Managed secrets are listed in `environment.proxyManaged` to ensure they are handled securely by the proxy.
+Each credential sets `apiKey.proxyManaged: true` to ensure it's handled securely by the proxy.
 
 ## Customization
 

--- a/junie/spec.yaml
+++ b/junie/spec.yaml
@@ -1,81 +1,84 @@
-schemaVersion: "1"
-kind: agent
+schemaVersion: "2"
+kind: sandbox
 name: junie
 displayName: Junie
 description: The AI coding agent by JetBrains.
-
-agent:
-  image: "docker/sandbox-templates:shell-docker"
-  aiFilename: AGENTS.md
+sandbox:
+  image: docker/sandbox-templates:shell-docker
   entrypoint:
-    run: [junie]
-
-network:
-  serviceDomains:
-    junie.jetbrains.com: junie
-    api.anthropic.com: anthropic
-    api.openai.com: openai
-    generativelanguage.googleapis.com: google
-    api.x.ai: xai
-    openrouter.ai: openrouter
-  serviceAuth:
-    junie:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-    anthropic:
-      headerName: x-api-key
-      valueFormat: "%s"
-    openai:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-    google:
-      headerName: x-goog-api-key
-      valueFormat: "%s"
-    xai:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-    openrouter:
-      headerName: Authorization
-      valueFormat: "Bearer %s"
-  allowedDomains:
-    - "junie.jetbrains.com"
-    - "api.jetbrains.ai"
-    - "github.com"
-    - "raw.githubusercontent.com"
-    - "release-assets.githubusercontent.com"
-    - "api.anthropic.com"
-    - "api.openai.com"
-    - "generativelanguage.googleapis.com"
-    - "api.x.ai"
-    - "openrouter.ai"
-
+    - junie
+agentInstructions:
+  filename: AGENTS.md
+permissions:
+  network:
+    allow:
+      - junie.jetbrains.com
+      - api.jetbrains.ai
+      - github.com
+      - raw.githubusercontent.com
+      - release-assets.githubusercontent.com
+      - api.anthropic.com
+      - api.openai.com
+      - generativelanguage.googleapis.com
+      - api.x.ai
+      - openrouter.ai
 credentials:
-  sources:
-    junie:
-      env: [JUNIE_API_KEY]
-    anthropic:
-      env: [ANTHROPIC_API_KEY]
-    openai:
-      env: [OPENAI_API_KEY]
-    google:
-      env: [GEMINI_API_KEY, GOOGLE_GENERATIVE_AI_API_KEY]
-    xai:
-      env: [XAI_API_KEY]
-    openrouter:
-      env: [OPENROUTER_API_KEY]
-
-environment:
-  proxyManaged:
-    - JUNIE_API_KEY
-    - ANTHROPIC_API_KEY
-    - OPENAI_API_KEY
-    - GEMINI_API_KEY
-    - GOOGLE_GENERATIVE_AI_API_KEY
-    - XAI_API_KEY
-    - OPENROUTER_API_KEY
-
-commands:
+  - service: anthropic
+    apiKey:
+      name: ANTHROPIC_API_KEY
+      proxyManaged: true
+      inject:
+        - domain: api.anthropic.com
+          header: x-api-key
+          format: '%s'
+  # v1 also accepted GOOGLE_GENERATIVE_AI_API_KEY as a fallback host env var
+  # name for this credential (credentials.sources.google.env listed both).
+  # v2's apiKey.name is a single string with no alias list, so only one host
+  # env var can be recognized here; GEMINI_API_KEY is Google's current
+  # canonical name for this key, so it's the one kept. A host with only
+  # GOOGLE_GENERATIVE_AI_API_KEY set will no longer be picked up.
+  - service: google
+    apiKey:
+      name: GEMINI_API_KEY
+      proxyManaged: true
+      inject:
+        - domain: generativelanguage.googleapis.com
+          header: x-goog-api-key
+          format: '%s'
+  - service: junie
+    apiKey:
+      name: JUNIE_API_KEY
+      proxyManaged: true
+      inject:
+        - domain: junie.jetbrains.com
+          header: Authorization
+          format: Bearer %s
+  - service: openai
+    apiKey:
+      name: OPENAI_API_KEY
+      proxyManaged: true
+      inject:
+        - domain: api.openai.com
+          header: Authorization
+          format: Bearer %s
+  - service: openrouter
+    apiKey:
+      name: OPENROUTER_API_KEY
+      proxyManaged: true
+      inject:
+        - domain: openrouter.ai
+          header: Authorization
+          format: Bearer %s
+  - service: xai
+    apiKey:
+      name: XAI_API_KEY
+      proxyManaged: true
+      inject:
+        - domain: api.x.ai
+          header: Authorization
+          format: Bearer %s
+setup:
   install:
-    - command: "curl -fsSL https://junie.jetbrains.com/install.sh | bash"
+    - command: curl -fsSL https://junie.jetbrains.com/install.sh | bash
       user: "1000"
       description: Install Junie

--- a/nanobot/spec.yaml
+++ b/nanobot/spec.yaml
@@ -1,49 +1,49 @@
-schemaVersion: "1"
-kind: agent
+schemaVersion: "2"
+kind: sandbox
 name: nanobot
 displayName: Nanobot
-description: "Lightweight personal AI assistant with multi-platform chat and multi-provider LLM support"
-
-agent:
-  image: "docker/sandbox-templates:shell-docker"
-  aiFilename: AGENTS.md
+description: Lightweight personal AI assistant with multi-platform chat and multi-provider LLM support
+sandbox:
+  image: docker/sandbox-templates:shell-docker
   entrypoint:
-    run: ["nanobot", "agent", "--config", "/home/agent/.nanobot/config.json"]
-
-network:
-  serviceDomains:
-    api.anthropic.com: anthropic
-    console.anthropic.com: anthropic
-    claude.ai: anthropic
-  serviceAuth:
-    anthropic:
-      headerName: x-api-key
-      valueFormat: "%s"
-  allowedDomains:
-    - pypi.org
-    - files.pythonhosted.org
-    - "*.telegram.org"
-    - "*.discord.com"
-    - gateway.discord.gg
-    - "*.whatsapp.com"
-    - "*.whatsapp.net"
-    - "*.slack.com"
-    - "*.feishu.cn"
-
+    - nanobot
+    - agent
+    - --config
+    - /home/agent/.nanobot/config.json
+agentInstructions:
+  filename: AGENTS.md
+permissions:
+  network:
+    allow:
+      - pypi.org
+      - files.pythonhosted.org
+      - '*.telegram.org'
+      - '*.discord.com'
+      - gateway.discord.gg
+      - '*.whatsapp.com'
+      - '*.whatsapp.net'
+      - '*.slack.com'
+      - '*.feishu.cn'
 credentials:
-  sources:
-    anthropic:
-      env:
-        - ANTHROPIC_API_KEY
-
+  - service: anthropic
+    apiKey:
+      name: ANTHROPIC_API_KEY
+      proxyManaged: true
+      inject:
+        - domain: api.anthropic.com
+          header: x-api-key
+          format: '%s'
+        - domain: claude.ai
+          header: x-api-key
+          format: '%s'
+        - domain: console.anthropic.com
+          header: x-api-key
+          format: '%s'
 environment:
   variables:
     NANOBOT_AGENTS__DEFAULTS__WORKSPACE: /home/agent/nanobot
-  proxyManaged:
-    - ANTHROPIC_API_KEY
-
-commands:
+setup:
   install:
-    - command: "pip install --break-system-packages nanobot-ai"
+    - command: pip install --break-system-packages nanobot-ai
       user: "1000"
       description: Install nanobot

--- a/nanoclaw/spec.yaml
+++ b/nanoclaw/spec.yaml
@@ -1,88 +1,85 @@
-schemaVersion: "1"
+schemaVersion: "2"
 kind: sandbox
 name: nanoclaw
 displayName: NanoClaw
-description: "NanoClaw host + nested per-session agent containers inside a Docker Sandbox micro-VM."
-
+description: NanoClaw host + nested per-session agent containers inside a Docker Sandbox micro-VM.
 sandbox:
-  image: "docker.io/nanoco/nanoclaw:sbx-claude-alpha"
+  image: docker.io/nanoco/nanoclaw:sbx-claude-alpha
   entrypoint:
-    run: ["/usr/local/bin/nanoclaw-start"]
+    - /usr/local/bin/nanoclaw-start
+agentInstructions:
+  filename: CLAUDE.md
+  content: |
+    ## Sandbox environment
 
-caps:
+    You are NanoClaw running inside a Docker Sandbox micro-VM. The host process
+    spawns one nested agent container per session via the VM's own Docker daemon.
+    Credentials go through OneCLI like a normal NanoClaw deployment. Never ask for
+    or print raw keys. `sudo` is passwordless.
+
+    ## Network policy errors
+
+    If an HTTP/HTTPS request fails with `502 Bad Gateway`, the request may be
+    blocked by Docker Sandbox network policy rather than by the target service.
+    Network access is controlled by the sbx kit `spec.yaml`.
+
+    Ask the user to inspect the sandbox policy from their host terminal:
+
+    `sbx policy ls <sandbox-name>`
+    `sbx policy ls <sandbox-name> --type network`
+
+    For NanoClaw, the sandbox name is usually `nanoclaw` unless the user supplied
+    a different `--name`.
+permissions:
   network:
     allow:
-    - "auth.docker.io:443"
-    - "index.docker.io:443"
-    - "production.cloudflare.docker.com:443"
-    - "registry-1.docker.io:443"
-    - "api.onecli.sh:443"
-    - "onecli.sh:443"
-    - "www.onecli.sh:443"
-    - "api.anthropic.com:443"
-    - "claude.ai:443"
-    - "claude.com:443"
-    - "console.anthropic.com:443"
-    - "downloads.claude.ai:443"
-    - "platform.claude.com:443"
-    - "api.github.com:443"
-    - "codeload.github.com:443"
-    - "ghcr.io:443"
-    - "github.com:443"
-    - "objects.githubusercontent.com:443"
-    - "raw.githubusercontent.com:443"
-    - "release-assets.githubusercontent.com:443"
-    - "bun.sh:443"
-    - "checkpoint.prisma.io:443"
-    - "deb.debian.org:443"
-    - "registry.npmjs.org:443"
-    - "security.debian.org:443"
-    - "api.slack.com:443"
-    - "api.telegram.org:443"
-    - "discord.com:443"
-    - "gateway.discord.gg:443"
-    - "slack.com:443"
-    - "t.me:443"
-    - "web.whatsapp.com:443"
-
-publishedPorts:
+      - auth.docker.io:443
+      - index.docker.io:443
+      - production.cloudflare.docker.com:443
+      - registry-1.docker.io:443
+      - api.onecli.sh:443
+      - onecli.sh:443
+      - www.onecli.sh:443
+      - api.anthropic.com:443
+      - claude.ai:443
+      - claude.com:443
+      - console.anthropic.com:443
+      - downloads.claude.ai:443
+      - platform.claude.com:443
+      - api.github.com:443
+      - codeload.github.com:443
+      - ghcr.io:443
+      - github.com:443
+      - objects.githubusercontent.com:443
+      - raw.githubusercontent.com:443
+      - release-assets.githubusercontent.com:443
+      - bun.sh:443
+      - checkpoint.prisma.io:443
+      - deb.debian.org:443
+      - registry.npmjs.org:443
+      - security.debian.org:443
+      - api.slack.com:443
+      - api.telegram.org:443
+      - discord.com:443
+      - gateway.discord.gg:443
+      - slack.com:443
+      - t.me:443
+      - web.whatsapp.com:443
+ports:
   - container: 3000
     name: webhook
   - container: 10254
     name: onecli-dashboard
   - container: 10255
     name: onecli-gateway
-
 environment:
   variables:
     IS_SANDBOX: "1"
+    NANOCLAW_AGENT_PROVIDER: claude
     NANOCLAW_NO_DIAGNOSTICS: "1"
-    NANOCLAW_AGENT_PROVIDER: "claude"
+    NO_PROXY: 127.0.0.1,localhost
     NODE_NO_WARNINGS: "1"
-    ONECLI_BIND_HOST: "0.0.0.0"
-    ONECLI_URL: "http://127.0.0.1:10254"
-    TZ: "UTC"
-    NO_PROXY: "127.0.0.1,localhost"
-    no_proxy: "127.0.0.1,localhost"
-
-agentContext: |
-  ## Sandbox environment
-
-  You are NanoClaw running inside a Docker Sandbox micro-VM. The host process
-  spawns one nested agent container per session via the VM's own Docker daemon.
-  Credentials go through OneCLI like a normal NanoClaw deployment. Never ask for
-  or print raw keys. `sudo` is passwordless.
-
-  ## Network policy errors
-
-  If an HTTP/HTTPS request fails with `502 Bad Gateway`, the request may be
-  blocked by Docker Sandbox network policy rather than by the target service.
-  Network access is controlled by the sbx kit `spec.yaml`.
-
-  Ask the user to inspect the sandbox policy from their host terminal:
-
-  `sbx policy ls <sandbox-name>`
-  `sbx policy ls <sandbox-name> --type network`
-
-  For NanoClaw, the sandbox name is usually `nanoclaw` unless the user supplied
-  a different `--name`.
+    ONECLI_BIND_HOST: 0.0.0.0
+    ONECLI_URL: http://127.0.0.1:10254
+    TZ: UTC
+    no_proxy: 127.0.0.1,localhost

--- a/neovim/spec.yaml
+++ b/neovim/spec.yaml
@@ -1,23 +1,21 @@
-schemaVersion: "1"
+schemaVersion: "2"
 kind: mixin
 name: neovim
 displayName: Neovim
-description: "Installs Neovim (latest stable) and injects the bundled ~/.config/nvim into the sandbox."
-
-network:
-  allowedDomains:
-    # GitHub release redirect for the stable tag
-    - github.com
-    # Asset CDN — GitHub has used both hosts across releases
-    - objects.githubusercontent.com
-    - release-assets.githubusercontent.com
-
+description: Installs Neovim (latest stable) and injects the bundled ~/.config/nvim into the sandbox.
+permissions:
+  network:
+    allow:
+      # GitHub release redirect for the stable tag
+      - github.com
+      # Asset CDN — GitHub has used both hosts across releases
+      - objects.githubusercontent.com
+      - release-assets.githubusercontent.com
 environment:
   variables:
     EDITOR: nvim
     VISUAL: nvim
-
-commands:
+setup:
   install:
     - command: |
         set -euo pipefail

--- a/openclaw/spec.yaml
+++ b/openclaw/spec.yaml
@@ -1,62 +1,62 @@
-schemaVersion: "1"
-kind: agent
+schemaVersion: "2"
+kind: sandbox
 name: openclaw
 displayName: OpenClaw
-description: "Personal AI assistant with multi-platform chat, skills, and gateway support"
-
-agent:
-  image: "docker/sandbox-templates:shell-docker"
-  aiFilename: AGENTS.md
+description: Personal AI assistant with multi-platform chat, skills, and gateway support
+sandbox:
+  image: docker/sandbox-templates:shell-docker
   entrypoint:
-    run: ["/usr/local/bin/openclaw-start"]
-
-network:
-  serviceDomains:
-    api.anthropic.com: anthropic
-    console.anthropic.com: anthropic
-    claude.ai: anthropic
-  serviceAuth:
-    anthropic:
-      headerName: x-api-key
-      valueFormat: "%s"
-  allowedDomains:
-    - registry.npmjs.org
-    - "*.npmjs.org"
-    - "nodejs.org:443"
-    - "*.telegram.org"
-    - "*.discord.com"
-    - gateway.discord.gg
-    - "*.whatsapp.com"
-    - "*.whatsapp.net"
-    - "*.slack.com"
-    - openclaw.ai
-    - docs.openclaw.ai
-
+    - /usr/local/bin/openclaw-start
+agentInstructions:
+  filename: AGENTS.md
+permissions:
+  network:
+    allow:
+      - registry.npmjs.org
+      - '*.npmjs.org'
+      - nodejs.org:443
+      - '*.telegram.org'
+      - '*.discord.com'
+      - gateway.discord.gg
+      - '*.whatsapp.com'
+      - '*.whatsapp.net'
+      - '*.slack.com'
+      - openclaw.ai
+      - docs.openclaw.ai
 credentials:
-  sources:
-    anthropic:
-      env:
-        - ANTHROPIC_API_KEY
-
+  - service: anthropic
+    apiKey:
+      name: ANTHROPIC_API_KEY
+      proxyManaged: true
+      inject:
+        - domain: api.anthropic.com
+          header: x-api-key
+          format: '%s'
+        - domain: claude.ai
+          header: x-api-key
+          format: '%s'
+        - domain: console.anthropic.com
+          header: x-api-key
+          format: '%s'
 environment:
   variables:
     OPENCLAW_STATE_DIR: /home/agent/.openclaw
-  proxyManaged:
-    - ANTHROPIC_API_KEY
-
-commands:
+setup:
   install:
-    - command: "npm config set proxy $HTTP_PROXY && npm config set https-proxy $HTTP_PROXY"
+    - command: npm config set proxy $HTTP_PROXY && npm config set https-proxy $HTTP_PROXY
       user: "0"
       description: Configure npm proxy
-    - command: "printf '#!/bin/sh\\nif ! [ -f /home/agent/.openclaw-installed ]; then\\n  echo \"Waiting for OpenClaw installation to complete...\" >&2\\n  until [ -f /home/agent/.openclaw-installed ]; do sleep 2; done\\nfi\\nexec /usr/local/share/npm-global/bin/openclaw chat\\n' > /usr/local/bin/openclaw-start && chmod +x /usr/local/bin/openclaw-start"
+    - command: printf '#!/bin/sh\nif ! [ -f /home/agent/.openclaw-installed ]; then\n  echo "Waiting for OpenClaw installation to complete..." >&2\n  until [ -f /home/agent/.openclaw-installed ]; do sleep 2; done\nfi\nexec /usr/local/share/npm-global/bin/openclaw chat\n' > /usr/local/bin/openclaw-start && chmod +x /usr/local/bin/openclaw-start
       user: "0"
       description: Create agent entrypoint early; polls for install flag before starting openclaw
-    - command: "printf '#!/bin/sh\\nnpm install -g n && n install 22 && npm install -g --maxsockets=1 --fetch-timeout=600000 openclaw@latest && touch /home/agent/.openclaw-installed\\n' > /home/agent/openclaw-install.sh && chmod +x /home/agent/openclaw-install.sh && setsid /home/agent/openclaw-install.sh > /home/agent/openclaw-install.log 2>&1 &"
+    - command: printf '#!/bin/sh\nnpm install -g n && n install 22 && npm install -g --maxsockets=1 --fetch-timeout=600000 openclaw@latest && touch /home/agent/.openclaw-installed\n' > /home/agent/openclaw-install.sh && chmod +x /home/agent/openclaw-install.sh && setsid /home/agent/openclaw-install.sh > /home/agent/openclaw-install.log 2>&1 &
       user: "0"
       description: Upgrade to Node.js 22 and install OpenClaw in detached background session (~3 minutes; .openclaw-installed flag written on completion)
   startup:
-    - command: [sh, -c, "until [ -f /home/agent/.openclaw-installed ]; do sleep 5; done; /usr/local/share/npm-global/bin/openclaw gateway run --allow-unconfigured"]
+    - command:
+        - sh
+        - -c
+        - until [ -f /home/agent/.openclaw-installed ]; do sleep 5; done; /usr/local/share/npm-global/bin/openclaw gateway run --allow-unconfigured
       user: "1000"
       background: true
       description: Wait for install then start OpenClaw gateway

--- a/opencode-model-runner/spec.yaml
+++ b/opencode-model-runner/spec.yaml
@@ -1,20 +1,17 @@
-schemaVersion: "1"
-kind: agent
+schemaVersion: "2"
+kind: sandbox
 name: opencode-model-runner
 displayName: OpenCode (Docker Model Runner)
 description: OpenCode wired to a local Docker Model Runner instance via its OpenAI-compatible API, with automatic model discovery.
-
-agent:
-  image: "docker/sandbox-templates:opencode-docker"
-  aiFilename: AGENTS.md
+sandbox:
+  image: docker/sandbox-templates:opencode-docker
   entrypoint:
-    run: [opencode]
-
-commands:
-  initFiles:
+    - opencode
+agentInstructions:
+  filename: AGENTS.md
+setup:
+  files:
     - path: /home/agent/.config/opencode/opencode.json
-      mode: "0644"
-      description: Configure OpenCode to use the local Docker Model Runner
       content: |
         {
           "$schema": "https://opencode.ai/config.json",
@@ -36,3 +33,5 @@ commands:
             }
           }
         }
+      mode: "0644"
+      description: Configure OpenCode to use the local Docker Model Runner

--- a/packages-through-sfw/spec.yaml
+++ b/packages-through-sfw/spec.yaml
@@ -1,33 +1,34 @@
-schemaVersion: "1"
+schemaVersion: "2"
 kind: mixin
 name: packages-through-sfw
 displayName: Packages through SFW
-description: "Installs Socket Firewall Free and routes npm, pip, pip3, and python3 -m pip commands through sfw when resolved through PATH."
-
-network:
-  allowedDomains:
-    - "github.com:443"
-    - "release-assets.githubusercontent.com:443"
-    - "api.socket.dev:443"
-    - "socket.dev:443"
-    - "registry.npmjs.org:443"
-    - "pypi.org:443"
-    - "files.pythonhosted.org:443"
-    # `apt-get update` (run by the first install hook) refreshes metadata
-    # for every configured apt source. The shell-docker base template
-    # ships three sources, all of which must succeed for the update to
-    # exit 0, regardless of which one our install actually fetches from.
-    # Ubuntu hosts amd64 packages on archive/security and arm64 packages
-    # on ports.ubuntu.com, so all three Ubuntu hosts are listed for
-    # cross-arch coverage.
-    - "archive.ubuntu.com:80"        # Ubuntu archive (amd64 main, HTTP)
-    - "security.ubuntu.com:80"       # Ubuntu security updates (amd64, HTTP)
-    - "ports.ubuntu.com:80"          # Ubuntu archive/security (arm64, HTTP)
-    - "download.docker.com:443"      # Docker's apt repo, pre-added by shell-docker
-
-commands:
+description: Installs Socket Firewall Free and routes npm, pip, pip3, and python3 -m pip commands through sfw when resolved through PATH.
+permissions:
+  network:
+    allow:
+      - "github.com:443"
+      # Confirmed by hand: github.com's release-download redirect target.
+      - "objects.githubusercontent.com:443"
+      - "release-assets.githubusercontent.com:443"
+      - "api.socket.dev:443"
+      - "socket.dev:443"
+      - "registry.npmjs.org:443"
+      - "pypi.org:443"
+      - "files.pythonhosted.org:443"
+      # `apt-get update` (run by the first install hook) refreshes metadata
+      # for every configured apt source. The shell-docker base template
+      # ships three sources, all of which must succeed for the update to
+      # exit 0, regardless of which one our install actually fetches from.
+      # Ubuntu hosts amd64 packages on archive/security and arm64 packages
+      # on ports.ubuntu.com, so all three Ubuntu hosts are listed for
+      # cross-arch coverage.
+      - "archive.ubuntu.com:80"        # Ubuntu archive (amd64 main, HTTP)
+      - "security.ubuntu.com:80"       # Ubuntu security updates (amd64, HTTP)
+      - "ports.ubuntu.com:80"          # Ubuntu archive/security (arm64, HTTP)
+      - "download.docker.com:443"      # Docker's apt repo, pre-added by shell-docker
+setup:
   install:
-    - command: "apt-get update && apt-get install -y --no-install-recommends ca-certificates curl nodejs npm python3-pip && rm -rf /var/lib/apt/lists/*"
+    - command: apt-get update && apt-get install -y --no-install-recommends ca-certificates curl nodejs npm python3-pip && rm -rf /var/lib/apt/lists/*
       user: "0"
       description: Install package-manager prerequisites
     - command: |
@@ -54,7 +55,7 @@ commands:
         rm -f /tmp/sfw
         sfw --version
       user: "0"
-      description: "Install Socket Firewall Free v1.10.0, version+digest pinned"
+      description: Install Socket Firewall Free v1.10.0, version+digest pinned
     - command: |
         set -euo pipefail
         mkdir -p /usr/local/lib/packages-through-sfw/shims

--- a/pi/spec.yaml
+++ b/pi/spec.yaml
@@ -1,39 +1,35 @@
-schemaVersion: "1"
-kind: agent
+schemaVersion: "2"
+kind: sandbox
 name: pi
 displayName: Pi
-description: "Minimal terminal coding agent with extensible tools, skills, and TUI"
-
-agent:
-  image: "docker/sandbox-templates:shell-docker"
-  aiFilename: AGENTS.md
+description: Minimal terminal coding agent with extensible tools, skills, and TUI
+sandbox:
+  image: docker/sandbox-templates:shell-docker
   entrypoint:
-    run: [pi]
-
-network:
-  serviceDomains:
-    api.anthropic.com: anthropic
-    console.anthropic.com: anthropic
-    claude.ai: anthropic
-  serviceAuth:
-    anthropic:
-      headerName: x-api-key
-      valueFormat: "%s"
-  allowedDomains:
-    - registry.npmjs.org
-
+    - pi
+agentInstructions:
+  filename: AGENTS.md
+permissions:
+  network:
+    allow:
+      - registry.npmjs.org
 credentials:
-  sources:
-    anthropic:
-      env:
-        - ANTHROPIC_API_KEY
-
-environment:
-  proxyManaged:
-    - ANTHROPIC_API_KEY
-
-commands:
+  - service: anthropic
+    apiKey:
+      name: ANTHROPIC_API_KEY
+      proxyManaged: true
+      inject:
+        - domain: api.anthropic.com
+          header: x-api-key
+          format: '%s'
+        - domain: claude.ai
+          header: x-api-key
+          format: '%s'
+        - domain: console.anthropic.com
+          header: x-api-key
+          format: '%s'
+setup:
   install:
-    - command: "npm config set proxy $HTTP_PROXY && npm config set https-proxy $HTTP_PROXY && i=0; while [ $i -lt 5 ]; do npm install -g --maxsockets=1 --fetch-timeout=600000 @earendil-works/pi-coding-agent && break; i=$((i+1)); echo \"Retrying ($i/5)...\"; done"
+    - command: npm config set proxy $HTTP_PROXY && npm config set https-proxy $HTTP_PROXY && i=0; while [ $i -lt 5 ]; do npm install -g --maxsockets=1 --fetch-timeout=600000 @earendil-works/pi-coding-agent && break; i=$((i+1)); echo "Retrying ($i/5)..."; done
       user: "1000"
-      description: "Configure npm proxy and install pi coding agent globally (with retries)"
+      description: Configure npm proxy and install pi coding agent globally (with retries)

--- a/playwright/README.md
+++ b/playwright/README.md
@@ -53,11 +53,11 @@ The sandbox has no display server, so `--headed`, `--ui` mode, and `codegen` won
 
 ### Why the version is pinned
 
-Kits are cached in user workflows and re-run on every sandbox creation, so a floating `latest` would make sandbox builds non-reproducible. The kit pins `playwright@1.61.1` and `@playwright/test@1.61.1`; npm verifies the downloaded tarballs against the sha512 integrity values in the registry metadata, so pinning the version pins the content. Browser builds are keyed to the Playwright version, so they're transitively pinned too. To bump: change `PLAYWRIGHT_VERSION` in `spec.yaml` and the version references in `agentContext` and this README.
+Kits are cached in user workflows and re-run on every sandbox creation, so a floating `latest` would make sandbox builds non-reproducible. The kit pins `playwright@1.61.1` and `@playwright/test@1.61.1`; npm verifies the downloaded tarballs against the sha512 integrity values in the registry metadata, so pinning the version pins the content. Browser builds are keyed to the Playwright version, so they're transitively pinned too. To bump: change `PLAYWRIGHT_VERSION` in `spec.yaml` and the version references in `agentInstructions` and this README.
 
 ### Why these domains
 
-`caps.network.allow` is the kit's complete outbound contract — CI runs e2e under a `deny-all` policy.
+`permissions.network.allow` is the kit's complete outbound contract — CI runs e2e under a `deny-all` policy.
 
 | Domain | Why |
 | --- | --- |

--- a/playwright/spec.yaml
+++ b/playwright/spec.yaml
@@ -1,55 +1,81 @@
-schemaVersion: "1"
+schemaVersion: "2"
 kind: mixin
 name: playwright
 displayName: Playwright
-description: "Playwright browser-automation toolchain for sandbox agents — the playwright CLI and @playwright/test v1.61.1 with Chromium, installed to a shared system browsers path so the agent user can run headless browser automation and end-to-end tests entirely inside the sandbox."
+description: Playwright browser-automation toolchain for sandbox agents — the playwright CLI and @playwright/test v1.61.1 with Chromium, installed to a shared system browsers path so the agent user can run headless browser automation and end-to-end tests entirely inside the sandbox.
+agentInstructions:
+  content: |
+    ## Playwright
 
-environment:
-  variables:
-    # Install hooks run as root but the agent runs as uid 1000, so the default
-    # per-user ~/.cache/ms-playwright would leave the browsers in root's home
-    # where the agent can't see them. A fixed system path shared by every user
-    # (the same trick the official Playwright Docker image uses) fixes that.
-    PLAYWRIGHT_BROWSERS_PATH: /opt/ms-playwright
-    # Lets `require('@playwright/test')` resolve from the global npm install
-    # in zero-config runs (a bare .spec.js with no package.json). Node only
-    # searches node_modules up the file's directory tree; NODE_PATH adds the
-    # global root as a fallback. Projects with their own node_modules are
-    # unaffected — the local copy always wins.
-    NODE_PATH: /usr/local/share/npm-global/lib/node_modules
+    playwright and @playwright/test v1.61.1 are installed globally (the
+    `playwright` CLI is on PATH). Chromium and its headless shell live in
+    /opt/ms-playwright; PLAYWRIGHT_BROWSERS_PATH points there system-wide —
+    don't unset or override it, or Playwright will look in ~/.cache and try to
+    re-download.
 
-caps:
+    - Run test suites with `npx playwright test`; drive a browser from a script
+      with `const { chromium } = require('playwright')`. Zero-config works: a
+      bare `smoke.spec.js` with no package.json resolves `@playwright/test`
+      from the global install via NODE_PATH. Projects with their own
+      node_modules use their local copy as usual.
+    - Headless only: the sandbox has no display server, so `--headed`, `--ui`,
+      and `codegen` will not work. Screenshots, PDFs, traces, and videos all
+      work headless.
+    - If a project pins a different Playwright version, its first run may need
+      the matching browser build: `npx playwright install chromium` fetches it
+      at runtime (the browser CDN domains are allowed, and /opt/ms-playwright
+      is writable).
+    - Only Chromium is installed. `npx playwright install firefox webkit` can
+      download the other engines, but their extra system libraries are not
+      installed — prefer Chromium, or extend the kit if you need cross-engine
+      runs.
+    - Sites under test must be reachable through the sandbox network policy:
+      localhost servers always work; external sites will fail with a proxy
+      error unless their domains are in the sandbox's allowed domains.
+permissions:
   network:
     allow:
       # npm packages (install time): playwright + @playwright/test tarballs.
-      - "registry.npmjs.org:443"
+      - registry.npmjs.org:443
       # Browser binaries (install time, and runtime if a project pins a
       # different Playwright version and fetches its matching build):
       # cdn.playwright.dev is the primary CDN, the prss.microsoft.com host
       # is the documented fallback Playwright rotates to on CDN failure.
-      - "cdn.playwright.dev:443"
-      - "playwright.download.prss.microsoft.com:443"
+      - cdn.playwright.dev:443
+      - playwright.download.prss.microsoft.com:443
       # On amd64, Playwright's Chromium is a "Chrome for Testing" build:
       # cdn.playwright.dev only issues a 302 redirect and the actual
       # chrome-linux64.zip is served from Google's Chrome-for-Testing bucket
       # on storage.googleapis.com. Without this, `playwright install chromium`
       # fails with a proxy 403 (Blocked by network policy) under deny-all.
       # (arm64 builds come from prss.microsoft.com instead, hence the split.)
-      - "storage.googleapis.com:443"
+      - storage.googleapis.com:443
       # `playwright install --with-deps` apt-installs Chromium's system
       # libraries. `apt-get update` refreshes every configured source, so all
       # template sources must be reachable: Ubuntu hosts amd64 packages on
       # archive/security and arm64 packages on ports.ubuntu.com, and the
       # *-docker templates pre-add Docker's apt repo.
-      - "archive.ubuntu.com:80"
-      - "security.ubuntu.com:80"
-      - "ports.ubuntu.com:80"
-      - "download.docker.com:443"
-
-commands:
+      - archive.ubuntu.com:80
+      - security.ubuntu.com:80
+      - ports.ubuntu.com:80
+      - download.docker.com:443
+environment:
+  variables:
+    # Lets `require('@playwright/test')` resolve from the global npm install
+    # in zero-config runs (a bare .spec.js with no package.json). Node only
+    # searches node_modules up the file's directory tree; NODE_PATH adds the
+    # global root as a fallback. Projects with their own node_modules are
+    # unaffected — the local copy always wins.
+    NODE_PATH: /usr/local/share/npm-global/lib/node_modules
+    # Install hooks run as root but the agent runs as uid 1000, so the default
+    # per-user ~/.cache/ms-playwright would leave the browsers in root's home
+    # where the agent can't see them. A fixed system path shared by every user
+    # (the same trick the official Playwright Docker image uses) fixes that.
+    PLAYWRIGHT_BROWSERS_PATH: /opt/ms-playwright
+setup:
   install:
-    # To bump Playwright: change PLAYWRIGHT_VERSION here and in agentContext /
-    # README. npm itself verifies the package tarballs against the sha512
+    # To bump Playwright: change PLAYWRIGHT_VERSION here and in agentInstructions
+    # / README. npm itself verifies the package tarballs against the sha512
     # integrity values in the registry metadata, so pinning the exact version
     # pins the content.
     - command: |
@@ -64,7 +90,7 @@ commands:
         ln -sf "$(command -v playwright)" /usr/local/bin/playwright
         playwright --version
       user: "0"
-      description: "Install playwright + @playwright/test v1.61.1 from registry.npmjs.org, version pinned"
+      description: Install playwright + @playwright/test v1.61.1 from registry.npmjs.org, version pinned
     - command: |
         set -euo pipefail
         export PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
@@ -75,33 +101,4 @@ commands:
         # project pins a different Playwright version.
         chmod -R 777 /opt/ms-playwright
       user: "0"
-      description: "Install Chromium (+ headless shell) into /opt/ms-playwright and its system libraries via apt"
-
-agentContext: |
-  ## Playwright
-
-  playwright and @playwright/test v1.61.1 are installed globally (the
-  `playwright` CLI is on PATH). Chromium and its headless shell live in
-  /opt/ms-playwright; PLAYWRIGHT_BROWSERS_PATH points there system-wide —
-  don't unset or override it, or Playwright will look in ~/.cache and try to
-  re-download.
-
-  - Run test suites with `npx playwright test`; drive a browser from a script
-    with `const { chromium } = require('playwright')`. Zero-config works: a
-    bare `smoke.spec.js` with no package.json resolves `@playwright/test`
-    from the global install via NODE_PATH. Projects with their own
-    node_modules use their local copy as usual.
-  - Headless only: the sandbox has no display server, so `--headed`, `--ui`,
-    and `codegen` will not work. Screenshots, PDFs, traces, and videos all
-    work headless.
-  - If a project pins a different Playwright version, its first run may need
-    the matching browser build: `npx playwright install chromium` fetches it
-    at runtime (the browser CDN domains are allowed, and /opt/ms-playwright
-    is writable).
-  - Only Chromium is installed. `npx playwright install firefox webkit` can
-    download the other engines, but their extra system libraries are not
-    installed — prefer Chromium, or extend the kit if you need cross-engine
-    runs.
-  - Sites under test must be reachable through the sandbox network policy:
-    localhost servers always work; external sites will fail with a proxy
-    error unless their domains are in the sandbox's allowed domains.
+      description: Install Chromium (+ headless shell) into /opt/ms-playwright and its system libraries via apt

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -27,20 +27,22 @@ If the spec is already v2 (no transforms apply), the script prints `no changes n
 
 ### What it migrates
 
-The script grows with the migration. Today's transforms cover **Phase 1**:
-
-| v1 spelling | v2 spelling | Notes |
-|---|---|---|
-| `kind: agent` | `kind: sandbox` | Top-level kind value |
-| `agent:` block | `sandbox:` block | Top-level YAML key |
-| `memory:` field | `agentContext:` field | Top-level YAML key |
-
-Later phases extend the script as their PRs land. See [`docs/specs/2026-05-27-unified-kit-spec-v2.md`](https://github.com/docker/sandboxes/blob/main/docs/specs/2026-05-27-unified-kit-spec-v2.md) on docker/sandboxes for the migration roadmap and which transforms each phase adds.
+The script loads a kit through the same normalization pass the engine itself
+uses, then re-emits it in v2 form — so it picks up every v1→v2 field rename
+that pass knows about, not a separately-maintained list. That includes (among
+others): `kind: agent`→`kind: sandbox`, the `agent:`→`sandbox:` block,
+`memory:`/`agentContext:`→`agentInstructions.content`, the
+`entrypoint`/`command` split, the network/credentials surfaces unifying into
+`permissions.network`/`credentials[]`, `commands:`→`setup:`, and
+`tmpfs:`/`volumes:` normalization. See
+[`spec/SPEC-v2.md`](../spec/SPEC-v2.md) for the full v1→v2 field reference,
+and [`skills/kit-author/topics/v1-migration.md`](../skills/kit-author/topics/v1-migration.md)
+for a worked-example migration walkthrough.
 
 ### What it doesn't migrate
 
-- **Engine-side workspace state** — sandboxes you've already created will have a `kits-memory/` directory in their workspace. The sandboxes engine handles that rename transparently on the next kit add/run; no need to migrate it manually.
-- **The `settings:` block** — in v2 the per-kit container-settings behavior is lifted into the kit's own `initFiles`/`commands.startup` entries, not a spec-level field. The script can't auto-translate it (the v2 replacement is kit-side setup, not spec data), so it prints the settings deprecation/lift notice when it encounters a `settings:` block and leaves the rest of the spec transformed. Lift it yourself using the built-in kits (e.g. `sandboxlib/kit/agents/{claude,codex}/spec.yaml`) as templates; see the v2 spec doc's Phase 4 plan for the recipe.
+- **Engine-side workspace state** — sandboxes you've already created will have a `kits-memory/` directory in their workspace. The engine handles that rename transparently on the next kit add/run; no need to migrate it manually.
+- **The `settings:` block** — in v2 the per-kit container-settings behavior is lifted into the kit's own `setup.install`/`setup.startup` entries, not a spec-level field. The script can't auto-translate it (the v2 replacement is kit-side setup, not spec data), so it prints the settings deprecation/lift notice when it encounters a `settings:` block and leaves the rest of the spec transformed. See `skills/kit-author/topics/v1-migration.md`'s manual-migration section for the recipe and a before/after example.
 
 ### Tests
 
@@ -131,6 +133,27 @@ the only record.
 
 On success it prints `kit=` and `version=` on stdout (diagnostics go to stderr),
 which is why `release-kit.yml` can redirect it straight into `$GITHUB_OUTPUT`.
+
+## `verify-kit-spec` — validate a kit spec, or confirm two are equivalent
+
+```bash
+go run ./scripts/verify-kit-spec ./my-kit
+go run ./scripts/verify-kit-spec ./my-kit ./my-kit-scratch-copy
+```
+
+Loads a kit through the same path `sbx kit validate`/`sbx kit inspect` use
+and fails on a validation error or a non-empty `Artifact.Warnings` — useful
+anywhere `sbx` itself isn't available to run those commands directly. With a
+second directory argument, also confirms both parse to the same spec,
+**ignoring `Artifact.Files`** — the compare directory only needs a
+`spec.yaml`, not the kit's whole `files/`/`Dockerfile`/`icons/` tree.
+
+That two-directory form is what a `migrate-v1-to-v2.go` migration should run
+after hand-restoring comments the mechanical rewrite dropped: regenerate a
+fresh, uncommented migration from the original v1 backup into a scratch
+directory containing just that `spec.yaml`, then confirm the hand-edited file
+still matches it field-for-field — proving the comment restoration didn't
+also change what the spec means.
 
 ## `check-image-ref.sh` — spec ↔ publishable image
 

--- a/scripts/migrate-v1-to-v2.go
+++ b/scripts/migrate-v1-to-v2.go
@@ -56,6 +56,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -174,10 +175,19 @@ func migrateSpec(data []byte) ([]byte, []string, error) {
 
 	out := buildV2(a, srcSandbox)
 
-	emitted, err := yaml.Marshal(out)
-	if err != nil {
-		return nil, nil, fmt.Errorf("emit v2 spec: %w", err)
+	// 2-space indent to match every hand-written spec.yaml in this repo —
+	// yaml.Marshal's default is 4, which every migrated kit would otherwise
+	// need reformatting to fix by hand.
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(out); err != nil {
+		return nil, nil, fmt.Errorf("emit v2 spec: encode: %w", err)
 	}
+	if err := enc.Close(); err != nil {
+		return nil, nil, fmt.Errorf("emit v2 spec: close: %w", err)
+	}
+	emitted := buf.Bytes()
 
 	// Safety net: the rewritten spec must parse cleanly through the same
 	// loader. A decode error here means we produced a malformed spec.yaml —

--- a/scripts/migrate-v1-to-v2.go
+++ b/scripts/migrate-v1-to-v2.go
@@ -80,9 +80,11 @@ func main() {
 // migrate runs the in-place migration on the spec.yaml under kitDir.
 // All progress messages are written to w; the only error condition is
 // a real I/O or contract failure (missing spec.yaml, undecodable spec,
-// refuse to clobber an existing .bak, etc.). A spec that already uses only
-// canonical v2 fields is a successful no-op: nothing is rewritten and no
-// .bak is created.
+// refuse to clobber an existing .bak, etc.). A spec that already declares
+// schemaVersion "2" and uses no deprecated fields is a successful no-op:
+// nothing is rewritten and no .bak is created. Every schemaVersion "1" spec
+// is rewritten, even one using only field names that are spelled identically
+// in both grammars (e.g. "requires:"), since the bump itself is a change.
 func migrate(kitDir string, w io.Writer) error {
 	specPath, err := findSpec(kitDir)
 	if err != nil {
@@ -149,14 +151,27 @@ func migrateSpec(data []byte) ([]byte, []string, error) {
 	// normalizeLegacySettings (in the spec package) now emits the settings:
 	// deprecation/lift notice into a.Warnings, so the dead Artifact.Settings
 	// detector that used to live here is gone — the notice flows through the
-	// warnings fold below. A spec that produced no warnings is already
-	// canonical v2: nothing to migrate. Returning before the entrypoint
-	// re-read below also means a clean v2 spec (whose entrypoint is the flat
-	// array shape, not the v1 run/args/ttyArgs mapping) is never fed to the
-	// mapping-shaped raw decoder.
+	// warnings fold below.
+	//
+	// Warnings alone aren't enough to decide there's nothing to do, though: a
+	// kit can use only canonical v1 field names (`commands:`, `agentContext:`)
+	// and trigger zero deprecation warnings while still declaring
+	// schemaVersion "1" — and those exact key names don't exist in the v2
+	// grammar at all (it wants `setup:` / `agentInstructions.content`), so
+	// leaving such a file untouched would silently leave it un-migrated. Only
+	// a spec that was ALREADY schemaVersion "2" with no warnings is a true
+	// no-op; anything else always needs at least the version bump and a
+	// canonical v2 re-emission. Returning before the entrypoint re-read below
+	// also means a clean v2 spec (whose entrypoint is the flat array shape,
+	// not the v1 run/args/ttyArgs mapping) is never fed to the mapping-shaped
+	// raw decoder.
 	changes := append([]string(nil), a.Warnings...)
-	if len(changes) == 0 {
+	alreadyV2 := a.Manifest.SchemaVersion == "2" && len(changes) == 0
+	if alreadyV2 {
 		return data, nil, nil
+	}
+	if len(changes) == 0 {
+		changes = append(changes, `schemaVersion: "1" -> "2" (no other deprecated fields in use; re-emitted in canonical v2 grammar)`)
 	}
 
 	// The spec loader flattens the sandbox entrypoint (run/args/ttyArgs) into

--- a/scripts/migrate_v1_to_v2_test.go
+++ b/scripts/migrate_v1_to_v2_test.go
@@ -282,6 +282,50 @@ credentials: {sources: {openai: {env: [OPENAI_API_KEY]}}}
 	}
 }
 
+// TestMigrateSpec_SchemaVersionOnlyBump is a regression test for a real kit
+// hitting a real gap: a schemaVersion "1" spec that uses only field names
+// spelled identically in both grammars (kind: mixin, requires:) plus fields
+// that are canonical v1 spellings distinct from v2 (commands:, agentContext:)
+// triggers zero deprecation warnings from spec.LoadArtifactFromBytes — those
+// two fields aren't deprecated in v1, just renamed in v2's grammar. Before the
+// fix, a.Warnings being empty was (wrongly) read as "nothing to migrate",
+// leaving the file at schemaVersion "1" forever, with the v2-invalid
+// `commands:`/`agentContext:` keys never renamed to `setup:`/
+// `agentInstructions.content`. This is exactly the shape claude-sbx-statusline
+// hit during the v2 kit migration.
+func TestMigrateSpec_SchemaVersionOnlyBump(t *testing.T) {
+	v1 := []byte(`schemaVersion: "1"
+kind: mixin
+name: t
+commands:
+  install:
+    - command: "echo hi"
+agentContext: |
+  some context
+`)
+	out, changes, err := migrateSpec(v1)
+	if err != nil {
+		t.Fatalf("migrateSpec: %v", err)
+	}
+	if len(changes) == 0 {
+		t.Fatal("expected the schemaVersion bump itself to count as a change")
+	}
+
+	got, err := spec.LoadArtifactFromBytes(out)
+	if err != nil {
+		t.Fatalf("migrated spec failed to load: %v\n%s", err, out)
+	}
+	if got.Manifest.SchemaVersion != "2" {
+		t.Errorf("schemaVersion: got %q, want \"2\"\nmigrated spec:\n%s", got.Manifest.SchemaVersion, out)
+	}
+	if !strings.Contains(string(out), "setup:") {
+		t.Errorf("migrated output did not rename commands: to setup::\n%s", out)
+	}
+	if !strings.Contains(string(out), "agentInstructions:") {
+		t.Errorf("migrated output did not rename agentContext: to agentInstructions.content:\n%s", out)
+	}
+}
+
 // TestMigrateSpec_PreservesLicensesAndMixins is a regression test for silent
 // data loss: the emitter used to be a hand-maintained struct local to this
 // tool, and it had no licenses/mixins fields — so a kit declaring either lost

--- a/scripts/publish-artifact.sh
+++ b/scripts/publish-artifact.sh
@@ -13,6 +13,7 @@
 #   IMAGE_TAG_LATEST  default latest        — the rolling tag MOVE_LATEST moves
 #   MOVE_LATEST       default false         — also re-point the rolling tag
 #   DRY_RUN           set to any value      — resolve and report, publish nothing
+#   PUBLISH_KITS      default (all kits, see below) — space-separated allow-list
 #
 # Emits `ref=`, `digest=`, `pushed=` and `reused=` on stdout, one per line, so CI
 # can redirect into $GITHUB_OUTPUT. Everything human goes to stderr, which keeps
@@ -36,7 +37,12 @@ IMAGE_NAMESPACE=${IMAGE_NAMESPACE:-sbx}
 IMAGE_TAG_LATEST=${IMAGE_TAG_LATEST:-latest}
 MOVE_LATEST=${MOVE_LATEST:-false}
 DRY_RUN=${DRY_RUN:-}
-PUBLISH_KITS=${PUBLISH_KITS:-kiro}
+# This default is duplicated (not read from a single source) in
+# build-and-publish-kits.yml, publish-artifact.yml, and hub-overview.yml's
+# own PUBLISH_KITS fallback — keep all four in step when this list changes.
+# A caller invoking this script directly without setting PUBLISH_KITS (e.g.
+# a manual local run) gets the same allow-list CI uses by default.
+PUBLISH_KITS=${PUBLISH_KITS:-'amp claude-acp claude-model-runner claude-ollama claude-sbx-statusline code-server codex-acp codex-app-server crush git-ssh-sign github-ssh hermes-agent junie kiro mise nanobot nanoclaw neovim openclaw opencode-model-runner packages-through-sfw pi playwright smolagents task trivy vale'}
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)

--- a/scripts/testdata/v2-expected/spec.yaml
+++ b/scripts/testdata/v2-expected/spec.yaml
@@ -4,61 +4,61 @@ name: legacy-kit
 displayName: Legacy Kit
 description: exercises every v1 → v2 transform at once
 sandbox:
-    image: example/test:latest
-    entrypoint:
-        - test-bin
-    command:
-        default:
-            - --flag
-        interactive:
-            - --interactive
+  image: example/test:latest
+  entrypoint:
+    - test-bin
+  command:
+    default:
+      - --flag
+    interactive:
+      - --interactive
 agentInstructions:
-    filename: TEST.md
-    content: |
-        Some legacy memory content.
-        Should be carried over verbatim under agentContext after migration.
+  filename: TEST.md
+  content: |
+    Some legacy memory content.
+    Should be carried over verbatim under agentContext after migration.
 permissions:
-    network:
-        allow:
-            - api.anthropic.com:443
-            - registry.npmjs.org
-        deny:
-            - malware.example.com
+  network:
+    allow:
+      - api.anthropic.com:443
+      - registry.npmjs.org
+    deny:
+      - malware.example.com
 ports:
-    - container: 8080
-      protocol: tcp
-      name: web
+  - container: 8080
+    protocol: tcp
+    name: web
 credentials:
-    - service: anthropic
-      apiKey:
-        name: ANTHROPIC_API_KEY
-        proxyManaged: true
-        inject:
-            - domain: api.anthropic.com
-              header: x-api-key
-              format: '%s'
-            - domain: console.anthropic.com
-              header: x-api-key
-              format: '%s'
-      oauth:
-        tokenEndpoint:
-            host: platform.claude.com
-            path: /v1/oauth/token
-        sentinels:
-            accessToken: sk-ant-oat01-proxy-managed
-            refreshToken: sk-ant-ort01-proxy-managed
-        credentialFile:
-            path: ~/.claude/.credentials.json
-            structure:
-                claudeAiOauth:
-                    accessToken: '{{.AccessToken}}'
-                    expiresAt: '{{.ExpiresAt}}'
-                    refreshToken: '{{.RefreshToken}}'
+  - service: anthropic
+    apiKey:
+      name: ANTHROPIC_API_KEY
+      proxyManaged: true
+      inject:
+        - domain: api.anthropic.com
+          header: x-api-key
+          format: '%s'
+        - domain: console.anthropic.com
+          header: x-api-key
+          format: '%s'
+    oauth:
+      tokenEndpoint:
+        host: platform.claude.com
+        path: /v1/oauth/token
+      sentinels:
+        accessToken: sk-ant-oat01-proxy-managed
+        refreshToken: sk-ant-ort01-proxy-managed
+      credentialFile:
+        path: ~/.claude/.credentials.json
+        structure:
+          claudeAiOauth:
+            accessToken: '{{.AccessToken}}'
+            expiresAt: '{{.ExpiresAt}}'
+            refreshToken: '{{.RefreshToken}}'
 environment:
-    variables:
-        IS_SANDBOX: "1"
+  variables:
+    IS_SANDBOX: "1"
 setup:
-    install:
-        - command: echo install
-          user: "0"
-          description: Install step
+  install:
+    - command: echo install
+      user: "0"
+      description: Install step

--- a/scripts/verify-kit-spec/main.go
+++ b/scripts/verify-kit-spec/main.go
@@ -1,0 +1,92 @@
+// Validates a migrated kit spec, and optionally confirms it's semantically
+// identical to another directory's spec — the check a v1→v2 migration runs
+// after hand-restoring comments the mechanical rewrite dropped, to prove the
+// restoration didn't change what the spec actually means.
+//
+// Usage:
+//
+//	go run ./scripts/verify-kit-spec <kit-dir>
+//	go run ./scripts/verify-kit-spec <kit-dir> <compare-dir>
+//
+// With one argument: loads <kit-dir> through the same path `sbx kit
+// validate`/`sbx kit inspect` use (spec.OpenFromDirectory already validates
+// internally), and additionally fails if Artifact.Warnings is non-empty —
+// this environment has no `sbx` binary to run those commands directly, so
+// this is the equivalent check.
+//
+// With two arguments: additionally loads <compare-dir> and fails unless both
+// parse to the same spec, ignoring Artifact.Files — migrate-v1-to-v2.go only
+// ever reads and writes spec.yaml, so <compare-dir> only needs a spec.yaml
+// (e.g. a scratch copy regenerated fresh from the original v1 backup, with
+// no comments restored); it has no files/, Dockerfile, or icons/ tree to
+// compare, and forcing that tree to match would compare something this tool
+// was never meant to check. Typical use: prove a hand-edited
+// comment-restoration pass didn't alter any field.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
+
+	"github.com/docker/sbx-kits-contrib/spec"
+)
+
+func main() {
+	if len(os.Args) != 2 && len(os.Args) != 3 {
+		fmt.Fprintln(os.Stderr, "usage: verify-kit-spec <kit-dir> [<compare-dir>]")
+		os.Exit(2)
+	}
+
+	a := loadOrExit(os.Args[1])
+
+	if len(os.Args) != 3 {
+		return
+	}
+
+	b := loadOrExit(os.Args[2])
+
+	// Files reflects the whole kit directory's tree, which this tool's
+	// two-directory comparison was never meant to check (see the doc
+	// comment above) — cleared here rather than compared. a and b are not
+	// used after this, so mutated in place rather than copied first.
+	a.Files, b.Files = nil, nil
+
+	if !reflect.DeepEqual(a, b) {
+		fmt.Fprintln(os.Stderr, "MISMATCH: the two directories' specs differ (Files excluded from this comparison)")
+		fmt.Fprintln(os.Stderr, os.Args[1]+":", marshalOrExit(a))
+		fmt.Fprintln(os.Stderr, os.Args[2]+":", marshalOrExit(b))
+		os.Exit(1)
+	}
+	fmt.Println("MATCH: both directories' specs are identical (Files excluded)")
+}
+
+// loadOrExit loads and validates dir, additionally rejecting any warning
+// (spec.OpenFromDirectory validates but does not treat a warning as fatal —
+// a migrated kit should have none). Uses the streaming path: validation and
+// the two-directory comparison only ever need Target/RelativePath, never
+// file content, so there's nothing to gain from reading files/ eagerly.
+// Exits the process on any failure.
+func loadOrExit(dir string) *spec.Artifact {
+	a, err := spec.OpenFromDirectory(dir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: load %s: %v\n", dir, err)
+		os.Exit(1)
+	}
+	if len(a.Warnings) > 0 {
+		fmt.Fprintf(os.Stderr, "error: %s has %d warning(s): %v\n", dir, len(a.Warnings), a.Warnings)
+		os.Exit(1)
+	}
+	fmt.Printf("%s: valid, no warnings\n", dir)
+	return a
+}
+
+func marshalOrExit(a *spec.Artifact) string {
+	b, err := json.Marshal(a)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error: marshal:", err)
+		os.Exit(1)
+	}
+	return string(b)
+}

--- a/smolagents/spec.yaml
+++ b/smolagents/spec.yaml
@@ -1,39 +1,37 @@
-schemaVersion: "1"
+schemaVersion: "2"
 kind: mixin
 name: smolagents
 displayName: smolagents
-description: "Installs Hugging Face smolagents in an isolated Python virtual environment and exposes the smolagent and webagent CLIs inside the sandbox."
-
-network:
-  allowedDomains:
-    # pip install path for smolagents and its Python dependencies.
-    - "pypi.org:443"
-    - "files.pythonhosted.org:443"
-    # Hugging Face Hub and Inference Providers, used by InferenceClientModel and
-    # hub-backed agent/tool loading at runtime.
-    - "huggingface.co:443"
-    - "hf.co:443"
-    - "router.huggingface.co:443"
-    # DuckDuckGo-backed search tools from the optional toolkit extra. Webpage
-    # fetches still require allowing the target sites you ask the agent to visit.
-    - "duckduckgo.com:443"
-    - "html.duckduckgo.com:443"
-    - "www.duckduckgo.com:443"
-    # `apt-get update` refreshes every configured apt source from the base
-    # template. Keep all template sources allowed for amd64 and arm64 sandboxes.
-    - "archive.ubuntu.com:80"
-    - "security.ubuntu.com:80"
-    - "ports.ubuntu.com:80"
-    - "download.docker.com:443"
-
+description: Installs Hugging Face smolagents in an isolated Python virtual environment and exposes the smolagent and webagent CLIs inside the sandbox.
+permissions:
+  network:
+    allow:
+      # pip install path for smolagents and its Python dependencies.
+      - "pypi.org:443"
+      - "files.pythonhosted.org:443"
+      # Hugging Face Hub and Inference Providers, used by InferenceClientModel and
+      # hub-backed agent/tool loading at runtime.
+      - "huggingface.co:443"
+      - "hf.co:443"
+      - "router.huggingface.co:443"
+      # DuckDuckGo-backed search tools from the optional toolkit extra. Webpage
+      # fetches still require allowing the target sites you ask the agent to visit.
+      - "duckduckgo.com:443"
+      - "html.duckduckgo.com:443"
+      - "www.duckduckgo.com:443"
+      # `apt-get update` refreshes every configured apt source from the base
+      # template. Keep all template sources allowed for amd64 and arm64 sandboxes.
+      - "archive.ubuntu.com:80"
+      - "security.ubuntu.com:80"
+      - "ports.ubuntu.com:80"
+      - "download.docker.com:443"
 environment:
   variables:
-    SMOLAGENTS_VENV: "/opt/smolagents"
-    SMOLAGENTS_PYTHON: "/opt/smolagents/bin/python"
-
-commands:
+    SMOLAGENTS_PYTHON: /opt/smolagents/bin/python
+    SMOLAGENTS_VENV: /opt/smolagents
+setup:
   install:
-    - command: "apt-get update && apt-get install -y --no-install-recommends ca-certificates python3 python3-venv python3-pip && rm -rf /var/lib/apt/lists/*"
+    - command: apt-get update && apt-get install -y --no-install-recommends ca-certificates python3 python3-venv python3-pip && rm -rf /var/lib/apt/lists/*
       user: "0"
       description: Install Python and venv prerequisites for smolagents
     - command: |
@@ -53,7 +51,7 @@ commands:
         webagent --help >/dev/null
         smolagents-python -c 'import smolagents; print("smolagents", smolagents.__version__)'
       user: "0"
-      description: "Install smolagents v1.26.0 with toolkit and vision extras in /opt/smolagents"
+      description: Install smolagents v1.26.0 with toolkit and vision extras in /opt/smolagents
     - command: |
         set -euo pipefail
         grep -qF 'smolagents-python' ~/.bashrc 2>/dev/null || \

--- a/task/spec.yaml
+++ b/task/spec.yaml
@@ -1,15 +1,16 @@
-schemaVersion: "1"
+schemaVersion: "2"
 kind: mixin
 name: task
 displayName: Task
 description: Installs the Task CLI so sandbox agents can run Taskfiles.
-
-network:
-  allowedDomains:
-    - github.com
-    - release-assets.githubusercontent.com
-
-commands:
+permissions:
+  network:
+    allow:
+      - github.com
+      # Confirmed by hand: github.com's release-download redirect target.
+      - objects.githubusercontent.com
+      - release-assets.githubusercontent.com
+setup:
   install:
     - command: |
         set -euo pipefail
@@ -36,4 +37,4 @@ commands:
         rm /tmp/task.tgz
         task --version
       user: "0"
-      description: "Install Task CLI v3.50.0, version+digest pinned"
+      description: Install Task CLI v3.50.0, version+digest pinned

--- a/trivy/README.md
+++ b/trivy/README.md
@@ -1,6 +1,6 @@
 # trivy
 
-A standalone agent kit (`kind: agent`) for the [Trivy](https://trivy.dev/)
+A standalone sandbox kit for the [Trivy](https://trivy.dev/)
 open-source vulnerability scanner from [Aqua Security](https://aquasec.com/).
 The kit installs `trivy` from a pinned, digest-verified GitHub release at
 sandbox creation time and drops you into a bash shell with the binary on
@@ -16,7 +16,7 @@ packages downstream. Microsoft's
 prescribes "governed execution pipelines" with "vault isolation and egress
 filtering". This kit puts that prescription one `sbx run` away: scanner
 runs in a microVM, your `~/.aws` / `~/.ssh` / `~/.docker/config.json` are
-not mounted, egress is allowlisted to four hosts (release fetch + vuln DB),
+not mounted, egress is allowlisted to six hosts (release fetch + vuln DB),
 and the install is digest-pinned against tag-rewrite attacks.
 
 ## Usage
@@ -43,12 +43,13 @@ flows (`fs`, `repo`, plain `image`). Aqua's commercial feeds (premium
 indicators, SaaS reporting) are out of scope for this kit; if you need
 them, fork and add the appropriate `serviceDomains` and `credentials`.
 
-The kit's `allowedDomains` covers exactly five hosts:
+The kit's network allowlist covers exactly six hosts:
 
 | Host | Why |
 | --- | --- |
 | `github.com` | Release page entry point for the install tarball (302-redirects) |
-| `release-assets.githubusercontent.com` | Where GitHub release blobs actually live (the redirect target) |
+| `objects.githubusercontent.com` | Actual redirect target for this repo's release asset (confirmed by hand) |
+| `release-assets.githubusercontent.com` | Kept alongside it since the redirect target isn't guaranteed to be the same host for every repo/asset |
 | `mirror.gcr.io` | Trivy's default *primary* vuln DB source (`mirror.gcr.io/aquasec/trivy-db`) |
 | `ghcr.io` | Trivy's *fallback* vuln DB source (`ghcr.io/aquasecurity/trivy-db`) |
 | `pkg-containers.githubusercontent.com` | GHCR blob storage backend |

--- a/trivy/spec.yaml
+++ b/trivy/spec.yaml
@@ -1,32 +1,36 @@
-schemaVersion: "1"
-kind: agent
+schemaVersion: "2"
+kind: sandbox
 name: trivy
 displayName: Trivy
-description: "Aqua's open source vulnerability scanner — sandboxed because security scanners shouldn't be able to compromise their hosts (TeamPCP, March 2026)."
-
-agent:
-  image: "docker/sandbox-templates:shell-docker"
-  aiFilename: AGENTS.md
+description: Aqua's open source vulnerability scanner — sandboxed because security scanners shouldn't be able to compromise their hosts (TeamPCP, March 2026).
+sandbox:
+  image: docker/sandbox-templates:shell-docker
   # Drop into bash with trivy on PATH and the workspace as cwd. Run `trivy fs .` to scan.
   entrypoint:
-    run: [bash, -l]
-
-network:
-  allowedDomains:
-    # Release tarball download (install time, one-shot).
-    # github.com 302-redirects to release-assets.githubusercontent.com for binary downloads.
-    - github.com
-    - release-assets.githubusercontent.com
-    # Vulnerability DB pull at runtime. Trivy's default chain is mirror.gcr.io (primary)
-    # with ghcr.io as a fallback for the trivy-db OCI artifact; we declare both openly in
-    # the allowlist rather than relying on env-var overrides to redirect the source.
-    # The trust footprint is intentionally explicit at the policy layer; tightening this
-    # is part of the v2 path (hardened-distribution-channel install).
-    - mirror.gcr.io
-    - ghcr.io
-    - pkg-containers.githubusercontent.com
-
-commands:
+    - bash
+    - -l
+agentInstructions:
+  filename: AGENTS.md
+permissions:
+  network:
+    allow:
+      # Release tarball download (install time, one-shot).
+      # github.com 302-redirects to objects.githubusercontent.com for binary
+      # downloads (confirmed by hand); release-assets.githubusercontent.com
+      # kept alongside it since that isn't guaranteed to be the same host
+      # for every repo/asset.
+      - github.com
+      - objects.githubusercontent.com
+      - release-assets.githubusercontent.com
+      # Vulnerability DB pull at runtime. Trivy's default chain is mirror.gcr.io (primary)
+      # with ghcr.io as a fallback for the trivy-db OCI artifact; we declare both openly in
+      # the allowlist rather than relying on env-var overrides to redirect the source.
+      # The trust footprint is intentionally explicit at the policy layer; tightening this
+      # is part of the v2 path (hardened-distribution-channel install).
+      - mirror.gcr.io
+      - ghcr.io
+      - pkg-containers.githubusercontent.com
+setup:
   install:
     # Install Trivy from a pinned, digest-verified GitHub release.
     # Why not the official `install.sh`: that pattern (curl|sh) is exactly what TeamPCP
@@ -58,4 +62,4 @@ commands:
         rm /tmp/trivy.tgz
         trivy --version
       user: "0"
-      description: "Install Trivy CLI v0.70.0, version+digest pinned"
+      description: Install Trivy CLI v0.70.0, version+digest pinned

--- a/vale/spec.yaml
+++ b/vale/spec.yaml
@@ -1,17 +1,27 @@
-schemaVersion: "1"
+schemaVersion: "2"
 kind: mixin
 name: vale
 displayName: Vale
 description: Installs the Vale prose linter from a pinned GitHub release.
+agentInstructions:
+  content: |
+    ## Vale prose linter
 
-network:
-  allowedDomains:
-    # Release tarball download (install time, one-shot).
-    # github.com 302-redirects to release-assets.githubusercontent.com for binary downloads.
-    - github.com
-    - release-assets.githubusercontent.com
-
-commands:
+    The `vale` CLI is installed and available on `PATH`. Use it to lint
+    prose in Markdown, AsciiDoc, reStructuredText, and other text formats.
+    Run `vale --version` to confirm, and `vale <file>` to lint a file.
+permissions:
+  network:
+    allow:
+      # Release tarball download (install time, one-shot).
+      # github.com 302-redirects to objects.githubusercontent.com for binary
+      # downloads (confirmed by hand); release-assets.githubusercontent.com
+      # kept alongside it since that isn't guaranteed to be the same host
+      # for every repo/asset.
+      - github.com
+      - objects.githubusercontent.com
+      - release-assets.githubusercontent.com
+setup:
   install:
     # Install Vale from a pinned, SHA256-verified GitHub release. We deliberately
     # do NOT query api.github.com for `releases/latest`: unauthenticated API calls
@@ -45,11 +55,4 @@ commands:
         rm /tmp/vale.tgz
         vale --version
       user: "0"
-      description: "Install pinned Vale CLI"
-
-memory: |
-  ## Vale prose linter
-
-  The `vale` CLI is installed and available on `PATH`. Use it to lint
-  prose in Markdown, AsciiDoc, reStructuredText, and other text formats.
-  Run `vale --version` to confirm, and `vale <file>` to lint a file.
+      description: Install pinned Vale CLI


### PR DESCRIPTION
## Summary

Migrates all 23 remaining schemaVersion-1 kits to schemaVersion 2, following
mise's pilot (#191). One commit per kit, mechanical migration via
`scripts/migrate-v1-to-v2.go` plus hand-restored comments and per-kit
verification (`verify-kit-spec`, `./scripts/test-kit.sh <kit>`).

- **Tooling** (`9c239c0`, `b49dff5`): 2-space YAML output, a reusable
  `verify-kit-spec` script, and a fix for a migration-tool gap where a spec
  using only canonical-but-renamed v1 field names (`commands:`, `agentContext:`)
  produced zero deprecation warnings and was wrongly treated as a no-op.
- **CI** (`5549f64`): widens kit discovery in `build-and-publish-kits.yml`
  from Dockerfile-based to spec.yaml-based, so every kit (not just `kiro`)
  is eligible for OCI artifact publishing. Whether a kit also builds its own
  image stays a separate per-kit decision (`has-image`, gated on Dockerfile
  presence).
- **23 kit migrations**, each its own commit: `git-ssh-sign`, `github-ssh`,
  `neovim`, `smolagents`, `task`, `vale`, `packages-through-sfw`, `trivy`,
  `claude-model-runner`, `amp`, `claude-sbx-statusline`, `code-server`,
  `opencode-model-runner`, `claude-ollama`, `pi`, `nanobot`, `openclaw`,
  `crush`, `hermes-agent`, `codex-app-server`, `playwright`, `nanoclaw`, `junie`.
- A handful of pre-existing bugs found and fixed along the way, each
  documented in its own commit: missing `objects.githubusercontent.com`
  redirect targets (`task`, `vale`, `packages-through-sfw`, `trivy`), a
  missing `agentInstructions.filename` that silently dropped `nanoclaw`'s
  agent guidance, and stale README prose in `trivy`, `playwright`, `junie`,
  `crush`.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt` clean
- [x] `go test ./scripts/... ./spec/...`
- [x] `verify-kit-spec` passes with zero warnings for all 27 kits
- [x] `./scripts/test-kit.sh <kit>` green for every migrated kit
- [ ] `test-kit-e2e.sh` (real `sbx`, host-only) not run from this sandbox —
      please spot-check on the host before merging, especially `playwright`
      and `nanoclaw`