### PR TITLE
feat(copilot): add the copilot sandbox kit with its own base image

### DIFF
--- a/copilot/.dockerignore
+++ b/copilot/.dockerignore
@@ -1,0 +1,10 @@
+# The build context is the kit directory, which also holds kit metadata that the
+# image has no use for. Excluding it keeps the context small and keeps README or
+# testdata edits from touching the image build at all.
+#
+# Listed by exclusion rather than as an allowlist (`*` + `!start.sh`) so that
+# adding a COPY for a new file does not silently fail on a stale ignore rule.
+README.md
+spec.yaml
+testdata/
+.dockerignore

--- a/copilot/Dockerfile
+++ b/copilot/Dockerfile
@@ -1,0 +1,58 @@
+# syntax=docker/dockerfile:1
+
+# Base image for the `copilot` sandbox kit.
+#
+# One image, no flavour suffix: the kit picks its own image, so the
+# Docker-in-Docker detail never reaches the user. There is no dockerless variant
+# either — a kind:sandbox kit names a single sandbox.image, so a second image
+# would be unreachable without a second kit to consume it.
+#
+# The base is a floating tag, which is why CI also rebuilds on a schedule.
+ARG BASE_IMAGE=docker/sandbox-templates:shell-docker
+FROM ${BASE_IMAGE}
+
+# Re-declared inside the stage: an ARG defined before the first FROM is a global
+# build arg, visible only to FROM lines. Without this, the LABEL below would
+# expand to an empty string.
+ARG BASE_IMAGE
+
+# Copilot CLI has no interactive-auth wrapper to install (unlike kiro's
+# device-flow launcher) — it reads GH_TOKEN from the environment, injected by
+# the sandbox proxy per spec.yaml's credentials block. So this is just the
+# upstream install script.
+RUN <<EOF
+set -exo pipefail
+curl -fsSL https://gh.io/copilot-install | bash
+EOF
+
+# Inherited from the base image, but re-declared deliberately so the value is
+# owned here rather than depending on inheritance from an image this repository
+# does not own.
+#
+# This is a *request* to the runtime, not a description of the image: setting it
+# over a base with no Docker engine yields a sandbox started in Docker mode with
+# nothing to run. Since BASE_IMAGE is overridable, CI asserts the engine is
+# really present rather than trusting this label.
+LABEL com.docker.sandboxes.start-docker="true"
+
+# Both of the labels below OVERRIDE values inherited from the base image, which
+# describe the base rather than this image. Overriding is not optional for
+# `flavor`: left inherited it would read "shell-docker", and sbx would report
+# this image's agent as "shell-docker".
+#
+# sbx reads `flavor` and treats it as an agent identifier — it surfaces the value
+# as an image's `Agent` in the API, and separately uses it (with any `-docker`
+# suffix trimmed) to warn when a template looks built for a different agent than
+# the one being run. So it must be the kit's own name: `copilot`.
+LABEL com.docker.sandboxes.flavor="copilot"
+
+# Informational only — nothing in sbx reads this. Worth setting because the base
+# is a floating tag rebuilt nightly, so this is the one place the produced image
+# records what it was actually built on.
+LABEL com.docker.sandboxes.base="${BASE_IMAGE}"
+
+# Note: `com.docker.sandboxes=templates` also appears on this image. It is
+# inherited from the base and is not set here — nothing reads it, and this image
+# is not part of that template family, so it is left alone rather than asserted.
+
+CMD [ "copilot" ]

--- a/copilot/README.image.md
+++ b/copilot/README.image.md
@@ -1,0 +1,18 @@
+# sbx/copilot-image
+
+Base image for the GitHub Copilot agent kit for
+[Docker Sandboxes](https://docs.docker.com/ai/sandboxes/).
+
+## Contents
+
+Built on `docker/sandbox-templates:shell-docker`: the standard sandbox tool
+chain plus a Docker engine, requesting Docker-in-Docker via
+`com.docker.sandboxes.start-docker=true`. On top of that:
+
+- `copilot`, GitHub's Copilot CLI, installed via the upstream install script
+
+Runs as the non-root `agent` user, with `CMD ["copilot"]`.
+
+## Kit
+
+[`docker.io/sbx/copilot-kit`](https://hub.docker.com/r/sbx/copilot-kit)

--- a/copilot/README.md
+++ b/copilot/README.md
@@ -1,0 +1,112 @@
+# copilot
+
+A standalone sandbox kit (`kind: sandbox`, `schemaVersion: "2"`) for
+[GitHub Copilot CLI](https://github.com/github/copilot-cli), GitHub's agentic
+coding CLI. The kit runs `copilot --yolo` as the entrypoint and authenticates
+through a `GH_TOKEN` the sandbox proxy injects per request.
+
+Copilot was previously a built-in `sbx` agent, run as `sbx run copilot`. This
+kit replaces that, and is backed by a base image built from the
+[`Dockerfile`](./Dockerfile) in this directory rather than by the
+`docker/sandbox-templates` release train.
+
+## Prerequisites
+
+A `GH_TOKEN` exported on your host with Copilot access. There is no
+interactive device-flow path — the proxy injects the token as a
+`Authorization: Bearer <token>` header on every request to a Copilot API host,
+so the token must already be present as a host environment variable before
+you run the kit.
+
+## Usage
+
+```console
+$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=copilot" copilot
+```
+
+Or with a local clone of this repo:
+
+```console
+$ sbx run --kit ./copilot/ copilot
+```
+
+The trailing `copilot` is required, not redundant: for `kind: sandbox` kits,
+`sbx` enforces that the agent name matches the kit's own `name`.
+
+## Passing arguments
+
+The entrypoint defaults to `--yolo`. Flags are appended after the defaults, so
+`-- --resume` runs `copilot --yolo --resume`. A bare word instead *replaces*
+the defaults.
+
+## How auth works
+
+The kit's `credentials` list declares one `apiKey` entry for the `github`
+service, with an `inject` rule per Copilot API host: `api.business.
+githubcopilot.com` (Business), `api.enterprise.githubcopilot.com`
+(Enterprise), `api.individual.githubcopilot.com` (Pro/Pro+),
+`api.githubcopilot.com`, `copilot.github.com`, and the plain
+`api.github.com`/`github.com` hosts. When Copilot calls one of those domains,
+the proxy adds
+`Authorization: Bearer <token>` using the `GH_TOKEN` value from your host —
+the real token never enters the sandbox.
+
+## Network policy
+
+`permissions.network.allow` mirrors every domain the credential block injects
+into, plus the apt sources the base image ships with (needed because the
+startup hook runs `apt-get update`, which fails wholesale if any configured
+source is unreachable).
+
+> [!IMPORTANT]
+> This list has not been verified end-to-end under `sbx policy init deny-all`
+> from this repo. Copilot CLI may reach further hosts (telemetry, self-update,
+> the extension registry) that aren't captured yet. If something fails under
+> deny-all, inspect what was blocked and widen the list:
+>
+> ```console
+> $ sbx policy log
+> ```
+>
+> then add the reported hosts to `permissions.network.allow` in `spec.yaml`.
+
+## Base image
+
+Unlike most kits here — which are `kind: mixin` or `kind: agent` and layer onto
+an existing `docker/sandbox-templates` image — a `kind: sandbox` kit *is* the
+whole environment, so it names the image the sandbox boots from. This kit
+builds and publishes its own, from the `Dockerfile` in this directory.
+
+The image is **`docker.io/sbx/copilot-image`**, built on
+`docker/sandbox-templates:shell-docker`, so it carries a Docker engine and
+requests Docker-in-Docker.
+
+The `-image` suffix distinguishes the base image from the kit itself: when the
+kit is published as an OCI artifact it will be `docker.io/sbx/copilot-kit`.
+The name is derived from the kit directory and enforced repo-wide — see
+[PUBLISHING.md](../PUBLISHING.md#naming).
+
+There is no flavour suffix and no dockerless variant. The sandbox templates
+distinguish `copilot` from `copilot-docker` because a user picks a template
+directly, but a kit picks its own image — so the Docker-in-Docker detail never
+reaches the user, just as `sbx run copilot` already resolves to the Docker
+flavour today. And a `kind: sandbox` kit names exactly one `sandbox.image`, so
+a second image would be unreachable without a second kit to consume it.
+
+### Building and publishing
+
+How the image is named, tagged, verified and pushed is the same for every kit
+in this repo that builds its own image — see
+**[PUBLISHING.md](../PUBLISHING.md)** for the pipeline, the tagging scheme,
+the coordinates, and the Docker Hub OIDC setup. Only the copilot-specific
+parts are below.
+
+### Building locally
+
+```console
+$ docker build -t docker.io/sbx/copilot-image:latest copilot
+```
+
+`BASE_IMAGE` is a build arg, so the base can be re-pointed or digest-pinned
+without editing the `Dockerfile`: `--build-arg BASE_IMAGE=…` accepts a tag or a
+digest.

--- a/copilot/spec.yaml
+++ b/copilot/spec.yaml
@@ -1,0 +1,96 @@
+schemaVersion: "2"
+kind: sandbox
+name: copilot
+# The KIT's version, not Copilot's. It covers this spec, the network policy
+# and the hooks — the agent inside the image floats, so a newer copilot-cli
+# does not bump this and this does not track releases of copilot-cli.
+#
+# Published as the vnd.docker.sandbox.kit.version OCI annotation at pack time,
+# and `scripts/check-release-tag.sh` refuses a `copilot/vX.Y.Z` tag that
+# disagrees with it. Bump here first, then tag.
+version: "1.0.0"
+displayName: GitHub Copilot
+description: GitHub Copilot CLI, GitHub's agentic coding CLI.
+sandbox:
+  image: "docker.io/sbx/copilot-image:latest"
+  entrypoint: [copilot, "--yolo"]
+
+credentials:
+  - service: github
+    apiKey:
+      name: GH_TOKEN
+      inject:
+        # https://github.blog/changelog/2026-02-13-network-configuration-changes-for-copilot-coding-agent/
+        - domain: api.business.githubcopilot.com # Copilot Business
+          header: Authorization
+          format: Bearer %s
+        - domain: api.enterprise.githubcopilot.com # Copilot Enterprise
+          header: Authorization
+          format: Bearer %s
+        - domain: api.github.com
+          header: Authorization
+          format: Bearer %s
+        - domain: api.githubcopilot.com
+          header: Authorization
+          format: Bearer %s
+        - domain: api.individual.githubcopilot.com # Copilot Pro and Pro+
+          header: Authorization
+          format: Bearer %s
+        - domain: copilot.github.com
+          header: Authorization
+          format: Bearer %s
+        - domain: github.com
+          header: Authorization
+          format: Bearer %s
+
+permissions:
+  network:
+    allow:
+      # Every domain the GH_TOKEN credential injects into — required here too,
+      # not just above: this repo's e2e runs every kit under
+      # `sbx policy init deny-all`, so a domain absent from this list is
+      # unreachable regardless of what the credential block declares.
+      - api.business.githubcopilot.com # Copilot Business
+      - api.enterprise.githubcopilot.com # Copilot Enterprise
+      - api.github.com
+      - api.githubcopilot.com
+      - api.individual.githubcopilot.com # Copilot Pro and Pro+
+      - copilot.github.com
+      - github.com
+      # `apt-get update` (the startup hook below) refreshes metadata for every
+      # configured apt source and returns exit 100 if any one of them fails.
+      # The shell-docker base ships three sources, so all three must be
+      # reachable. Ubuntu serves amd64 from archive/security and arm64 from
+      # ports.ubuntu.com, so all three Ubuntu hosts are listed to keep the kit
+      # working cross-arch.
+      - archive.ubuntu.com        # Ubuntu archive (amd64 main)
+      - security.ubuntu.com       # Ubuntu security updates (amd64)
+      - ports.ubuntu.com          # Ubuntu archive/security (arm64)
+      - download.docker.com       # Docker's apt repo, pre-added by shell-docker
+      #
+      # TODO(copilot-extraction): the domains above are the ones the
+      # credential block already declared; they have not been verified
+      # end-to-end under deny-all from this repo, and Copilot CLI may reach
+      # further hosts (telemetry, self-update, extension registry). Confirm
+      # or widen from a live run:
+      #
+      #   sbx run --kit ./copilot copilot   # then attempt a prompt
+      #   sbx policy log                    # lists every blocked host + reason
+
+setup:
+  install:
+    - command: mkdir -p /home/agent/.copilot && chown agent:agent /home/agent/.copilot
+      user: "0"
+      description: Ensure .copilot is owned by agent before bind mounts and initFiles run
+  startup:
+    - command: ["sh", "-c", "command -v apt-get > /dev/null 2>&1 && (apt-get update -qq -y > /dev/null 2>&1 || true) &"]
+      user: "root"
+      description: Update apt package cache in background
+  files:
+    - path: /home/agent/.copilot/config.json
+      content: '{"trusted_folders": ["${WORKDIR}"]}'
+      onlyIfMissing: true
+      description: Copilot config with trusted workspace folder
+
+agentInstructions:
+  filename: AGENTS.md

--- a/copilot/testdata/tck.yaml
+++ b/copilot/testdata/tck.yaml
@@ -1,0 +1,27 @@
+# TCK configuration for the copilot kit.
+#
+# copilot is still a built-in agent in released sbx builds, and sbx refuses to
+# load a kit whose name collides with a built-in ("built-in agents cannot be
+# overridden by a kit"). This flag turns that one specific `sbx create` failure
+# into a skip, so the kit can land and be reviewed here before the built-in is
+# removed from sbx.
+#
+# Nothing needs re-enabling later: once a released sbx no longer registers the
+# built-in, `sbx create` succeeds, the full e2e runs, and the test logs a notice
+# that this line is obsolete and can be deleted.
+extractedFromBuiltin: true
+#
+# `promptArgs` is deliberately omitted for now, which skips the e2e `prompt`
+# subtest. Unlike kiro (interactive device-flow only, genuinely no
+# non-interactive mode), Copilot CLI likely has a way to answer a prompt
+# non-interactively with a real GH_TOKEN — but the built-in agent's own e2e
+# test never exercises this either (it runs an auth-free echo/true-only smoke
+# check with SkipCredentialsTest: true), so there is no known-working recipe to
+# carry over from there, and none has been verified from this repo. Wire
+# `promptArgs` once one has, rather than guessing at flags that could flake CI.
+#
+# The remaining subtests (env, files, tmpfs, agentContext) still run and are
+# what actually gate this kit.
+
+# Copilot's startup hook does no MCP-gateway registration (unlike kiro's), so
+# no `mcp:` block is needed here.


### PR DESCRIPTION
## Summary

Phase A of extracting the built-in `copilot` agent from `docker/sandboxes`
into this repo as a standalone community kit — the same playbook `kiro`'s
own extraction used (docker/sandboxes#4944, #177). Draft because several
items genuinely need a live `sbx` session or a team decision before this is
merge-ready (see below); the kit itself is verified and TCK-green.

- `copilot/spec.yaml` — lifted from the embedded agent's spec, plus
  `sandbox.image` pointed at `docker.io/sbx/copilot-image`, a new
  `permissions.network.allow` block, and `displayName`/`description`.
- `copilot/Dockerfile` — installs Copilot CLI on top of
  `docker/sandbox-templates:shell-docker`. Verified the built image actually
  runs `copilot --version` successfully (caught and fixed a real bug along
  the way: `curl | bash` without `pipefail` silently produces a broken image
  if the download fails).
- `copilot/testdata/tck.yaml` — `extractedFromBuiltin: true` (copilot is
  still a built-in agent today, so `sbx create` would otherwise refuse the
  name collision); `promptArgs` deliberately omitted for now.

## Open before merge

- `permissions.network.allow` is only as complete as the credential-inject
  domains plus known apt hosts — not verified end-to-end under
  `sbx policy init deny-all` from a real `sbx run`.
- Whether to add `proxyManaged: true` to the `GH_TOKEN` credential (every
  other apiKey-based kit here sets it; the built-in spec didn't) — needs a
  live check that nothing shells out and reads `$GH_TOKEN` directly.
- Whether to also publish `copilot-kit` as an OCI artifact (`PUBLISH_KITS`).
- The Phase B removal PR in `docker/sandboxes` isn't started yet — that's
  what actually turns the e2e skip above into real coverage.

## Test plan

- [x] `go run ./scripts/verify-kit-spec ./copilot` — clean
- [x] `./scripts/test-kit.sh copilot` — full TCK green, including a real
      `docker build` and confirming `copilot --version` runs inside it
- [ ] `./scripts/test-kit-e2e.sh copilot` (real `sbx`, host-only) — not run
      from this sandbox; please spot-check once the image is pushed