### PR TITLE
chore(ci): remove the PUBLISH_KITS allow-list, publish every kit by discovery

### DIFF
--- a/.github/workflows/build-and-publish-kits.yml
+++ b/.github/workflows/build-and-publish-kits.yml
@@ -6,8 +6,8 @@ name: Build and publish kits
 #   image     builds <kit>/Dockerfile and pushes <kit>-image — only for a kit
 #             that ships one; most kits are mixins layered onto someone else's
 #             image and have nothing to build here
-#   artifact  packages the spec plus files/ and pushes <kit>-kit — every
-#             PUBLISH_KITS entry, image or not
+#   artifact  packages the spec plus files/ and pushes <kit>-kit — every kit
+#             being built this run, image or not
 #
 # The Hub repository pages are NOT set here; see hub-overview.yml.
 #
@@ -67,17 +67,6 @@ env:
   IMAGE_NAMESPACE: ${{ vars.IMAGE_NAMESPACE || 'sbx' }}
   IMAGE_TAG_LATEST: ${{ vars.IMAGE_TAG_LATEST || 'latest' }}
   PLATFORMS: ${{ vars.PLATFORMS || 'linux/amd64,linux/arm64' }}
-  # Kits published as OCI artifacts (`<kit>-kit`), space-separated. Still an
-  # allow-list rather than discovery — so a kit lands here as a deliberate
-  # decision, not automatically the moment it gets a spec.yaml — but every kit
-  # in the repo is now eligible (discovery below is by spec.yaml, not
-  # Dockerfile, and publishing a kit artifact never required an image).
-  PUBLISH_KITS: >-
-    ${{ vars.PUBLISH_KITS || 'amp claude-acp claude-model-runner claude-ollama
-    claude-sbx-statusline code-server codex-acp codex-app-server crush
-    git-ssh-sign github-ssh hermes-agent junie kiro mise nanobot nanoclaw
-    neovim openclaw opencode-model-runner packages-through-sfw pi playwright
-    smolagents task trivy vale' }}
 
 jobs:
   detect-changes:
@@ -89,9 +78,6 @@ jobs:
       # Every discovered kit, regardless of what changed — the drift check
       # validates all specs, not just the ones touched.
       all: ${{ steps.collect.outputs.all }}
-      # Kits whose ARTIFACT is published this run: the intersection of what
-      # changed with the PUBLISH_KITS allow-list.
-      artifacts: ${{ steps.collect.outputs.artifacts }}
       # Which of this run's kits have their own Dockerfile — decides per-kit
       # whether publish-one-kit.yml's `image` job runs at all.
       dockerfile-kits: ${{ steps.collect.outputs.dockerfile-kits }}
@@ -112,15 +98,7 @@ jobs:
         # it's a candidate for artifact publishing.
         run: |
           set -euo pipefail
-          # sort -u: a kit could carry both spec.yaml and spec.yml (mid-migration,
-          # say), which would otherwise list it twice and spawn two matrix legs
-          # racing to push the same tags. Same de-dup tck.yml's own discovery uses.
-          kits=$(
-            for f in */spec.yaml */spec.yml; do
-              [ -f "$f" ] || continue
-              dirname "$f"
-            done | sort -u | tr '\n' ' '
-          )
+          kits=$(scripts/discover-kits.sh | tr '\n' ' ')
           kits="${kits% }"
           echo "Discovered kits:${kits:+ }${kits:-(none)}"
           echo "kits=${kits}" >> "$GITHUB_OUTPUT"
@@ -266,16 +244,6 @@ jobs:
           echo "dockerfile-kits=${dockerfile_kits:-[]}" >> "$GITHUB_OUTPUT"
           echo "Kits with their own image: ${dockerfile_kits}"
 
-          # Kit artifacts are published for the allow-listed kits only, and the
-          # list is intersected with what is being built rather than used
-          # directly — a kit named here but not rebuilt this run has nothing new
-          # to publish. jq does the intersection so an entry that names a
-          # non-existent kit simply drops out instead of minting an empty job.
-          allow=$(printf '%s\n' ${PUBLISH_KITS} | jq -R . | jq -sc .)
-          artifacts=$(jq -cn --argjson a "${kits:-[]}" --argjson b "${allow}" '$a - ($a - $b)')
-          echo "artifacts=${artifacts}" >> "$GITHUB_OUTPUT"
-          echo "Publishing kit artifacts for: ${artifacts}"
-
           # Date first so lexicographic order is chronological: tag listings
           # (`oras repo tags`, Hub's tag page, `docker image ls`) sort as
           # strings, and a hash-first tag sorts randomly. Date-first also makes
@@ -323,10 +291,8 @@ jobs:
       kit: ${{ matrix.kit }}
       dated: ${{ needs.detect-changes.outputs.dated }}
       has-image: ${{ contains(fromJson(needs.detect-changes.outputs.dockerfile-kits), matrix.kit) }}
-      # Not every kit that builds an image publishes its artifact: `artifacts` is
-      # `kits` intersected with the allow-list. No `schedule` either — a kit's
-      # content is a pure function of the commit, so a nightly re-push would only
-      # mint a new digest for identical bytes.
-      publish-artifact: >-
-        ${{ github.event_name != 'schedule'
-          && contains(fromJson(needs.detect-changes.outputs.artifacts), matrix.kit) }}
+      # Every kit being built publishes its artifact — no allow-list, discovery
+      # is by spec.yaml alone (see the header comment). No `schedule` either — a
+      # kit's content is a pure function of the commit, so a nightly re-push
+      # would only mint a new digest for identical bytes.
+      publish-artifact: ${{ github.event_name != 'schedule' }}

--- a/.github/workflows/hub-overview.yml
+++ b/.github/workflows/hub-overview.yml
@@ -43,7 +43,7 @@ on:
       kit:
         description: |
           Sync only this kit. Used by build-and-publish-kits.yml after publishing it; the
-          docs trigger leaves it empty and syncs the whole allow-list.
+          docs trigger leaves it empty and syncs every discovered kit.
         type: string
         default: ""
 
@@ -69,30 +69,25 @@ jobs:
       # DRY_RUN, and the pull-request one never touches a credential.
       ready: ${{ steps.gate.outputs.ready || steps.gate-pr.outputs.ready }}
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
       - name: Resolve the kits to sync
         id: kits
-        # Same allow-list as publishing: a kit with no Hub repositories has no
-        # pages to sync. This default is duplicated (not read from a single
-        # source) in build-and-publish-kits.yml, publish-artifact.yml, and
-        # scripts/publish-artifact.sh's own fallback — keep all four in step
-        # when this list changes.
+        # Same discovery as publishing: every directory with a spec.yaml is a
+        # candidate. A kit with no Hub repository yet is not an error — the
+        # "Is the kit artifact's repository published?" step below skips it
+        # gracefully, the same way it skips one waiting on its first publish.
         run: |
           set -euo pipefail
           if [ -n "${ONE_KIT}" ]; then
             list=$(printf '%s' "${ONE_KIT}" | jq -R . | jq -sc .)
           else
-            list=$(printf '%s\n' ${PUBLISH_KITS} | jq -R . | jq -sc .)
+            list=$(scripts/discover-kits.sh | jq -R . | jq -sc .)
           fi
           echo "list=${list}" >> "$GITHUB_OUTPUT"
           echo "Syncing overviews for: ${list}"
         env:
           ONE_KIT: ${{ inputs.kit }}
-          PUBLISH_KITS: >-
-            ${{ vars.PUBLISH_KITS || 'amp claude-acp claude-model-runner claude-ollama
-            claude-sbx-statusline code-server codex-acp codex-app-server crush
-            git-ssh-sign github-ssh hermes-agent junie kiro mise nanobot nanoclaw
-            neovim openclaw opencode-model-runner packages-through-sfw pi playwright
-            smolagents task trivy vale' }}
 
       # Two gates, mutually exclusive, so the credential is NEVER referenced on
       # the pull-request path.

--- a/.github/workflows/publish-artifact.yml
+++ b/.github/workflows/publish-artifact.yml
@@ -51,24 +51,6 @@ env:
   REGISTRY: ${{ vars.REGISTRY || 'docker.io' }}
   IMAGE_NAMESPACE: ${{ vars.IMAGE_NAMESPACE || 'sbx' }}
   IMAGE_TAG_LATEST: ${{ vars.IMAGE_TAG_LATEST || 'latest' }}
-  # Publication is opt-in: every kit here is pushable, so an allow-list rather
-  # than discovery. Passed to the script, which enforces it — build-and-publish-kits.yml
-  # also intersects its matrix with the same variable so it does not spawn jobs
-  # that would only refuse, but the release path picks its kit from a git tag and
-  # has nothing to intersect. This default is duplicated (not read from a single
-  # source) in build-and-publish-kits.yml, hub-overview.yml, and this script's
-  # own PUBLISH_KITS fallback in scripts/publish-artifact.sh — reusable workflows
-  # don't inherit a caller's env, so each copy is load-bearing. A prior version
-  # of this file kept only 'kiro' here while the other three were widened,
-  # which made every kit's publish step hard-fail with "not in PUBLISH_KITS
-  # (kiro)" despite build-and-publish-kits.yml deciding to run it. Keep all
-  # four in step when this list changes.
-  PUBLISH_KITS: >-
-    ${{ vars.PUBLISH_KITS || 'amp claude-acp claude-model-runner claude-ollama
-    claude-sbx-statusline code-server codex-acp codex-app-server crush
-    git-ssh-sign github-ssh hermes-agent junie kiro mise nanobot nanoclaw
-    neovim openclaw opencode-model-runner packages-through-sfw pi playwright
-    smolagents task trivy vale' }}
   # Publish for real only from this repository, off a pull request, with the Hub
   # connection configured. Otherwise the script resolves and reports without
   # touching the registry, which is what makes the pull-request run meaningful.

--- a/.github/workflows/publish-one-kit.yml
+++ b/.github/workflows/publish-one-kit.yml
@@ -33,8 +33,10 @@ on:
         default: false
       publish-artifact:
         description: |
-          Whether to publish the kit ARTIFACT and sync its Hub pages. False for a
-          kit that builds an image but is not on the publish allow-list.
+          Whether to publish the kit ARTIFACT and sync its Hub pages. False only
+          on a scheduled (nightly) run — a kit's content is a pure function of
+          the commit, so a nightly re-push would only mint a new digest for
+          identical bytes.
         type: boolean
         default: false
 

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -200,8 +200,14 @@ the pipeline holding a static credential — the org bot's
 this repo and scoped for exactly this kind of write, rather than a new
 per-repo secret.
 
-**Publication is opt-in**, via the `PUBLISH_KITS` allow-list, because every kit
-in the repo is pushable and discovery would publish all of them.
+**Publication is automatic**: every kit directory with a `spec.yaml` is a
+candidate, the same discovery every other kit-facing workflow in this repo
+uses. There is no allow-list — the real gates are upstream of publishing
+itself: a PR has to be reviewed and merged before a kit's content can change
+on `main`, and every actual push path (CI's OIDC-scoped credentials, or a
+direct local run of `scripts/publish-artifact.sh`) requires holding the org's
+real Hub credentials, which is a strictly higher bar than editing a file in
+this repo.
 
 ### Releasing a version
 

--- a/scripts/discover-kits.sh
+++ b/scripts/discover-kits.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Print every kit directory at the repo root, one per line, sorted.
+#
+# A kit is any directory with a spec.yaml or spec.yml — no registration list,
+# so adding a kit needs no change here or in any of this script's callers.
+# sort -u de-dupes: a kit could carry both spec.yaml and spec.yml (mid
+# migration, say), which would otherwise list it twice and spawn two matrix
+# legs racing to push the same tags.
+#
+# Used by every workflow that needs the full kit list — build-and-publish-kits.yml's
+# own discovery and hub-overview.yml's docs-triggered sync — so what counts as
+# a kit is defined in exactly one place.
+set -euo pipefail
+
+for f in */spec.yaml */spec.yml; do
+  [ -f "$f" ] || continue
+  dirname "$f"
+done | sort -u

--- a/scripts/publish-artifact.sh
+++ b/scripts/publish-artifact.sh
@@ -13,7 +13,6 @@
 #   IMAGE_TAG_LATEST  default latest        — the rolling tag MOVE_LATEST moves
 #   MOVE_LATEST       default false         — also re-point the rolling tag
 #   DRY_RUN           set to any value      — resolve and report, publish nothing
-#   PUBLISH_KITS      default (all kits, see below) — space-separated allow-list
 #
 # Emits `ref=`, `digest=`, `pushed=` and `reused=` on stdout, one per line, so CI
 # can redirect into $GITHUB_OUTPUT. Everything human goes to stderr, which keeps
@@ -37,12 +36,6 @@ IMAGE_NAMESPACE=${IMAGE_NAMESPACE:-sbx}
 IMAGE_TAG_LATEST=${IMAGE_TAG_LATEST:-latest}
 MOVE_LATEST=${MOVE_LATEST:-false}
 DRY_RUN=${DRY_RUN:-}
-# This default is duplicated (not read from a single source) in
-# build-and-publish-kits.yml, publish-artifact.yml, and hub-overview.yml's
-# own PUBLISH_KITS fallback — keep all four in step when this list changes.
-# A caller invoking this script directly without setting PUBLISH_KITS (e.g.
-# a manual local run) gets the same allow-list CI uses by default.
-PUBLISH_KITS=${PUBLISH_KITS:-'amp claude-acp claude-model-runner claude-ollama claude-sbx-statusline code-server codex-acp codex-app-server crush git-ssh-sign github-ssh hermes-agent junie kiro mise nanobot nanoclaw neovim openclaw opencode-model-runner packages-through-sfw pi playwright smolagents task trivy vale'}
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
@@ -73,18 +66,6 @@ emit() { echo "$1=$2" >&3; }
 # wrong value would push a kit manifest over an unrelated tag in this namespace,
 # the kit's own base image included.
 ref="${REGISTRY}/${IMAGE_NAMESPACE}/${kit}-kit"
-
-# Enforced HERE rather than only where jobs are selected, so it applies to every
-# caller. build-and-publish-kits.yml intersects its matrix with the same list to avoid
-# spawning jobs that would only refuse — but the release path selects its kit
-# from a git tag, so without this check any kit that declared a `version:` could
-# be published by tagging it, allow-list or not.
-case " ${PUBLISH_KITS} " in
-  *" ${kit} "*) ;;
-  *)
-    die "'${kit}' is not in PUBLISH_KITS (${PUBLISH_KITS}). Every kit here is pushable, so publication is opt-in — add it to the PUBLISH_KITS repository variable first."
-    ;;
-esac
 
 log "kit         : ${kit}"
 log "reference   : ${ref}:${tag}"


### PR DESCRIPTION
## Summary

`copilot`'s artifact silently never published after its extraction (#194) because it was missing from `PUBLISH_KITS` — an allow-list duplicated across 4 files (`build-and-publish-kits.yml`, `publish-artifact.yml`, `hub-overview.yml`, `scripts/publish-artifact.sh`).

Traced every real path that can push a kit's image or artifact (push to `main`, PR, nightly cron, `workflow_dispatch`, a `kit/vX.Y.Z` release tag, and a direct local run of the publish script) — every single one is already gated by something with more teeth than this list ever had: PR review to merge, CI-only OIDC credentials, an exact tag+spec-version match for releases, or possession of the org's real Docker Hub credentials for a direct script run. The list never added protection beyond those, it just had to be remembered in 4 places and one got missed.

- Removed `PUBLISH_KITS` everywhere; kits now publish by the same `spec.yaml` discovery already used elsewhere in this repo.
- Extracted the discovery glob into `scripts/discover-kits.sh`, called from both `build-and-publish-kits.yml` and `hub-overview.yml`, so "what counts as a kit" lives in one place instead of two.
- Updated `PUBLISHING.md` and two stale doc strings that referenced the removed allow-list.

## Test plan

- [x] Local dry-run: `DRY_RUN=1 ./scripts/publish-artifact.sh copilot <tag>` — no longer refused
- [x] `scripts/discover-kits.sh` matches the prior `PUBLISH_KITS` set plus `copilot` (28 kits)
- [x] YAML/shell syntax validated for all edited workflow files and scripts