### PR TITLE
fix(ci): Hub overview sync bugs found on the first post-merge run

### DIFF
--- a/.github/workflows/hub-overview.yml
+++ b/.github/workflows/hub-overview.yml
@@ -177,11 +177,52 @@ jobs:
           HUB_USERNAME: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
           HUB_TOKEN: ${{ secrets.DOCKERPUBLICBOT_DELETE_PAT }}
 
+      - name: Does this kit own the base image it references?
+        id: image-owned
+        # A kit owns (and therefore may describe) its base image repository
+        # only if it builds that image itself AND has written docs for it —
+        # computed once here, in outputs, rather than as inline hashFiles()
+        # calls repeated at both the gate below and in "Report what happened",
+        # so the two can never silently diverge if this ever changes.
+        #
+        # has-dockerfile guards a real, previously-latent bug: most kits boot
+        # from a shared template (docker/sandbox-templates) or a third-party
+        # image (nanoclaw's nanoco/nanoclaw) rather than one built and owned by
+        # the kit itself — kit-meta.sh resolves image-repository from
+        # sandbox.image regardless of who owns that repository. Without this
+        # guard, every one of those kits' matrix legs would try to PATCH the
+        # SAME shared (or someone else's) Hub repository with ITS OWN
+        # kit-specific "Base image for the <kit> kit" text — a last-write-wins
+        # race across unrelated kits, or an overwrite of a repository this
+        # project doesn't own the narrative for. The same Dockerfile-presence
+        # signal build-and-publish-kits.yml and publish-one-kit.yml gate the
+        # actual image build/push on (`has-image`); today that's only `kiro`,
+        # the one kit this workflow was built and tested against.
+        #
+        # has-readme guards a second failure mode: the sync step below hands
+        # its path straight to peter-evans/dockerhub-description with no
+        # existence check of its own, so a kit with a Dockerfile but no
+        # README.image.md would otherwise reach that step and fail on a
+        # missing file instead of skipping cleanly.
+        #
+        # hashFiles() sees these here because checkout already ran earlier in
+        # this same job — a step-level `if:`/expression, unlike a job-level
+        # one, evaluates after prior steps in the same job have run.
+        run: |
+          echo "has-dockerfile=${HAS_DOCKERFILE}" >> "$GITHUB_OUTPUT"
+          echo "has-readme=${HAS_README}" >> "$GITHUB_OUTPUT"
+        env:
+          HAS_DOCKERFILE: ${{ hashFiles(format('{0}/Dockerfile', matrix.kit)) != '' }}
+          HAS_README: ${{ hashFiles(format('{0}/README.image.md', matrix.kit)) != '' }}
+
       - name: Is the base image's repository published?
         id: image-repo
         # Absent output means the kit builds no image — kit-meta.sh omits it
         # rather than emitting it empty, precisely so this can branch on it.
-        if: steps.meta.outputs.image-repository != ''
+        if: >-
+          steps.meta.outputs.image-repository != '' &&
+          steps.image-owned.outputs.has-dockerfile == 'true' &&
+          steps.image-owned.outputs.has-readme == 'true'
         run: ./scripts/hub-repo-ready.sh "${{ steps.meta.outputs.image-repository }}" >> "$GITHUB_OUTPUT"
 
       - name: Sync the base image's overview
@@ -209,6 +250,11 @@ jobs:
           [ "${{ steps.kit-repo.outputs.ready }}" = "true" ] ||
             echo "::notice::${{ steps.meta.outputs.kit-repository }} has nothing published — overview not synced."
           if [ -n "${{ steps.meta.outputs.image-repository }}" ]; then
-            [ "${{ steps.image-repo.outputs.ready }}" = "true" ] ||
+            if [ "${{ steps.image-owned.outputs.has-dockerfile }}" != "true" ]; then
+              echo "::notice::${{ matrix.kit }} does not build its own image — nothing to sync to ${{ steps.meta.outputs.image-repository }}, which it does not own."
+            elif [ "${{ steps.image-owned.outputs.has-readme }}" != "true" ]; then
+              echo "::notice::${{ matrix.kit }} has no README.image.md — nothing to sync to ${{ steps.meta.outputs.image-repository }}."
+            elif [ "${{ steps.image-repo.outputs.ready }}" != "true" ]; then
               echo "::notice::${{ steps.meta.outputs.image-repository }} has nothing published — overview not synced."
+            fi
           fi

--- a/.github/workflows/publish-one-kit.yml
+++ b/.github/workflows/publish-one-kit.yml
@@ -332,7 +332,18 @@ jobs:
   # the primary one — the page tracks the default branch, not this run.
   overview:
     needs: artifact
-    if: inputs.publish-artifact
+    # `!cancelled()` overrides GitHub's implicit `&& success()` on this if, for
+    # the same reason as `artifact`'s own if: above — but one level removed.
+    # `success()` (with no args) walks this job's ENTIRE transitive dependency
+    # chain, not just the immediate `needs: artifact` — so it also inspects
+    # `image`, which is legitimately skipped for a kit with no Dockerfile. A
+    # bare `if: inputs.publish-artifact` therefore never ran `overview` for any
+    # kit whose `image` job was skipped, EVEN WHEN `artifact` itself succeeded:
+    # every kit but `kiro`. This is why most kits' Hub overview page was never
+    # synced by this path despite their artifact publish going green — caught
+    # only once a real post-merge run made ALL 27 kits' artifact jobs succeed
+    # at once and their overview pages still didn't update.
+    if: "!cancelled() && needs.artifact.result == 'success'"
     permissions:
       contents: read
     uses: ./.github/workflows/hub-overview.yml

--- a/scripts/kit-meta.sh
+++ b/scripts/kit-meta.sh
@@ -105,8 +105,34 @@ image_repository=$(awk '
   }
 ' "$spec")
 image_repository=${image_repository%%@*}
-image_repository=${image_repository%:*}
-image_repository=${image_repository#*/}
+
+# A tag's colon can only ever appear after the last "/" — a registry's port
+# colon comes before it — so only strip a trailing ":tag" when there's one in
+# that last path segment. Blindly taking the rightmost ":" in the whole string
+# (the previous form of this line) mis-parsed a port-bearing, untagged
+# registry like "myregistry.local:5000/team/image": bash's shortest suffix
+# match for ":*" removed everything from the port colon onward, leaving just
+# "myregistry.local" with no path left for the registry-detection below to
+# even see.
+last_segment=${image_repository##*/}
+if [[ "$last_segment" == *:* ]]; then
+  image_repository=${image_repository%:*}
+fi
+
+# Strip a leading registry-host segment, but only if the first path component
+# actually looks like a registry — matching the same rule the Docker CLI uses
+# to parse image references. A two-segment reference like
+# "docker/sandbox-templates" is already <namespace>/<name> on Docker Hub, not
+# <registry>/<name>: blindly stripping up to the first "/" turned it into the
+# bare name "sandbox-templates", which hub-repo-ready.sh then rejected outright
+# ("is not <namespace>/<name>") for every kit using the shared shell-docker
+# template — this went unnoticed while PUBLISH_KITS only ever listed kiro,
+# whose own image is built (and named) differently. A registry host is only
+# ever distinguished by containing a "." or a ":", or by being "localhost".
+first_segment=${image_repository%%/*}
+case "$first_segment" in
+  *.*|*:*|localhost) image_repository=${image_repository#*/} ;;
+esac
 
 # Only the KEY=VALUE stream is printed. Echoing a prose copy to stderr as well
 # would double every line on a terminal, where both streams land together — and

--- a/skills/kit-author/topics/image-publishing.md
+++ b/skills/kit-author/topics/image-publishing.md
@@ -9,17 +9,33 @@ root. This topic is the author-facing subset — what you write, and the traps.
 
 ## What you write
 
-Two things, no CI edit:
+Three things, no CI edit:
 
 ```
 my-kit/
-├── Dockerfile     # build context is the kit directory
-└── spec.yaml      # sandbox.image: docker.io/sbx/my-kit-image:latest
+├── Dockerfile         # build context is the kit directory
+├── spec.yaml          # sandbox.image: docker.io/sbx/my-kit-image:latest
+└── README.image.md    # the Hub "About" page for my-kit-image
 ```
 
-`.github/workflows/build-and-publish-kits.yml` **discovers** kits: any top-level directory
-with both a `spec.yaml` and a `Dockerfile` is picked up. There is no matrix to
-register and no per-kit workflow.
+`.github/workflows/build-and-publish-kits.yml` **discovers** every kit by
+`spec.yaml` alone — Dockerfile presence is a separate, per-kit decision about
+whether that kit *also* builds and publishes its own image, not about whether
+the kit is discovered at all. There is no matrix to register and no per-kit
+workflow.
+
+`README.image.md` is optional in the sense that nothing fails without it, but
+skipping it leaves `my-kit-image`'s Hub page blank forever: `.github/workflows/
+hub-overview.yml` only syncs a base image's overview for a kit that has both a
+`Dockerfile` (proof the kit actually owns that image, not just a shared
+template or someone else's pre-built one) *and* a `README.image.md` to publish
+— the sync step is guarded on both, precisely so a kit reusing
+`docker/sandbox-templates` (or, like `nanoclaw`, someone else's own image)
+never overwrites a Hub repository it doesn't own the narrative for. This is
+separate from `my-kit/README.md`, which documents the *kit* (how to run it);
+`README.image.md` documents the *image* (what's installed, how it's built) —
+someone who pulled `sbx/my-kit-image` directly, without going through the kit
+at all, is the reader.
 
 The image name is enforced as `<kit-dir>-image`, in the `docker.io/sbx`
 namespace, at the rolling tag. `scripts/check-image-ref.sh` derives all three


### PR DESCRIPTION
## Summary

Two bugs found by cross-referencing the first real post-merge run of #192
against observed Hub state (most kits' overview page never updated
despite green CI):

- `kit-meta.sh` mis-parsed bare Docker Hub refs like
  `docker/sandbox-templates` (10 kits share it), stripping the namespace
  as if it were a registry host. Fixed, plus gated the base-image overview
  sync on Dockerfile + README.image.md presence so kits sharing a
  template (or a third party's image, like nanoclaw) can't race to
  overwrite a repo they don't own.
- `publish-one-kit.yml`'s `overview` job had no `!cancelled()` override,
  so GitHub's implicit `success()` walked the whole dependency chain back
  to `image` — skipped for every kit without a Dockerfile — silently
  skipping `overview` even when `artifact` succeeded.

## Test plan

- [x] `actionlint` clean on all touched workflows
- [x] `go build ./...`, `go vet ./...`
- [x] `kit-meta.sh` re-verified against every real kit's `sandbox.image`
      plus synthetic edge cases (port+tag, port+no-tag, `localhost`)
- [ ] Real post-merge run not observable from a PR — please confirm on
      merge that `overview` jobs actually run for all 27 kits and only
      `kiro`'s base image gets synced