### PR TITLE
fix(spec): align SPEC-v2 and kit-author docs with the code

### DIFF
--- a/skills/kit-author/SKILL.md
+++ b/skills/kit-author/SKILL.md
@@ -31,7 +31,7 @@ Use this skill when:
 
 Primary topics describe the **v2** spec form (`schemaVersion: "2"`):
 
-- [Spec anatomy](topics/spec-anatomy.md) — `spec.yaml` top-level fields (`mixins`, `licenses`, `extends`, `locked`, `args`) and every section (`sandbox` with `image:`/`build:` + `entrypoint`/`command`, `agentInstructions` with `filename`/`content`, `credentials[]` with `apiKey`/`oauth`/`sshAgent` and the `scheme` sugar, `permissions.network`, `ports`, `environment`, `setup` with `install`/`startup`/`files`, `volumes`, `files/`).
+- [Spec anatomy](topics/spec-anatomy.md) — `spec.yaml` top-level fields (`mixins`, `licenses`, `extends`, `locked`, `args`) and every section (`sandbox` with `image:`/`build:` + `entrypoint`/`command`, `agentInstructions` with `filename`/`content`, `credentials[]` with `apiKey`/`oauth` and the `scheme` sugar, `permissions.network`, `ports`, `environment`, `setup` with `install`/`startup`/`files`, `volumes`, `files/`).
 - [Lifecycle](topics/lifecycle.md) — Sourcing → load (schemaVersion-forked decode) → normalize → validate → extends → compose → configure → hooks → container → runtime. What happens at each stage as observed by the kit author.
 - [Composition](topics/composition.md) — `extends:` inheritance vs `--kit` composition. Merge strategies per section, conflict rules, what "last wins" means.
 - [Authoring guide](topics/authoring.md) — Step-by-step recipes for a minimal mixin and a full sandbox kit. Where to put files. When to use `files/` vs `setup.files`.

--- a/skills/kit-author/topics/spec-anatomy.md
+++ b/skills/kit-author/topics/spec-anatomy.md
@@ -214,9 +214,8 @@ Per-entry fields:
 | `provider` | conditional | Explicit provider registry entry. Only needed when `service` doesn't match a known provider — sets the auth defaults the registry would otherwise derive from the name. |
 | `apiKey` | conditional | api-key shape (see below). |
 | `oauth` | conditional | OAuth shape (see below). |
-| `sshAgent` | no | SSH-agent forwarding (P2 — see below). |
 
-For custom services not in the provider registry, **at least one** of `apiKey.inject`, `oauth`, or `sshAgent` MUST be specified.
+For custom services not in the provider registry, **at least one** of `apiKey.inject` or `oauth` MUST be specified.
 
 ### api-key shape
 
@@ -257,7 +256,7 @@ credentials:
 
 `bearer` supplies `header: Authorization` only when you left `header` empty, so writing an explicit `header:` alongside it still wins. `basic` is username-driven at the proxy rather than a header encoding, so it sets no `header` at all — write one yourself if the service needs a specific one.
 
-**Validation:** every `apiKey.inject[].domain` MUST appear in `permissions.network.allow`. The spec library rejects a kit whose injection domain isn't allow-listed — there is no auto-derived egress from credentials.
+**Enforcement:** every `apiKey.inject[].domain` MUST appear in `permissions.network.allow`. There is no auto-derived egress from credentials. The spec validator does not cross-check the two lists; the engine enforces the rule, and a missing domain surfaces at load or sandbox-create time (SPEC-v2 §6).
 
 ### OAuth shape
 
@@ -283,39 +282,15 @@ credentials:
         expiresIn: "expires_in"
         scope: "scope"
       # passthrough: true                          # opt-out of sentinel masking — see below
-      # passthroughReason: "..."                   # REQUIRED when passthrough is set
 ```
 
 **`credentialFile.structure`** is a declarative JSON map with `{{.AccessToken}}` / `{{.RefreshToken}}` / `{{.ExpiresAt}}` / `{{.Scopes}}` placeholders. `ExpiresAt` is a Unix-millisecond timestamp. The engine encodes the map as JSON, then substitutes placeholders — output is guaranteed well-formed.
 
 **`responseFields`** maps logical OAuth token field names to the actual JSON field names returned by the token endpoint. Defaults match the OAuth 2.0 RFC (`access_token`, `refresh_token`, `expires_in`, `scope`); set explicit overrides for providers that use camelCase or vendor-specific names.
 
-**`passthrough: true`** bypasses sentinel masking — the proxy returns the real OAuth response to the container instead of swapping in sentinels. This is a security downgrade (the container sees the real token). Required companion: `passthroughReason` — a non-empty string explaining why passthrough is needed (typically: provider returns a JWT the agent must inspect locally). The spec library validates that `passthroughReason` is set whenever `passthrough: true`.
+**`passthrough: true`** bypasses sentinel masking: the proxy returns the real OAuth response to the container instead of swapping in sentinels. This is a security downgrade (the container sees the real token), so say why the kit needs it in the PR description; the typical reason is a provider that returns a JWT the agent must inspect locally. When `passthrough: true`, the validator stops requiring `sentinels`. There is no `passthroughReason` field in the schema.
 
 A credential entry can declare **both** `apiKey` and `oauth`. The precedence rule is: **api key wins when found**. If no API key value is present on the host, the user can authenticate via OAuth (e.g. `/login`). Setting both lets the kit support either auth method without the kit author choosing one.
-
-### SSH-agent shape (P2)
-
-For services that authenticate via SSH (e.g. `git push` over SSH). Keys remain on the host — the container can request SSH operations through the agent socket but cannot extract key material.
-
-```yaml
-credentials:
-  - service: github-ssh
-    sshAgent:
-      hosts:                                       # required — SSH destinations, format host:port
-        - github.com:22
-        - github.com:443                           # GitHub's HTTPS-over-SSH port
-      identities:                                  # optional — restrict to specific key fingerprints
-        - "SHA256:abc123..."
-
-permissions:
-  network:
-    allow:                                         # MUST include every host listed in sshAgent.hosts
-      - github.com:22
-      - github.com:443
-```
-
-Every `sshAgent.hosts` entry MUST also appear in `permissions.network.allow` — the spec validator rejects mismatches.
 
 ## `permissions` — capability grants
 

--- a/skills/kit-author/topics/v1-migration.md
+++ b/skills/kit-author/topics/v1-migration.md
@@ -278,13 +278,13 @@ credentials:
             refreshToken: "{{.RefreshToken}}"
 ```
 
-> The v1 `oauth.skipIfEnv` list was a sandboxes-specific extension and is **not** part of the v2 unified spec. Implementations that still ship `skipIfEnv` accept it on the v1 path during load; the field does not exist in the v2 form. If you need conditional-OAuth behaviour ("skip OAuth setup when this env var is set"), use a `credentials[]` entry with both `apiKey` and `oauth` — api-key wins when found and OAuth is the fallback.
+> The v2 decoder accepts `oauth.skipIfEnv` so migrated specs load unchanged, but the field has no effect for a v2 kit: v2 credential resolution is binding-driven and never skips OAuth because of a host env var (SPEC-v2 §5.4.2). If you need conditional-OAuth behaviour ("use the API key when one is available"), use a `credentials[]` entry with both `apiKey` and `oauth`; the api-key wins when found and OAuth is the fallback.
 
 Normalize matches the v1 standalone `oauth:` block by `service:` to a `credentials[]` entry; if no entry exists yet for that service, normalize synthesizes one.
 
 The `credentialFile.template` (free-form Go `text/template`) is **deprecated** in favour of `credentialFile.structure` (a declarative JSON map with placeholders the engine substitutes deterministically). Both load; when both are set, `structure` wins and `template` emits a deprecation warning. Phase 6 removes `template`.
 
-The v1 `passthroughResponse` field renamed to `passthrough` in v2 — same semantic (opts out of sentinel masking, security downgrade flagged with a warning at load time).
+The v1 `passthroughResponse` field renamed to `passthrough` in v2, same semantic: opts out of sentinel masking, a security downgrade.
 
 ## The `Artifact.Warnings` channel
 

--- a/spec/SPEC-v2.md
+++ b/spec/SPEC-v2.md
@@ -548,8 +548,7 @@ Rules:
   Overlap between the lists is **legal** (a parent may allow `*.example.com`
   while a child denies `telemetry.example.com`).
 - **All-egress-declared.** Every domain a credential injects into
-  (`credentials[].apiKey.inject[].domain`) and every SSH host
-  (`credentials[].sshAgent.hosts[]`) **MUST** appear in
+  (`credentials[].apiKey.inject[].domain`) **MUST** appear in
   `permissions.network.allow`. The engine does not auto-derive egress.
 - Composition: `allow` and `deny` lists append across kits.
 
@@ -586,7 +585,6 @@ never declare discovery.
 | `provider` | optional | Forward-compat stub for the provider registry; warns and has no effect. |
 | `apiKey` | conditional | api-key shape ([§5.4.1](#541-apikey)). |
 | `oauth` | conditional | OAuth shape ([§5.4.2](#542-oauth)). |
-| `sshAgent` | conditional | SSH-agent forwarding ([§5.4.3](#543-sshagent)). |
 
 An entry MAY declare both `apiKey` and `oauth`; at runtime the API key wins when
 present, with OAuth as the fallback.
@@ -654,7 +652,7 @@ credentials:
         refreshToken: "refresh_token"
         expiresIn: "expires_in"
         scope: "scope"
-      skipIfEnv: []                      # optional — skip OAuth when these env vars are present
+      skipIfEnv: []                      # accepted at decode time; no effect for v2 kits (see below)
       passthrough: false                 # optional — opt out of sentinel masking (security downgrade)
 ```
 
@@ -663,25 +661,21 @@ credentials:
   placeholders. The engine encodes the map as JSON, then substitutes — output is
   guaranteed well-formed. The free-form `credentialFile.template` (Go
   `text/template`) is **deprecated**; when both are set, `structure` wins.
+- `skipIfEnv` is a v1-era field. The v2 decoder accepts it so migrated specs
+  load unchanged, but the binding-driven credential resolution that
+  `schemaVersion: "2"` selects (see §1.3) never consults it: a host env var
+  must not override the user's binding. For conditional behavior, declare both
+  `apiKey` and `oauth`; the API key wins when present.
 - `passthrough: true` returns the real token to the container instead of a
-  sentinel — a security downgrade, flagged with a warning at load.
+  sentinel. This is a security downgrade: the container sees the real token.
 
-#### 5.4.3 `sshAgent`
+#### 5.4.3 Reserved
 
-For services that authenticate over SSH. Keys stay on the host.
-
-```yaml
-credentials:
-  - service: github-ssh
-    sshAgent:
-      hosts:                             # REQUIRED — host:port SSH destinations
-        - github.com:22
-        - github.com:443
-      identities:                        # optional — restrict to key fingerprints
-        - "SHA256:abc123..."
-```
-
-Every `hosts` entry MUST also appear in `permissions.network.allow`.
+An earlier draft of this section described an `sshAgent` credential mechanism.
+No such field exists in the schema: `Credential` carries only the members
+listed in [§5.4](#54-credentials), and strict decoding ([§1.2](#12-strict-decoding))
+rejects a spec that declares `sshAgent:`. The section number is reserved for a
+future revision.
 
 ### 5.5 `environment`
 

--- a/spec/types.go
+++ b/spec/types.go
@@ -759,7 +759,7 @@ type OAuthPolicy struct {
 // minus Service (the service identifier comes from the parent Credential),
 // and with Passthrough replacing PassthroughResponse (renamed; same
 // semantics — Passthrough = true opts out of sentinel masking, a security
-// downgrade flagged with a warning at load time).
+// downgrade).
 //
 // A `passthroughReason: ...` field is deliberately NOT included in this
 // release. Whether passthrough should require a documented justification is


### PR DESCRIPTION
A kit author who follows SPEC-v2.md section 5.4.3 or the authoring skill's spec anatomy ships a spec the loader rejects: both documents describe features the code does not implement. Closes #184, which carries the evidence.

- `sshAgent` has no schema field and strict decoding rejects it. Removed everywhere; section 5.4.3 stays as a stub so anchors keep working.
- validate.go never cross-checks inject domains against the allowlist; the engine enforces that rule (spec section 6). The skill now says so.
- `oauth.skipIfEnv` decodes but v2 credential resolution never consults it. Both documents now say so.
- The same check felled `passthroughReason` and the warning claim for `passthrough`; neither is implemented.

Docs and one Go comment; no behavior change. `go test ./spec/... ./tck/... ./scripts/...` passes.