### PR TITLE
fix(ci): stop every kit filter matching on unrelated changes

### DIFF
--- a/.github/workflows/build-and-publish-kits.yml
+++ b/.github/workflows/build-and-publish-kits.yml
@@ -133,19 +133,40 @@ jobs:
         # allowlist silently stops matching once a Dockerfile starts COPYing a
         # new file, leaving a published image stale until the next nightly.
         # spec.yaml is deliberately NOT excluded — the drift check reads it.
+        #
+        # Two separate filter documents, not one, because the two "Filter ...
+        # changes" steps below need two DIFFERENT predicate-quantifier settings
+        # (dorny/paths-filter applies one quantifier to every filter in a
+        # single invocation, so kit-filters and shared-filters can't share a
+        # step): kit-filters mixes a positive pattern with negations per kit
+        # and needs "every" (see that step's comment for why); shared-filters
+        # lists several alternative exact paths with no negations, meant as
+        # "OR", and must stay at the default "some" — "every" would require a
+        # single file to match all of them at once, which is impossible.
         run: |
           set -euo pipefail
-          filters=""
+          # Writes a $GITHUB_OUTPUT multiline value and echoes it to the log,
+          # shared by both filter documents below so they can't drift apart.
+          emit_output() {
+            echo "$1<<EOF" >> "$GITHUB_OUTPUT"
+            echo "$2" >> "$GITHUB_OUTPUT"
+            echo "EOF" >> "$GITHUB_OUTPUT"
+            echo "$2"
+          }
+
+          kit_filters=""
           for kit in ${{ steps.discover.outputs.kits }}; do
-            filters=$(printf '%s\n%s:\n  - "%s/**"\n  - "!%s/README.md"\n  - "!%s/README.image.md"\n  - "!%s/testdata/**"' \
-              "$filters" "$kit" "$kit" "$kit" "$kit" "$kit")
+            kit_filters=$(printf '%s\n%s:\n  - "%s/**"\n  - "!%s/README.md"\n  - "!%s/README.image.md"\n  - "!%s/testdata/**"' \
+              "$kit_filters" "$kit" "$kit" "$kit" "$kit" "$kit")
           done
+          emit_output "kit-filters" "$kit_filters"
+
           # Shared inputs rebuild everything. The publish path is listed too:
           # without it, a change to publish-artifact.yml or any of the scripts it
           # calls produces no artifacts, so the publish job does not run at all
           # — not even as a dry run — and the PR that changes the publishing
           # logic is the one PR that never exercises it.
-          filters=$(printf '%s\nshared:\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s' "$filters" \
+          shared_filters=$(printf 'shared:\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s' \
             '  - ".github/workflows/build-and-publish-kits.yml"' \
             '  - ".github/workflows/publish-artifact.yml"' \
             '  - ".github/workflows/publish-one-kit.yml"' \
@@ -154,18 +175,48 @@ jobs:
             '  - "scripts/check-release-tag.sh"' \
             '  - "scripts/install-sbx.sh"' \
             '  - "scripts/publish-artifact.sh"')
+          emit_output "shared-filters" "$shared_filters"
 
-          echo "filters<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$filters" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
-          echo "$filters"
-
-      - name: Filter changes
-        id: filter
+      - name: Filter kit changes
+        id: filter-kits
         if: github.event_name == 'push' || github.event_name == 'pull_request'
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         with:
-          filters: ${{ steps.filter-setup.outputs.filters }}
+          filters: ${{ steps.filter-setup.outputs.kit-filters }}
+          # Local git diff rather than the API, so fork PRs work with a
+          # restricted GITHUB_TOKEN.
+          token: ""
+          # Every per-kit filter mixes a positive pattern with negations
+          # (kit/**, !kit/README.md, ...). Under the default predicate-quantifier
+          # ("some" — a file matches the filter if ANY listed pattern's own
+          # per-pattern predicate returns true), a negated pattern's predicate
+          # returns true for almost every file that ISN'T that exact excluded
+          # path — so `.some()` over [positive, !a, !b, !c] is true for nearly
+          # anything, not just the intended "under kit/, except a/b/c". That
+          # silently made EVERY kit's filter true on EVERY run regardless of
+          # what actually changed (a PR touching only one new kit's files
+          # reported all ~28 kits as changed) — confirmed by inspecting a real
+          # run's per-filter "Matching files" log, where e.g. the "pi" filter
+          # matched files under an unrelated new copilot/ directory.
+          # "every" instead requires ALL listed patterns' predicates to be true
+          # for a given file — including the negated ones, whose own predicate
+          # is already "does NOT match this path" — which is exactly "matches
+          # kit/** AND is not README.md AND is not README.image.md AND is not
+          # under testdata/", the behavior every filter here was written
+          # assuming. (v4.0.2's newer "some-with-excludes" quantifier would be
+          # the more legible name for this, but it isn't implemented at this
+          # pinned commit — confirmed by reading src/filter.ts there directly.)
+          #
+          # Scoped to this step only — see "Generate filters" above for why
+          # "shared" can't use the same quantifier.
+          predicate-quantifier: every
+
+      - name: Filter shared changes
+        id: filter-shared
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        with:
+          filters: ${{ steps.filter-setup.outputs.shared-filters }}
           # Local git diff rather than the API, so fork PRs work with a
           # restricted GITHUB_TOKEN.
           token: ""
@@ -184,12 +235,11 @@ jobs:
               kits="${all}"
               ;;
             *)
-              changes='${{ steps.filter.outputs.changes }}'
-              if echo "${changes}" | jq -e 'index("shared")' >/dev/null 2>&1; then
+              if [ "${{ steps.filter-shared.outputs.shared }}" = "true" ]; then
                 # This workflow or the drift check changed — rebuild everything.
                 kits="${all}"
               else
-                kits=$(echo "${changes}" | jq -c '[.[] | select(. != "shared")]')
+                kits='${{ steps.filter-kits.outputs.changes }}'
               fi
               ;;
           esac


### PR DESCRIPTION
## Summary

Root-caused why PR #194 (a new `copilot/` directory only) reported all
~28 kits as "changed" in `build-and-publish-kits.yml`.

Every per-kit filter mixes a positive pattern with negations:
`["kit/**", "!kit/README.md", "!kit/README.image.md", "!kit/testdata/**"]`.
Under `dorny/paths-filter`'s default `predicate-quantifier: some`, each
negated pattern is evaluated as its own standalone predicate meaning
"doesn't match this exact path" — true for nearly every file in the repo.
`.some()` over the full pattern list is therefore true for nearly
anything, not just real changes under that kit's directory. Confirmed
directly against a real run's per-filter "Matching files" log (the `pi`
filter matched files under the unrelated new `copilot/` directory) and by
reading the action's actual source at the pinned commit.

Fix: split into two `paths-filter` steps. `kit-filters` now runs at
`predicate-quantifier: every` (requires every listed pattern — including
the negations — to hold, which is what these filters were written
assuming). `shared` stays at the default `some`, in its own step, since it
lists several alternative exact paths with no negations and would become
permanently unmatchable under `every`.

**Merge order**: independent of #194 and #193's fixes — this can merge on
its own. It doesn't block anything currently open, but merging it before
the next kit-touching PR means that PR's own CI preview will be accurate.

## Test plan

- [x] `actionlint` clean
- [x] Reimplemented the actual filter-matching logic locally (picomatch,
      same options) and confirmed `some` false-matches unrelated files
      while `every` correctly rejects them and still matches real in-kit
      changes
- [ ] This PR's own CI run will show `kits=all` regardless of the fix
      (it touches `build-and-publish-kits.yml` itself, which is legitimately
      in the `shared` list) — the real before/after validation is the
      *next* PR that touches only one kit