### PR TITLE
docs: oci artifact usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Pick an existing kit closest in shape to what you want to build and read it end-
 Every kit should ship a `README.md`. The structure isn't mandatory, but the existing kits converge on:
 
 - **Title and one-paragraph description** of what the kit does and what agent it pairs with.
-- **Usage** — the `sbx run` invocation and any host-side prerequisites.
+- **Usage** — the `sbx run` invocation and any host-side prerequisites. Show all three source forms — git URL, local clone, and the published `docker.io/sbx/<kit>-kit:latest` OCI artifact — since every kit here publishes automatically (see [`PUBLISHING.md`](./PUBLISHING.md)).
 - **How _X_ works** — short sections explaining non-obvious decisions in the spec, so the next reviewer doesn't have to reverse-engineer the YAML.
 - **Cleanup**, if the kit creates state on the host.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Pick an existing kit closest in shape to what you want to build and read it end-
 Every kit should ship a `README.md`. The structure isn't mandatory, but the existing kits converge on:
 
 - **Title and one-paragraph description** of what the kit does and what agent it pairs with.
-- **Usage** — the `sbx run` invocation and any host-side prerequisites. Show all three source forms — git URL, local clone, and the published `docker.io/sbx/<kit>-kit:latest` OCI artifact — since every kit here publishes automatically (see [`PUBLISHING.md`](./PUBLISHING.md)).
+- **Usage** — the `sbx run` invocation and any host-side prerequisites. Lead with the published `docker.io/sbx/<kit>-kit:latest` OCI artifact — every kit here publishes automatically (see [`PUBLISHING.md`](./PUBLISHING.md)), so it's the primary way to consume a kit — then the git-URL form, then the local-clone form.
 - **How _X_ works** — short sections explaining non-obvious decisions in the spec, so the next reviewer doesn't have to reverse-engineer the YAML.
 - **Cleanup**, if the kit creates state on the host.
 

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -16,7 +16,8 @@ docker.io/sbx/<kit>-image
 ```
 
 The `-image` suffix is not decoration: it keeps `docker.io/sbx/<kit>-kit` free
-for the kit artifact itself, once kits are distributed as OCI artifacts too.
+for the kit artifact itself, which is also distributed as an OCI artifact (see
+["The kit artifact"](#the-kit-artifact) below).
 
 `scripts/check-image-ref.sh` enforces all three parts against every kit that
 ships a `Dockerfile` — the namespace, the `<kit>-image` name, and the rolling

--- a/README.md
+++ b/README.md
@@ -26,9 +26,15 @@ Contributing a kit or a fix? Read [`CONTRIBUTING.md`](./CONTRIBUTING.md) first â
 
 ## Using a kit
 
-Kits are passed to `sbx run` (or `sbx create`) via `--kit`. The flag accepts a local path, an OCI registry reference, a ZIP archive, or a `git+...` URL.
+Kits are passed to `sbx run` (or `sbx create`) via `--kit`. The flag accepts an OCI registry reference, a `git+...` URL, a local path, or a ZIP archive.
 
-The most common form is a git URL targeting this repo:
+The primary way to consume a kit from this repo is its published OCI artifact on Docker Hub â€” every kit here is discovered and published automatically (see [`PUBLISHING.md`](./PUBLISHING.md)), so the artifact exists the moment a change merges to `main`:
+
+```console
+$ sbx run --kit "docker.io/sbx/code-server-kit:latest" claude
+```
+
+Or target this repo directly over git:
 
 ```console
 $ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=code-server" claude

--- a/amp/README.md
+++ b/amp/README.md
@@ -43,7 +43,14 @@ the real secret on outbound requests to `ampcode.com`.
 
 ## Usage
 
-Run the kit. Pass the kit's name (`amp`) as the agent argument:
+Run the kit. Pass the kit's name (`amp`) as the agent argument. The primary
+form is its published OCI artifact on Docker Hub:
+
+```console
+$ sbx run --kit "docker.io/sbx/amp-kit:latest" amp
+```
+
+Or from a git URL targeting this repo:
 
 ```console
 $ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=amp" amp
@@ -53,12 +60,6 @@ Or with a local clone of this repo:
 
 ```console
 $ sbx run --kit ./amp/ amp
-```
-
-Or from its published OCI artifact on Docker Hub:
-
-```console
-$ sbx run --kit "docker.io/sbx/amp-kit:latest" amp
 ```
 
 The first launch installs Amp via its `curl | bash` script and applies

--- a/amp/README.md
+++ b/amp/README.md
@@ -55,6 +55,12 @@ Or with a local clone of this repo:
 $ sbx run --kit ./amp/ amp
 ```
 
+Or from its published OCI artifact on Docker Hub:
+
+```console
+$ sbx run --kit "docker.io/sbx/amp-kit:latest" amp
+```
+
 The first launch installs Amp via its `curl | bash` script and applies
 the kit's network and proxy auth wiring. Subsequent launches reuse the
 sandbox.

--- a/claude-acp/README.md
+++ b/claude-acp/README.md
@@ -37,16 +37,16 @@ the sandbox so the built-in `claude` kit can refresh its Claude settings.
 
 ## Usage
 
-Create a sandbox:
-
-```console
-$ sbx create --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=claude-acp" --name my-task claude /path/to/task
-```
-
-Or from its published OCI artifact on Docker Hub:
+Create a sandbox from its published OCI artifact on Docker Hub:
 
 ```console
 $ sbx create --kit "docker.io/sbx/claude-acp-kit:latest" --name my-task claude /path/to/task
+```
+
+Or from a git URL targeting this repo:
+
+```console
+$ sbx create --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=claude-acp" --name my-task claude /path/to/task
 ```
 
 Run the adapter over stdio:

--- a/claude-acp/README.md
+++ b/claude-acp/README.md
@@ -43,6 +43,12 @@ Create a sandbox:
 $ sbx create --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=claude-acp" --name my-task claude /path/to/task
 ```
 
+Or from its published OCI artifact on Docker Hub:
+
+```console
+$ sbx create --kit "docker.io/sbx/claude-acp-kit:latest" --name my-task claude /path/to/task
+```
+
 Run the adapter over stdio:
 
 ```console

--- a/claude-model-runner/README.md
+++ b/claude-model-runner/README.md
@@ -25,6 +25,12 @@ $ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=claude-m
 $ sbx run --kit ./claude-model-runner/ claude ~/my-project
 ```
 
+Or from its published OCI artifact on Docker Hub:
+
+```console
+$ sbx run --kit "docker.io/sbx/claude-model-runner-kit:latest" claude ~/my-project
+```
+
 The agent name passed to `sbx run` (`claude`) is the base agent the mixin
 extends.
 

--- a/claude-model-runner/README.md
+++ b/claude-model-runner/README.md
@@ -21,14 +21,14 @@ cost-free experimentation, or testing custom local models with Claude Code.
 ## Usage
 
 ```console
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=claude-model-runner" claude ~/my-project
-$ sbx run --kit ./claude-model-runner/ claude ~/my-project
+$ sbx run --kit "docker.io/sbx/claude-model-runner-kit:latest" claude ~/my-project
 ```
 
-Or from its published OCI artifact on Docker Hub:
+Or from a git URL or a local clone of this repo:
 
 ```console
-$ sbx run --kit "docker.io/sbx/claude-model-runner-kit:latest" claude ~/my-project
+$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=claude-model-runner" claude ~/my-project
+$ sbx run --kit ./claude-model-runner/ claude ~/my-project
 ```
 
 The agent name passed to `sbx run` (`claude`) is the base agent the mixin

--- a/claude-ollama/README.md
+++ b/claude-ollama/README.md
@@ -16,14 +16,14 @@ offline development, cost-free experimentation, or testing with custom local mod
 ## Usage
 
 ```console
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=claude-ollama" claude-ollama ~/my-project
-$ sbx run --kit ./claude-ollama/ claude-ollama ~/my-project
+$ sbx run --kit "docker.io/sbx/claude-ollama-kit:latest" claude-ollama ~/my-project
 ```
 
-Or from its published OCI artifact on Docker Hub:
+Or from a git URL or a local clone of this repo:
 
 ```console
-$ sbx run --kit "docker.io/sbx/claude-ollama-kit:latest" claude-ollama ~/my-project
+$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=claude-ollama" claude-ollama ~/my-project
+$ sbx run --kit ./claude-ollama/ claude-ollama ~/my-project
 ```
 
 The agent name passed to `sbx run` (`claude-ollama`) matches the `name:` field in

--- a/claude-ollama/README.md
+++ b/claude-ollama/README.md
@@ -20,6 +20,12 @@ $ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=claude-o
 $ sbx run --kit ./claude-ollama/ claude-ollama ~/my-project
 ```
 
+Or from its published OCI artifact on Docker Hub:
+
+```console
+$ sbx run --kit "docker.io/sbx/claude-ollama-kit:latest" claude-ollama ~/my-project
+```
+
 The agent name passed to `sbx run` (`claude-ollama`) matches the `name:` field in
 the kit's `spec.yaml`.
 

--- a/claude-sbx-statusline/README.md
+++ b/claude-sbx-statusline/README.md
@@ -28,22 +28,22 @@ it reflects the sandbox's allocation, not the host's.
 
 ## Quick start
 
-Pair the mixin with the `claude` agent via `--kit`:
+Pair the mixin with the `claude` agent via `--kit`, from its published OCI artifact on Docker Hub:
 
 ```console
-$ sbx run claude --kit ./claude-sbx-statusline .
+$ sbx run claude --kit "docker.io/sbx/claude-sbx-statusline-kit:latest" .
 ```
 
-Or pull it straight from this repo (pinned by ref):
+Or pull it straight from this repo over git (pinned by ref):
 
 ```console
 $ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=claude-sbx-statusline" .
 ```
 
-Or from its published OCI artifact on Docker Hub:
+Or with a local clone of this repo:
 
 ```console
-$ sbx run claude --kit "docker.io/sbx/claude-sbx-statusline-kit:latest" .
+$ sbx run claude --kit ./claude-sbx-statusline .
 ```
 
 ## How it works

--- a/claude-sbx-statusline/README.md
+++ b/claude-sbx-statusline/README.md
@@ -40,6 +40,12 @@ Or pull it straight from this repo (pinned by ref):
 $ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=claude-sbx-statusline" .
 ```
 
+Or from its published OCI artifact on Docker Hub:
+
+```console
+$ sbx run claude --kit "docker.io/sbx/claude-sbx-statusline-kit:latest" .
+```
+
 ## How it works
 
 - **`files/home/.claude/statusline.sh`** is copied to `~/.claude/statusline.sh` at sandbox

--- a/code-server/README.md
+++ b/code-server/README.md
@@ -18,6 +18,12 @@ Pair it with the built-in `claude` agent:
 $ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=code-server" ~/my-project
 ```
 
+Or from its published OCI artifact on Docker Hub:
+
+```console
+$ sbx run claude --kit "docker.io/sbx/code-server-kit:latest" ~/my-project
+```
+
 Once the sandbox is up, find the assigned host port:
 
 ```console

--- a/code-server/README.md
+++ b/code-server/README.md
@@ -12,16 +12,16 @@ CLI agent.
 
 ## Usage
 
-Pair it with the built-in `claude` agent:
-
-```console
-$ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=code-server" ~/my-project
-```
-
-Or from its published OCI artifact on Docker Hub:
+Pair it with the built-in `claude` agent, from its published OCI artifact on Docker Hub:
 
 ```console
 $ sbx run claude --kit "docker.io/sbx/code-server-kit:latest" ~/my-project
+```
+
+Or from a git URL targeting this repo:
+
+```console
+$ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=code-server" ~/my-project
 ```
 
 Once the sandbox is up, find the assigned host port:

--- a/codex-acp/README.md
+++ b/codex-acp/README.md
@@ -38,16 +38,16 @@ kit can refresh its Codex auth files.
 
 ## Usage
 
-Create a sandbox:
-
-```console
-$ sbx create --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=codex-acp" --name my-task codex /path/to/task
-```
-
-Or from its published OCI artifact on Docker Hub:
+Create a sandbox from its published OCI artifact on Docker Hub:
 
 ```console
 $ sbx create --kit "docker.io/sbx/codex-acp-kit:latest" --name my-task codex /path/to/task
+```
+
+Or from a git URL targeting this repo:
+
+```console
+$ sbx create --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=codex-acp" --name my-task codex /path/to/task
 ```
 
 Run the adapter over stdio:

--- a/codex-acp/README.md
+++ b/codex-acp/README.md
@@ -44,6 +44,12 @@ Create a sandbox:
 $ sbx create --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=codex-acp" --name my-task codex /path/to/task
 ```
 
+Or from its published OCI artifact on Docker Hub:
+
+```console
+$ sbx create --kit "docker.io/sbx/codex-acp-kit:latest" --name my-task codex /path/to/task
+```
+
 Run the adapter over stdio:
 
 ```console

--- a/codex-app-server/README.md
+++ b/codex-app-server/README.md
@@ -45,6 +45,8 @@ sbx_codex() {
     local name="${1:?usage: sbx_codex <name> [path]}"
     local path="${2:-.}"
     local kit="git+https://github.com/docker/sbx-kits-contrib.git#dir=codex-app-server"
+    # Or, from the published OCI artifact on Docker Hub, instead of git:
+    #   local kit="docker.io/sbx/codex-app-server-kit:latest"
 
     if ! sbx ls -q | grep -qx "$name"; then
         sbx create --clone --kit "$kit" --name "$name" codex "$path" || return
@@ -146,6 +148,8 @@ Then per sandbox:
 
 ```console
 $ sbx create --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=codex-app-server" --name myproject codex ~/myproject
+# Or from its published OCI artifact on Docker Hub:
+# $ sbx create --kit "docker.io/sbx/codex-app-server-kit:latest" --name myproject codex ~/myproject
 $ sbx-codex-attach myproject
 # … later, when done with the GUI integration for this sandbox …
 $ sbx-codex-detach myproject

--- a/codex-app-server/README.md
+++ b/codex-app-server/README.md
@@ -44,9 +44,9 @@ this in your `~/.bashrc` / `~/.zshrc`:
 sbx_codex() {
     local name="${1:?usage: sbx_codex <name> [path]}"
     local path="${2:-.}"
-    local kit="git+https://github.com/docker/sbx-kits-contrib.git#dir=codex-app-server"
-    # Or, from the published OCI artifact on Docker Hub, instead of git:
-    #   local kit="docker.io/sbx/codex-app-server-kit:latest"
+    local kit="docker.io/sbx/codex-app-server-kit:latest"
+    # Or, from a git URL targeting this repo, instead of the published OCI artifact:
+    #   local kit="git+https://github.com/docker/sbx-kits-contrib.git#dir=codex-app-server"
 
     if ! sbx ls -q | grep -qx "$name"; then
         sbx create --clone --kit "$kit" --name "$name" codex "$path" || return
@@ -147,9 +147,9 @@ $ ln -s $(pwd)/bin/sbx-codex-{attach,detach} ~/.local/bin/
 Then per sandbox:
 
 ```console
-$ sbx create --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=codex-app-server" --name myproject codex ~/myproject
-# Or from its published OCI artifact on Docker Hub:
-# $ sbx create --kit "docker.io/sbx/codex-app-server-kit:latest" --name myproject codex ~/myproject
+$ sbx create --kit "docker.io/sbx/codex-app-server-kit:latest" --name myproject codex ~/myproject
+# Or from a git URL targeting this repo:
+# $ sbx create --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=codex-app-server" --name myproject codex ~/myproject
 $ sbx-codex-attach myproject
 # … later, when done with the GUI integration for this sandbox …
 $ sbx-codex-detach myproject

--- a/copilot/README.md
+++ b/copilot/README.md
@@ -41,6 +41,12 @@ Or with a local clone of this repo:
 $ sbx run --kit ./copilot/ copilot
 ```
 
+Or from its published OCI artifact on Docker Hub:
+
+```console
+$ sbx run --kit "docker.io/sbx/copilot-kit:latest" copilot
+```
+
 The trailing `copilot` is required, not redundant: for `kind: sandbox` kits,
 `sbx` enforces that the agent name matches the kit's own `name`.
 
@@ -104,8 +110,9 @@ The image is **`docker.io/sbx/copilot-image`**, built on
 `docker/sandbox-templates:shell-docker`, so it carries a Docker engine and
 requests Docker-in-Docker.
 
-The `-image` suffix distinguishes the base image from the kit itself: when the
-kit is published as an OCI artifact it will be `docker.io/sbx/copilot-kit`.
+The `-image` suffix distinguishes the base image from the kit itself: the kit
+itself is published as an OCI artifact at `docker.io/sbx/copilot-kit` (see
+[Usage](#usage) above).
 The name is derived from the kit directory and enforced repo-wide — see
 [PUBLISHING.md](../PUBLISHING.md#naming).
 

--- a/copilot/README.md
+++ b/copilot/README.md
@@ -32,6 +32,12 @@ two credential services (`github` and `copilot`) instead of one.
 ## Usage
 
 ```console
+$ sbx run --kit "docker.io/sbx/copilot-kit:latest" copilot
+```
+
+Or from a git URL targeting this repo:
+
+```console
 $ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=copilot" copilot
 ```
 
@@ -39,12 +45,6 @@ Or with a local clone of this repo:
 
 ```console
 $ sbx run --kit ./copilot/ copilot
-```
-
-Or from its published OCI artifact on Docker Hub:
-
-```console
-$ sbx run --kit "docker.io/sbx/copilot-kit:latest" copilot
 ```
 
 The trailing `copilot` is required, not redundant: for `kind: sandbox` kits,

--- a/crush/README.md
+++ b/crush/README.md
@@ -31,6 +31,12 @@ You only need keys for the providers you intend to use.
 ## Usage
 
 ```console
+$ sbx run --kit "docker.io/sbx/crush-kit:latest" crush
+```
+
+Or from a git URL targeting this repo:
+
+```console
 $ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=crush" crush
 ```
 
@@ -38,12 +44,6 @@ Or with a local clone of this repo:
 
 ```console
 $ sbx run --kit ./crush/ crush
-```
-
-Or from its published OCI artifact on Docker Hub:
-
-```console
-$ sbx run --kit "docker.io/sbx/crush-kit:latest" crush
 ```
 
 The first launch installs Crush via the Charm apt repository and applies

--- a/crush/README.md
+++ b/crush/README.md
@@ -40,6 +40,12 @@ Or with a local clone of this repo:
 $ sbx run --kit ./crush/ crush
 ```
 
+Or from its published OCI artifact on Docker Hub:
+
+```console
+$ sbx run --kit "docker.io/sbx/crush-kit:latest" crush
+```
+
 The first launch installs Crush via the Charm apt repository and applies
 the kit's network and proxy auth wiring. Subsequent launches reuse the
 sandbox.

--- a/git-ssh-sign/README.md
+++ b/git-ssh-sign/README.md
@@ -17,16 +17,16 @@ On the host, load your SSH key into the agent:
 $ ssh-add ~/.ssh/id_ed25519
 ```
 
-Then start the sandbox with the kit attached:
-
-```console
-$ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=git-ssh-sign" ~/my-project
-```
-
-Or from its published OCI artifact on Docker Hub:
+Then start the sandbox with the kit attached, from its published OCI artifact on Docker Hub:
 
 ```console
 $ sbx run claude --kit "docker.io/sbx/git-ssh-sign-kit:latest" ~/my-project
+```
+
+Or from a git URL targeting this repo:
+
+```console
+$ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=git-ssh-sign" ~/my-project
 ```
 
 Inside the sandbox, verify that the forwarded agent exposes your key:

--- a/git-ssh-sign/README.md
+++ b/git-ssh-sign/README.md
@@ -23,6 +23,12 @@ Then start the sandbox with the kit attached:
 $ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=git-ssh-sign" ~/my-project
 ```
 
+Or from its published OCI artifact on Docker Hub:
+
+```console
+$ sbx run claude --kit "docker.io/sbx/git-ssh-sign-kit:latest" ~/my-project
+```
+
 Inside the sandbox, verify that the forwarded agent exposes your key:
 
 ```console

--- a/github-ssh/README.md
+++ b/github-ssh/README.md
@@ -15,6 +15,12 @@ GitHub account. Start the sandbox with this kit attached:
 $ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=github-ssh" claude
 ```
 
+Or from its published OCI artifact on Docker Hub:
+
+```console
+$ sbx run --kit "docker.io/sbx/github-ssh-kit:latest" claude
+```
+
 ## Usage
 
 Once the kit is installed, SSH operations to GitHub work without any

--- a/github-ssh/README.md
+++ b/github-ssh/README.md
@@ -9,16 +9,16 @@ is no TTY available to interactively accept a new host key.
 ## Prerequisites
 
 Your SSH key must be loaded in the agent on the host and registered with your
-GitHub account. Start the sandbox with this kit attached:
-
-```console
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=github-ssh" claude
-```
-
-Or from its published OCI artifact on Docker Hub:
+GitHub account. Start the sandbox with this kit attached, from its published OCI artifact on Docker Hub:
 
 ```console
 $ sbx run --kit "docker.io/sbx/github-ssh-kit:latest" claude
+```
+
+Or from a git URL targeting this repo:
+
+```console
+$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=github-ssh" claude
 ```
 
 ## Usage

--- a/hermes-agent/README.md
+++ b/hermes-agent/README.md
@@ -54,6 +54,12 @@ $ sbx secret set-custom -g \
 ## Usage
 
 ```console
+$ sbx run --kit "docker.io/sbx/hermes-agent-kit:latest" hermes-agent
+```
+
+Or from a git URL targeting this repo:
+
+```console
 $ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=hermes-agent" hermes-agent
 ```
 
@@ -61,12 +67,6 @@ Or with a local clone of this repo:
 
 ```console
 $ sbx run --kit ./hermes-agent/ hermes-agent
-```
-
-Or from its published OCI artifact on Docker Hub:
-
-```console
-$ sbx run --kit "docker.io/sbx/hermes-agent-kit:latest" hermes-agent
 ```
 
 Once inside the agent, use `hermes model` to choose a provider and model, then

--- a/hermes-agent/README.md
+++ b/hermes-agent/README.md
@@ -63,6 +63,12 @@ Or with a local clone of this repo:
 $ sbx run --kit ./hermes-agent/ hermes-agent
 ```
 
+Or from its published OCI artifact on Docker Hub:
+
+```console
+$ sbx run --kit "docker.io/sbx/hermes-agent-kit:latest" hermes-agent
+```
+
 Once inside the agent, use `hermes model` to choose a provider and model, then
 start chatting.
 

--- a/junie/README.md
+++ b/junie/README.md
@@ -40,6 +40,12 @@ Or with a local clone of this repo:
 $ sbx run --kit ./junie/ junie
 ```
 
+Or from its published OCI artifact on Docker Hub:
+
+```console
+$ sbx run --kit "docker.io/sbx/junie-kit:latest" junie
+```
+
 The first launch installs Junie via its official install script. Subsequent launches reuse the sandbox.
 
 ## How auth works

--- a/junie/README.md
+++ b/junie/README.md
@@ -28,7 +28,14 @@ To use Junie with its primary API:
 
 ## Usage
 
-Run the kit. Pass the kit's name (`junie`) as the agent argument:
+Run the kit. Pass the kit's name (`junie`) as the agent argument. The primary
+form is its published OCI artifact on Docker Hub:
+
+```console
+$ sbx run --kit "docker.io/sbx/junie-kit:latest" junie
+```
+
+Or from a git URL targeting this repo:
 
 ```console
 $ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=junie" junie
@@ -38,12 +45,6 @@ Or with a local clone of this repo:
 
 ```console
 $ sbx run --kit ./junie/ junie
-```
-
-Or from its published OCI artifact on Docker Hub:
-
-```console
-$ sbx run --kit "docker.io/sbx/junie-kit:latest" junie
 ```
 
 The first launch installs Junie via its official install script. Subsequent launches reuse the sandbox.

--- a/kiro/README.md
+++ b/kiro/README.md
@@ -27,6 +27,12 @@ Or with a local clone of this repo:
 $ sbx run --kit ./kiro/ kiro
 ```
 
+Or from its published OCI artifact on Docker Hub:
+
+```console
+$ sbx run --kit "docker.io/sbx/kiro-kit:latest" kiro
+```
+
 The trailing `kiro` is required, not redundant: for `kind: sandbox` kits, `sbx`
 enforces that the agent name matches the kit's own `name`.
 
@@ -102,9 +108,9 @@ The image is **`docker.io/sbx/kiro-image`**, built on
 `docker/sandbox-templates:shell-docker`, so it carries a Docker engine and
 requests Docker-in-Docker.
 
-The `-image` suffix distinguishes the base image from the kit itself: when the kit
-is published as an OCI artifact it will be `docker.io/sbx/kiro-kit`. The name is
-derived from the kit directory and enforced repo-wide — see
+The `-image` suffix distinguishes the base image from the kit itself: the kit
+itself is published as an OCI artifact at `docker.io/sbx/kiro-kit` (see
+[Usage](#usage) above). The name is derived from the kit directory and enforced repo-wide — see
 [PUBLISHING.md](../PUBLISHING.md#naming).
 
 There is no flavour suffix and no dockerless variant. The sandbox templates

--- a/kiro/README.md
+++ b/kiro/README.md
@@ -18,6 +18,12 @@ authenticates only via device flow, which needs a browser on your host.
 ## Usage
 
 ```console
+$ sbx run --kit "docker.io/sbx/kiro-kit:latest" kiro
+```
+
+Or from a git URL targeting this repo:
+
+```console
 $ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=kiro" kiro
 ```
 
@@ -25,12 +31,6 @@ Or with a local clone of this repo:
 
 ```console
 $ sbx run --kit ./kiro/ kiro
-```
-
-Or from its published OCI artifact on Docker Hub:
-
-```console
-$ sbx run --kit "docker.io/sbx/kiro-kit:latest" kiro
 ```
 
 The trailing `kiro` is required, not redundant: for `kind: sandbox` kits, `sbx`

--- a/mise/README.md
+++ b/mise/README.md
@@ -10,14 +10,14 @@ agent can resolve and install per-project tool versions from
 `mise` is agent-agnostic — pair it with whichever agent you're using:
 
 ```console
-$ sbx run shell --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=mise" ~/my-project
-$ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=mise" ~/my-project
+$ sbx run claude --kit "docker.io/sbx/mise-kit:latest" ~/my-project
 ```
 
-Or from its published OCI artifact on Docker Hub:
+Or from a git URL targeting this repo:
 
 ```console
-$ sbx run claude --kit "docker.io/sbx/mise-kit:latest" ~/my-project
+$ sbx run shell --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=mise" ~/my-project
+$ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=mise" ~/my-project
 ```
 
 Once attached, any interactive shell has `mise` on PATH and shell hooks

--- a/mise/README.md
+++ b/mise/README.md
@@ -14,6 +14,12 @@ $ sbx run shell --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=mi
 $ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=mise" ~/my-project
 ```
 
+Or from its published OCI artifact on Docker Hub:
+
+```console
+$ sbx run claude --kit "docker.io/sbx/mise-kit:latest" ~/my-project
+```
+
 Once attached, any interactive shell has `mise` on PATH and shell hooks
 active:
 

--- a/nanobot/README.md
+++ b/nanobot/README.md
@@ -21,6 +21,12 @@ Or with a local clone of this repo:
 $ sbx run --kit ./nanobot/ nanobot
 ```
 
+Or from its published OCI artifact on Docker Hub:
+
+```console
+$ sbx run --kit "docker.io/sbx/nanobot-kit:latest" nanobot
+```
+
 The first launch installs nanobot via `pip install nanobot-ai` and
 runs it against the kit-shipped config at
 `/home/agent/.nanobot/config.json`. Subsequent launches reuse the

--- a/nanobot/README.md
+++ b/nanobot/README.md
@@ -12,6 +12,12 @@ attach.
 ## Usage
 
 ```console
+$ sbx run --kit "docker.io/sbx/nanobot-kit:latest" nanobot
+```
+
+Or from a git URL targeting this repo:
+
+```console
 $ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=nanobot" nanobot
 ```
 
@@ -19,12 +25,6 @@ Or with a local clone of this repo:
 
 ```console
 $ sbx run --kit ./nanobot/ nanobot
-```
-
-Or from its published OCI artifact on Docker Hub:
-
-```console
-$ sbx run --kit "docker.io/sbx/nanobot-kit:latest" nanobot
 ```
 
 The first launch installs nanobot via `pip install nanobot-ai` and

--- a/nanoclaw/README.md
+++ b/nanoclaw/README.md
@@ -12,6 +12,12 @@ starting OneCLI/Postgres, and walking through NanoClaw setup.
 ## Usage
 
 ```console
+$ sbx run --name nanoclaw --kit "docker.io/sbx/nanoclaw-kit:latest" nanoclaw
+```
+
+Or from a git URL targeting this repository:
+
+```console
 $ sbx run --name nanoclaw --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=nanoclaw" nanoclaw
 ```
 
@@ -19,12 +25,6 @@ Or with a local clone of this repository:
 
 ```console
 $ sbx run --name nanoclaw --kit ./nanoclaw nanoclaw
-```
-
-Or from its published OCI artifact on Docker Hub:
-
-```console
-$ sbx run --name nanoclaw --kit "docker.io/sbx/nanoclaw-kit:latest" nanoclaw
 ```
 
 The `--name nanoclaw` flag gives the sandbox a stable name for follow-up

--- a/nanoclaw/README.md
+++ b/nanoclaw/README.md
@@ -21,6 +21,12 @@ Or with a local clone of this repository:
 $ sbx run --name nanoclaw --kit ./nanoclaw nanoclaw
 ```
 
+Or from its published OCI artifact on Docker Hub:
+
+```console
+$ sbx run --name nanoclaw --kit "docker.io/sbx/nanoclaw-kit:latest" nanoclaw
+```
+
 The `--name nanoclaw` flag gives the sandbox a stable name for follow-up
 commands such as `sbx exec`, `sbx policy ls`, and `sbx rm`.
 

--- a/neovim/README.md
+++ b/neovim/README.md
@@ -11,6 +11,12 @@ $ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=n
 $ sbx run shell  --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=neovim" ~/my-project
 ```
 
+Or from its published OCI artifact on Docker Hub:
+
+```console
+$ sbx run claude --kit "docker.io/sbx/neovim-kit:latest" ~/my-project
+```
+
 ## Bringing your own config
 
 The kit ships a minimal starter `init.lua`. To use your personal config, run the bundled `sync-config.sh` once from the kit directory:

--- a/neovim/README.md
+++ b/neovim/README.md
@@ -4,17 +4,17 @@ A mixin that installs the latest stable [Neovim](https://neovim.io) release and 
 
 ## Usage
 
-Pair with any agent:
+Pair with any agent. The primary form is its published OCI artifact on Docker Hub:
+
+```console
+$ sbx run claude --kit "docker.io/sbx/neovim-kit:latest" ~/my-project
+```
+
+Or from a git URL targeting this repo:
 
 ```console
 $ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=neovim" ~/my-project
 $ sbx run shell  --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=neovim" ~/my-project
-```
-
-Or from its published OCI artifact on Docker Hub:
-
-```console
-$ sbx run claude --kit "docker.io/sbx/neovim-kit:latest" ~/my-project
 ```
 
 ## Bringing your own config

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -11,6 +11,12 @@ interactive TUI) as the entrypoint when you attach.
 ## Usage
 
 ```console
+$ sbx run --kit "docker.io/sbx/openclaw-kit:latest" openclaw
+```
+
+Or from a git URL targeting this repo:
+
+```console
 $ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=openclaw" openclaw
 ```
 
@@ -18,12 +24,6 @@ Or with a local clone of this repo:
 
 ```console
 $ sbx run --kit ./openclaw/ openclaw
-```
-
-Or from its published OCI artifact on Docker Hub:
-
-```console
-$ sbx run --kit "docker.io/sbx/openclaw-kit:latest" openclaw
 ```
 
 The kit auto-launches the openclaw gateway in the background on

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -20,6 +20,12 @@ Or with a local clone of this repo:
 $ sbx run --kit ./openclaw/ openclaw
 ```
 
+Or from its published OCI artifact on Docker Hub:
+
+```console
+$ sbx run --kit "docker.io/sbx/openclaw-kit:latest" openclaw
+```
+
 The kit auto-launches the openclaw gateway in the background on
 loopback port `18789` (token-authenticated; the token is generated
 on first run and stored in `/home/agent/.openclaw/openclaw.json`).

--- a/opencode-model-runner/README.md
+++ b/opencode-model-runner/README.md
@@ -21,14 +21,14 @@ cost-free experimentation, or testing custom local models with the OpenCode UI.
 ## Usage
 
 ```console
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=opencode-model-runner" opencode-model-runner ~/my-project
-$ sbx run --kit ./opencode-model-runner/ opencode-model-runner ~/my-project
+$ sbx run --kit "docker.io/sbx/opencode-model-runner-kit:latest" opencode-model-runner ~/my-project
 ```
 
-Or from its published OCI artifact on Docker Hub:
+Or from a git URL or a local clone of this repo:
 
 ```console
-$ sbx run --kit "docker.io/sbx/opencode-model-runner-kit:latest" opencode-model-runner ~/my-project
+$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=opencode-model-runner" opencode-model-runner ~/my-project
+$ sbx run --kit ./opencode-model-runner/ opencode-model-runner ~/my-project
 ```
 
 The agent name passed to `sbx run` (`opencode-model-runner`) matches the

--- a/opencode-model-runner/README.md
+++ b/opencode-model-runner/README.md
@@ -25,6 +25,12 @@ $ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=opencode
 $ sbx run --kit ./opencode-model-runner/ opencode-model-runner ~/my-project
 ```
 
+Or from its published OCI artifact on Docker Hub:
+
+```console
+$ sbx run --kit "docker.io/sbx/opencode-model-runner-kit:latest" opencode-model-runner ~/my-project
+```
+
 The agent name passed to `sbx run` (`opencode-model-runner`) matches the
 `name:` field in the kit's `spec.yaml`.
 

--- a/packages-through-sfw/README.md
+++ b/packages-through-sfw/README.md
@@ -12,7 +12,13 @@ Enterprise or a forked kit with the right network and credential wiring.
 
 ## Usage
 
-Run it with any agent kit or built-in agent:
+Run it with any agent kit or built-in agent, from its published OCI artifact on Docker Hub:
+
+```console
+$ sbx run --kit "docker.io/sbx/packages-through-sfw-kit:latest" <agent>
+```
+
+Or from a git URL targeting this repo:
 
 ```console
 $ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=packages-through-sfw" <agent>
@@ -22,12 +28,6 @@ For local development, point `--kit` at this directory:
 
 ```console
 $ sbx run --kit ./packages-through-sfw/ <agent>
-```
-
-Or from its published OCI artifact on Docker Hub:
-
-```console
-$ sbx run --kit "docker.io/sbx/packages-through-sfw-kit:latest" <agent>
 ```
 
 After the sandbox starts, package-manager commands invoked by name are routed

--- a/packages-through-sfw/README.md
+++ b/packages-through-sfw/README.md
@@ -24,6 +24,12 @@ For local development, point `--kit` at this directory:
 $ sbx run --kit ./packages-through-sfw/ <agent>
 ```
 
+Or from its published OCI artifact on Docker Hub:
+
+```console
+$ sbx run --kit "docker.io/sbx/packages-through-sfw-kit:latest" <agent>
+```
+
 After the sandbox starts, package-manager commands invoked by name are routed
 through `sfw`:
 

--- a/pi/README.md
+++ b/pi/README.md
@@ -18,6 +18,12 @@ Or with a local clone of this repo:
 $ sbx run --kit ./pi/ pi
 ```
 
+Or from its published OCI artifact on Docker Hub:
+
+```console
+$ sbx run --kit "docker.io/sbx/pi-kit:latest" pi
+```
+
 The first launch installs the agent via `npm install -g`. Subsequent
 launches reuse the sandbox.
 

--- a/pi/README.md
+++ b/pi/README.md
@@ -9,6 +9,12 @@ it as the entrypoint when you attach.
 ## Usage
 
 ```console
+$ sbx run --kit "docker.io/sbx/pi-kit:latest" pi
+```
+
+Or from a git URL targeting this repo:
+
+```console
 $ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=pi" pi
 ```
 
@@ -16,12 +22,6 @@ Or with a local clone of this repo:
 
 ```console
 $ sbx run --kit ./pi/ pi
-```
-
-Or from its published OCI artifact on Docker Hub:
-
-```console
-$ sbx run --kit "docker.io/sbx/pi-kit:latest" pi
 ```
 
 The first launch installs the agent via `npm install -g`. Subsequent

--- a/playwright/README.md
+++ b/playwright/README.md
@@ -14,6 +14,12 @@ Or straight from this repository:
 $ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=playwright" claude
 ```
 
+Or from its published OCI artifact on Docker Hub:
+
+```console
+$ sbx run claude --kit "docker.io/sbx/playwright-kit:latest" .
+```
+
 Prerequisites:
 
 - A base image with Node.js ≥ 18 and npm — all standard agent templates ship it. The install fails loudly with a clear message if npm is missing.

--- a/playwright/README.md
+++ b/playwright/README.md
@@ -5,19 +5,19 @@ A mixin kit that installs the **Playwright** browser-automation toolchain inside
 ## Usage
 
 ```console
-$ sbx run claude --kit ./playwright/ .
+$ sbx run claude --kit "docker.io/sbx/playwright-kit:latest" .
 ```
 
-Or straight from this repository:
+Or straight from this repository over git:
 
 ```console
 $ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=playwright" claude
 ```
 
-Or from its published OCI artifact on Docker Hub:
+Or with a local clone of this repo:
 
 ```console
-$ sbx run claude --kit "docker.io/sbx/playwright-kit:latest" .
+$ sbx run claude --kit ./playwright/ .
 ```
 
 Prerequisites:

--- a/scripts/check-image-ref.sh
+++ b/scripts/check-image-ref.sh
@@ -22,7 +22,7 @@
 # namespace when REGISTRY/IMAGE_NAMESPACE move.
 #
 # The `-image` suffix is not decoration: it leaves `<namespace>/<kit>-kit` free
-# for the kit artifact itself, once kits are distributed as OCI artifacts too.
+# for the kit artifact itself, which is also distributed as an OCI artifact.
 #
 # The name is DERIVED from the kit directory rather than looked up in a table.
 # An enumerated list of expected names would be one more thing to leave stale —

--- a/skills/kit-author/topics/authoring.md
+++ b/skills/kit-author/topics/authoring.md
@@ -249,14 +249,15 @@ For changes that affect immutable container settings (privileged, volumes, tmpfs
 ## Before opening a PR
 
 Your kit's `README.md` **Usage** section needs three ways to run it, not just
-the git-URL and local-path forms shown in the recipes above: also add the
+the git-URL and local-path forms shown in the recipes above: lead with the
 published-OCI-artifact form, `docker.io/sbx/<kit>-kit:latest` — publishing is
 automatic and needs no opt-in (see [`PUBLISHING.md`](../../../PUBLISHING.md)),
-so the artifact exists the moment this PR merges to `main`. Match the
-invocation your kit already uses (agent name as the argument for `kind:
-sandbox`, `sbx run <agent> --kit <ref> [path]` for `kind: mixin`) — only the
-`--kit` value changes. See any existing kit's README for the pattern, and
-[CONTRIBUTING.md](../../../CONTRIBUTING.md#per-kit-readme) for the full
+so the artifact exists the moment this PR merges to `main`, which makes it the
+primary way to consume the kit — then the git-URL form, then the local-path
+form. Match the invocation your kit already uses (agent name as the argument
+for `kind: sandbox`, `sbx run <agent> --kit <ref> [path]` for `kind: mixin`) —
+only the `--kit` value changes. See any existing kit's README for the
+pattern, and [CONTRIBUTING.md](../../../CONTRIBUTING.md#per-kit-readme) for the full
 per-kit README convention.
 
 CI on the repo skips the e2e legs (`e2e-release`, `e2e-nightly`) for fork PRs (Docker Hub secrets aren't exposed to fork-triggered workflows). Run e2e locally before you ask for review:

--- a/skills/kit-author/topics/authoring.md
+++ b/skills/kit-author/topics/authoring.md
@@ -248,6 +248,17 @@ For changes that affect immutable container settings (privileged, volumes, tmpfs
 
 ## Before opening a PR
 
+Your kit's `README.md` **Usage** section needs three ways to run it, not just
+the git-URL and local-path forms shown in the recipes above: also add the
+published-OCI-artifact form, `docker.io/sbx/<kit>-kit:latest` — publishing is
+automatic and needs no opt-in (see [`PUBLISHING.md`](../../../PUBLISHING.md)),
+so the artifact exists the moment this PR merges to `main`. Match the
+invocation your kit already uses (agent name as the argument for `kind:
+sandbox`, `sbx run <agent> --kit <ref> [path]` for `kind: mixin`) — only the
+`--kit` value changes. See any existing kit's README for the pattern, and
+[CONTRIBUTING.md](../../../CONTRIBUTING.md#per-kit-readme) for the full
+per-kit README convention.
+
 CI on the repo skips the e2e legs (`e2e-release`, `e2e-nightly`) for fork PRs (Docker Hub secrets aren't exposed to fork-triggered workflows). Run e2e locally before you ask for review:
 
 ```bash

--- a/skills/kit-author/topics/image-publishing.md
+++ b/skills/kit-author/topics/image-publishing.md
@@ -46,7 +46,8 @@ $ ./scripts/check-image-ref.sh docker.io/sbx latest
 ```
 
 The `-image` suffix keeps `docker.io/sbx/<kit>-kit` free for the kit artifact
-itself, once kits are distributed as OCI artifacts too.
+itself, which is also distributed as an OCI artifact — see
+[Distribution](distribution.md).
 
 ## Do not reach for `sandbox.build:`
 

--- a/smolagents/README.md
+++ b/smolagents/README.md
@@ -14,6 +14,12 @@ $ sbx run shell --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=sm
 $ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=smolagents" ~/my-project
 ```
 
+Or from its published OCI artifact on Docker Hub:
+
+```console
+$ sbx run claude --kit "docker.io/sbx/smolagents-kit:latest" ~/my-project
+```
+
 Once attached, the command-line tools are available:
 
 ```console

--- a/smolagents/README.md
+++ b/smolagents/README.md
@@ -7,17 +7,17 @@ and exposes the upstream `smolagent` and `webagent` CLIs on `PATH`.
 
 ## Usage
 
-Pair it with whichever sandbox agent you want to work from:
+Pair it with whichever sandbox agent you want to work from, from its published OCI artifact on Docker Hub:
+
+```console
+$ sbx run claude --kit "docker.io/sbx/smolagents-kit:latest" ~/my-project
+```
+
+Or from a git URL targeting this repo:
 
 ```console
 $ sbx run shell --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=smolagents" ~/my-project
 $ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=smolagents" ~/my-project
-```
-
-Or from its published OCI artifact on Docker Hub:
-
-```console
-$ sbx run claude --kit "docker.io/sbx/smolagents-kit:latest" ~/my-project
 ```
 
 Once attached, the command-line tools are available:

--- a/task/README.md
+++ b/task/README.md
@@ -17,6 +17,12 @@ For local development, point `--kit` at this directory:
 $ sbx run --kit ./task/ claude
 ```
 
+Or from its published OCI artifact on Docker Hub:
+
+```console
+$ sbx run --kit "docker.io/sbx/task-kit:latest" claude
+```
+
 After the sandbox starts, `task` is available on `PATH`:
 
 ```console

--- a/task/README.md
+++ b/task/README.md
@@ -5,7 +5,13 @@ agents can run `Taskfile.yml` tasks from the workspace.
 
 ## Usage
 
-Run it with any agent kit or built-in agent:
+Run it with any agent kit or built-in agent, from its published OCI artifact on Docker Hub:
+
+```console
+$ sbx run --kit "docker.io/sbx/task-kit:latest" claude
+```
+
+Or from a git URL targeting this repo:
 
 ```console
 $ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=task" claude
@@ -15,12 +21,6 @@ For local development, point `--kit` at this directory:
 
 ```console
 $ sbx run --kit ./task/ claude
-```
-
-Or from its published OCI artifact on Docker Hub:
-
-```console
-$ sbx run --kit "docker.io/sbx/task-kit:latest" claude
 ```
 
 After the sandbox starts, `task` is available on `PATH`:

--- a/trivy/README.md
+++ b/trivy/README.md
@@ -23,20 +23,20 @@ and the install is digest-pinned against tag-rewrite attacks.
 
 ```console
 $ cd ~/work/some-project
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=trivy" trivy .
+$ sbx run --kit "docker.io/sbx/trivy-kit:latest" trivy .
 agent@trivy-some-project:/Users/mark/work/some-project$ trivy fs .
+```
+
+Or from a git URL targeting this repo:
+
+```console
+$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=trivy" trivy .
 ```
 
 Or with a local clone of this repo:
 
 ```console
 $ sbx run --kit ./trivy/ trivy .
-```
-
-Or from its published OCI artifact on Docker Hub:
-
-```console
-$ sbx run --kit "docker.io/sbx/trivy-kit:latest" trivy .
 ```
 
 The first launch downloads, verifies, and installs Trivy. Subsequent

--- a/trivy/README.md
+++ b/trivy/README.md
@@ -33,6 +33,12 @@ Or with a local clone of this repo:
 $ sbx run --kit ./trivy/ trivy .
 ```
 
+Or from its published OCI artifact on Docker Hub:
+
+```console
+$ sbx run --kit "docker.io/sbx/trivy-kit:latest" trivy .
+```
+
 The first launch downloads, verifies, and installs Trivy. Subsequent
 launches reuse the sandbox; the vuln DB is cached on a persistent volume.
 

--- a/vale/README.md
+++ b/vale/README.md
@@ -15,6 +15,12 @@ Or with a local clone:
 $ sbx run --kit ./vale/ claude
 ```
 
+Or from its published OCI artifact on Docker Hub:
+
+```console
+$ sbx run --kit "docker.io/sbx/vale-kit:latest" claude
+```
+
 Vale is on `PATH` after install. To lint a directory:
 
 ```console

--- a/vale/README.md
+++ b/vale/README.md
@@ -5,20 +5,20 @@ A mixin kit (`kind: mixin`) that installs the latest [Vale](https://vale.sh/) pr
 ## Usage
 
 ```console
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=vale" claude
+$ sbx run --kit "docker.io/sbx/vale-kit:latest" claude
 agent@...$ vale --version
+```
+
+Or from a git URL targeting this repo:
+
+```console
+$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=vale" claude
 ```
 
 Or with a local clone:
 
 ```console
 $ sbx run --kit ./vale/ claude
-```
-
-Or from its published OCI artifact on Docker Hub:
-
-```console
-$ sbx run --kit "docker.io/sbx/vale-kit:latest" claude
 ```
 
 Vale is on `PATH` after install. To lint a directory:


### PR DESCRIPTION
## Summary
- Add a "run from its published OCI artifact" example (`docker.io/sbx/<kit>-kit:latest`) to all 28 kit READMEs, alongside the existing git-URL and local-path examples, matching each kit's own invocation shape.
- Fix a few spots that still described the kit artifact in future tense now that publishing is real (`PUBLISHING.md`, `scripts/check-image-ref.sh`, `skills/kit-author/topics/image-publishing.md`, `copilot/README.md`, `kiro/README.md`).
- Update `CONTRIBUTING.md` and the `kit-author` skill so a brand-new kit's README includes the OCI-artifact form by default, not just as a one-off retrofit.

## Test plan
- [ ] Docs-only change; no TCK/e2e impact. Spot-checked that every `docker.io/sbx/<kit>-kit` reference matches its kit directory name.

Closes #202.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>