### PR TITLE
fix(spec): stop rejecting non-WORKDIR ${...} in initFiles content

### DIFF
--- a/spec/validate.go
+++ b/spec/validate.go
@@ -18,9 +18,6 @@ var namePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,62}[a-z0-9])?$`)
 // shellIdentifierPattern matches valid shell variable names.
 var shellIdentifierPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
-// placeholderPattern matches ${...} placeholders in init file content.
-var placeholderPattern = regexp.MustCompile(`\$\{[^}]+\}`)
-
 // lockedPathPattern matches a dotted YAML path: lowercase letter or digit
 // start, then segments of letters/digits separated by single dots, e.g.
 // "sandbox.image" or "permissions.network.allow". Used only for
@@ -37,11 +34,6 @@ var octalModePattern = regexp.MustCompile(`^0?[0-7]{3,4}$`)
 // never be confused with the dotted ${{ kit.args.<name> }} reference that
 // selects it.
 var argNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_-]*$`)
-
-// supportedPlaceholders lists the placeholders allowed in initFiles content.
-var supportedPlaceholders = map[string]bool{
-	"${WORKDIR}": true,
-}
 
 // ValidateManifest validates a Manifest for correctness. A sandbox kit must
 // declare a template (image source); use validateManifest with inheritsImage
@@ -226,23 +218,11 @@ func ValidateCommandsPolicy(c *CommandsPolicy) error {
 		if !strings.HasPrefix(f.Path, "/") {
 			return fmt.Errorf("commands: initFiles[%d].path must be absolute (got %q)", i, f.Path)
 		}
-		if err := validateInitFileContent(i, f.Content); err != nil {
-			return err
-		}
 		if f.Mode != "" && !octalModePattern.MatchString(f.Mode) {
 			return fmt.Errorf("commands: initFiles[%d].mode must be octal (e.g. \"0755\"), got %q", i, f.Mode)
 		}
 	}
 
-	return nil
-}
-
-func validateInitFileContent(index int, content string) error {
-	for _, match := range placeholderPattern.FindAllString(content, -1) {
-		if !supportedPlaceholders[match] {
-			return fmt.Errorf("commands: initFiles[%d].content contains unsupported placeholder %q (supported: ${WORKDIR})", index, match)
-		}
-	}
 	return nil
 }
 

--- a/spec/validate_test.go
+++ b/spec/validate_test.go
@@ -250,16 +250,41 @@ func TestValidateCommandsPolicy(t *testing.T) {
 		require.ErrorContains(t, ValidateCommandsPolicy(c), "must be absolute")
 	})
 
-	t.Run("unsupported_placeholder", func(t *testing.T) {
+	t.Run("non_workdir_dollar_brace_is_not_a_validation_error", func(t *testing.T) {
+		// initFiles[].content is opaque file content, most commonly a
+		// script. Only "${WORKDIR}" is a kit-spec placeholder (substituted
+		// by a literal string replace at kit-load time); any other
+		// "${...}" is the consuming shell/interpreter's own syntax and
+		// must pass through unexamined.
 		c := &CommandsPolicy{
 			InitFiles: []InitFile{{Path: "/tmp/f", Content: "${HOME}/data"}},
 		}
-		require.ErrorContains(t, ValidateCommandsPolicy(c), "unsupported placeholder")
+		require.NoError(t, ValidateCommandsPolicy(c))
 	})
 
 	t.Run("supported_placeholder", func(t *testing.T) {
 		c := &CommandsPolicy{
 			InitFiles: []InitFile{{Path: "/tmp/f", Content: "${WORKDIR}/data"}},
+		}
+		require.NoError(t, ValidateCommandsPolicy(c))
+	})
+
+	t.Run("bash_parameter_expansions_in_content_are_not_validation_errors", func(t *testing.T) {
+		c := &CommandsPolicy{
+			InitFiles: []InitFile{{
+				Path: "/home/agent/test.sh",
+				Mode: "0755",
+				Content: `#!/bin/bash
+NAME="World"
+COUNT=4
+TOTAL=10
+REMAINING=$((TOTAL - COUNT))
+printf -v FILL "%${COUNT}s" ""
+printf -v PAD  "%${REMAINING}s" ""
+BAR="${FILL// /#}${PAD// /-}"
+echo "Hello, ${NAME} [${BAR}]"
+`,
+			}},
 		}
 		require.NoError(t, ValidateCommandsPolicy(c))
 	})


### PR DESCRIPTION
## Summary

`initFiles[].content` is opaque file content — usually a script. `ValidateCommandsPolicy` scanned the whole content for any `${...}`-shaped text and rejected it unless it was exactly `${WORKDIR}`, so ordinary bash parameter expansion (`${VAR}`, `${VAR//search/replace}`, `${VAR:-default}`) in an init-file script tripped `unsupported placeholder` and failed `sbx kit validate` / `sbx run --kit`.

The actual `${WORKDIR}` substitution (`sandboxlib/kit/resolve_cmds.go` in the engine) is a plain `strings.ReplaceAll("${WORKDIR}", workdir)` at kit-load time — not a template engine — so any other `${...}` text already passes through completely unmodified. Verified this empirically before changing anything. The validator was rejecting input its own substitution step already handles safely, with no reachable partial-substitution failure mode it was protecting against.

This drops the whole-content placeholder scan (`placeholderPattern`, `supportedPlaceholders`, `validateInitFileContent`) from `spec/validate.go`. `${WORKDIR}` substitution itself is unchanged.

Fixes docker/sbx-releases#165

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` on changed files (clean)
- [x] `go test ./...`
- [x] Added regression test with the exact bash script from the issue (parameter expansion, `${VAR//search/replace}`, arithmetic)