### PR TITLE
feat(droid): add the droid sandbox kit with its own base image

### DIFF
--- a/droid/.dockerignore
+++ b/droid/.dockerignore
@@ -1,0 +1,10 @@
+# The build context is the kit directory, which also holds kit metadata that the
+# image has no use for. Excluding it keeps the context small and keeps README or
+# testdata edits from touching the image build at all.
+#
+# Listed by exclusion rather than as an allowlist (`*` + `!start.sh`) so that
+# adding a COPY for a new file does not silently fail on a stale ignore rule.
+README.md
+spec.yaml
+testdata/
+.dockerignore

--- a/droid/Dockerfile
+++ b/droid/Dockerfile
@@ -1,0 +1,59 @@
+# syntax=docker/dockerfile:1
+
+# Base image for the `droid` sandbox kit.
+#
+# One image, no flavour suffix: the kit picks its own image, so the
+# Docker-in-Docker detail never reaches the user. There is no dockerless variant
+# either — a kind:sandbox kit names a single sandbox.image, so a second image
+# would be unreachable without a second kit to consume it.
+#
+# The base is a floating tag, which is why CI also rebuilds on a schedule.
+ARG BASE_IMAGE=docker/sandbox-templates:shell-docker
+FROM ${BASE_IMAGE}
+
+# Re-declared inside the stage: an ARG defined before the first FROM is a global
+# build arg, visible only to FROM lines. Without this, the LABEL below would
+# expand to an empty string.
+ARG BASE_IMAGE
+
+# Droid CLI has no interactive-auth wrapper to install (unlike kiro's
+# device-flow launcher) — the sandbox proxy injects FACTORY_API_KEY (or
+# resolves the credential's OAuth block) per spec.yaml's credentials block. So
+# this is just the upstream install script, verbatim from
+# https://docs.factory.ai/cli/getting-started/quickstart.
+RUN <<EOF
+set -exo pipefail
+curl -fsSL https://app.factory.ai/cli | sh
+EOF
+
+# Inherited from the base image, but re-declared deliberately so the value is
+# owned here rather than depending on inheritance from an image this repository
+# does not own.
+#
+# This is a *request* to the runtime, not a description of the image: setting it
+# over a base with no Docker engine yields a sandbox started in Docker mode with
+# nothing to run. Since BASE_IMAGE is overridable, CI asserts the engine is
+# really present rather than trusting this label.
+LABEL com.docker.sandboxes.start-docker="true"
+
+# Both of the labels below OVERRIDE values inherited from the base image, which
+# describe the base rather than this image. Overriding is not optional for
+# `flavor`: left inherited it would read "shell-docker", and sbx would report
+# this image's agent as "shell-docker".
+#
+# sbx reads `flavor` and treats it as an agent identifier — it surfaces the value
+# as an image's `Agent` in the API, and separately uses it (with any `-docker`
+# suffix trimmed) to warn when a template looks built for a different agent than
+# the one being run. So it must be the kit's own name: `droid`.
+LABEL com.docker.sandboxes.flavor="droid"
+
+# Informational only — nothing in sbx reads this. Worth setting because the base
+# is a floating tag rebuilt nightly, so this is the one place the produced image
+# records what it was actually built on.
+LABEL com.docker.sandboxes.base="${BASE_IMAGE}"
+
+# Note: `com.docker.sandboxes=templates` also appears on this image. It is
+# inherited from the base and is not set here — nothing reads it, and this image
+# is not part of that template family, so it is left alone rather than asserted.
+
+CMD [ "droid" ]

--- a/droid/README.image.md
+++ b/droid/README.image.md
@@ -1,0 +1,18 @@
+# sbx/droid-image
+
+Base image for the Droid agent kit for
+[Docker Sandboxes](https://docs.docker.com/ai/sandboxes/).
+
+## Contents
+
+Built on `docker/sandbox-templates:shell-docker`: the standard sandbox tool
+chain plus a Docker engine, requesting Docker-in-Docker via
+`com.docker.sandboxes.start-docker=true`. On top of that:
+
+- `droid`, Factory's Droid CLI, installed via the upstream install script
+
+Runs as the non-root `agent` user, with `CMD ["droid"]`.
+
+## Kit
+
+[`docker.io/sbx/droid-kit`](https://hub.docker.com/r/sbx/droid-kit)

--- a/droid/README.md
+++ b/droid/README.md
@@ -1,0 +1,141 @@
+# droid
+
+A standalone sandbox kit (`kind: sandbox`, `schemaVersion: "2"`) for
+[Droid CLI](https://docs.factory.ai/cli/getting-started/quickstart), Factory's
+agentic coding CLI. The kit runs `droid` as the entrypoint and authenticates
+through a single credential the sandbox proxy resolves per request: an
+`apiKey` if `FACTORY_API_KEY` is set on the host, or an interactive OAuth
+device/token flow otherwise.
+
+Droid was previously a built-in `sbx` agent, run as `sbx run droid`. This kit
+replaces that, and is backed by a base image built from the
+[`Dockerfile`](./Dockerfile) in this directory rather than by the
+`docker/sandbox-templates` release train.
+
+## Prerequisites
+
+Either of these works — you do not need both:
+
+- `FACTORY_API_KEY`, exported on your host — a Factory API key. The proxy
+  injects it as `Authorization: Bearer <token>` on outbound requests to
+  `api.factory.ai`, `app.factory.ai`, and `relay.factory.ai`.
+- Nothing set at all — Droid falls back to its own OAuth device/token flow
+  against `api.workos.com`, handled inside the sandbox at first use.
+
+## Usage
+
+```console
+$ sbx run --kit "docker.io/sbx/droid-kit:latest" droid
+```
+
+Or from a git URL targeting this repo:
+
+```console
+$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=droid" droid
+```
+
+Or with a local clone of this repo:
+
+```console
+$ sbx run --kit ./droid/ droid
+```
+
+The trailing `droid` is required, not redundant: for `kind: sandbox` kits,
+`sbx` enforces that the agent name matches the kit's own `name`.
+
+## Passing arguments
+
+The entrypoint is a bare `droid`, with no default flags — unlike some other
+kits here, arguments you pass are not appended to anything.
+
+## How auth works
+
+The kit declares one credential, `droid`, with both an `apiKey` and an
+`oauth` block:
+
+- `apiKey` holds `FACTORY_API_KEY`, injected as `Authorization: Bearer <token>`
+  into `api.factory.ai`, `app.factory.ai`, and `relay.factory.ai`.
+- `oauth` points at Factory's WorkOS-backed token endpoint
+  (`api.workos.com/user_management/authenticate`), used for the interactive
+  device/token-exchange flow when no `apiKey` is bound.
+
+When both are declared on one credential, the `apiKey` takes precedence
+whenever it resolves — a host with `FACTORY_API_KEY` bound never triggers the
+interactive flow. The spec also carries a `skipIfEnv: [FACTORY_API_KEY]` entry
+under `oauth`, inherited unchanged from the built-in agent's spec, but it has
+no effect here: it's a host-env-driven shortcut that only applies to older,
+non-binding kit schemas, not to this kit's binding-driven credential
+resolution. It's kept for parity with the built-in spec rather than dropped.
+
+> [!IMPORTANT]
+> This kit sets `apiKey.proxyManaged: true` on `FACTORY_API_KEY`, matching
+> most (not all — `copilot`'s credentials notably don't, with no recorded
+> reason) apiKey-based kits in this repo. That makes the engine set the
+> in-container value to a sentinel and have the proxy substitute the real key
+> only on the domains listed above. **This interaction has not been verified
+> end-to-end**: it is not confirmed whether Droid's OAuth device/token-exchange
+> flow still resolves correctly when `FACTORY_API_KEY` holds the sentinel
+> rather than a value the CLI can use directly for anything outside those
+> three domains. If Droid misbehaves with only the OAuth path expected to run,
+> this is the first thing to check.
+
+## Network policy
+
+`permissions.network.allow` mirrors every domain the credential block injects
+into or resolves against, plus the apt sources the base image ships with
+(needed because the startup hook runs `apt-get update`, which fails wholesale
+if any configured source is unreachable).
+
+> [!IMPORTANT]
+> This list has not been verified end-to-end under `sbx policy init deny-all`
+> from this repo. Droid CLI may reach further hosts (telemetry, self-update,
+> the extension registry) that aren't captured yet. If something fails under
+> deny-all, inspect what was blocked and widen the list:
+>
+> ```console
+> $ sbx policy log
+> ```
+>
+> then add the reported hosts to `permissions.network.allow` in `spec.yaml`.
+
+## Base image
+
+Unlike most kits here — which are `kind: mixin` or `kind: agent` and layer onto
+an existing `docker/sandbox-templates` image — a `kind: sandbox` kit *is* the
+whole environment, so it names the image the sandbox boots from. This kit
+builds and publishes its own, from the `Dockerfile` in this directory.
+
+The image is **`docker.io/sbx/droid-image`**, built on
+`docker/sandbox-templates:shell-docker`, so it carries a Docker engine and
+requests Docker-in-Docker.
+
+The `-image` suffix distinguishes the base image from the kit itself: the kit
+itself is published as an OCI artifact at `docker.io/sbx/droid-kit` (see
+[Usage](#usage) above).
+The name is derived from the kit directory and enforced repo-wide — see
+[PUBLISHING.md](../PUBLISHING.md#naming).
+
+There is no flavour suffix and no dockerless variant. The sandbox templates
+distinguish `droid` from `droid-docker` because a user picks a template
+directly, but a kit picks its own image — so the Docker-in-Docker detail never
+reaches the user, just as `sbx run droid` already resolves to the Docker
+flavour today. And a `kind: sandbox` kit names exactly one `sandbox.image`, so
+a second image would be unreachable without a second kit to consume it.
+
+### Building and publishing
+
+How the image is named, tagged, verified and pushed is the same for every kit
+in this repo that builds its own image — see
+**[PUBLISHING.md](../PUBLISHING.md)** for the pipeline, the tagging scheme,
+the coordinates, and the Docker Hub OIDC setup. Only the droid-specific parts
+are below.
+
+### Building locally
+
+```console
+$ docker build -t docker.io/sbx/droid-image:latest droid
+```
+
+`BASE_IMAGE` is a build arg, so the base can be re-pointed or digest-pinned
+without editing the `Dockerfile`: `--build-arg BASE_IMAGE=…` accepts a tag or a
+digest.

--- a/droid/spec.yaml
+++ b/droid/spec.yaml
@@ -1,0 +1,122 @@
+schemaVersion: "2"
+kind: sandbox
+name: droid
+# The KIT's version, not Droid's. It covers this spec, the network policy and
+# the hooks — the agent inside the image floats, so a newer droid-cli does not
+# bump this and this does not track releases of droid-cli.
+#
+# Published as the vnd.docker.sandbox.kit.version OCI annotation at pack time,
+# and `scripts/check-release-tag.sh` refuses a `droid/vX.Y.Z` tag that
+# disagrees with it. Bump here first, then tag.
+version: "1.0.0"
+displayName: Droid
+description: Droid CLI by Factory, an agentic coding CLI.
+sandbox:
+  # Built from the Dockerfile beside this spec and published by
+  # .github/workflows/build-and-publish-kits.yml. Carries a Docker engine and
+  # requests Docker-in-Docker, matching the built-in agent this kit replaces.
+  #
+  # This value is the source of truth for what CI builds and publishes: the
+  # workflow reads it from here rather than deriving a name, because spec.yaml
+  # is consumed literally (no env interpolation) and so cannot follow a
+  # variable. scripts/check-image-ref.sh asserts it stays inside the namespace
+  # CI can actually push to.
+  #
+  # The `-image` suffix distinguishes the base image from the kit artifact:
+  # when the kit itself is published as an OCI artifact it will be
+  # `docker.io/sbx/droid-kit`.
+  image: "docker.io/sbx/droid-image:latest"
+  entrypoint: [droid]
+
+credentials:
+  - service: droid
+    apiKey:
+      name: FACTORY_API_KEY
+      # Most apiKey-based kits in this repo set this (pi, nanobot, crush,
+      # junie); copilot's own credentials notably don't, with no recorded
+      # reason. Following the majority here — but it has NOT been verified
+      # end-to-end whether Droid's OAuth device/token-exchange flow below
+      # still resolves correctly when FACTORY_API_KEY holds the proxy's
+      # sentinel value instead of a raw key the CLI reads directly. Needs a
+      # live `sbx run --kit ./droid droid` check; see the PR description.
+      proxyManaged: true
+      inject:
+        - domain: api.factory.ai
+          header: Authorization
+          format: Bearer %s
+        - domain: app.factory.ai
+          header: Authorization
+          format: Bearer %s
+        - domain: relay.factory.ai
+          header: Authorization
+          format: Bearer %s
+    # Ported close to verbatim from the built-in spec: the OAuth device/token
+    # flow itself is generic engine machinery on the consuming side, not
+    # something this kit implements differently. When both apiKey and oauth
+    # are declared on the same credential (as here), the apiKey takes
+    # precedence whenever it resolves, so a host with FACTORY_API_KEY bound
+    # never triggers the OAuth path.
+    #
+    # skipIfEnv below is carried over from the built-in spec for parity, but
+    # is a no-op for a schemaVersion "2" credential like this one — resolution
+    # here is binding-driven, not host-env-driven, so a host env var alone
+    # (as opposed to a bound credential) does not gate this. Kept rather than
+    # dropped so a future diff against the built-in spec stays minimal.
+    oauth:
+      tokenEndpoint:
+        host: api.workos.com
+        path: /user_management/authenticate
+      sentinels:
+        accessToken: droid-oat-proxy-managed
+        refreshToken: droid-ort-proxy-managed
+      skipIfEnv:
+        - FACTORY_API_KEY
+
+permissions:
+  network:
+    # Built-in agents ship no egress policy of their own: they inherit
+    # whatever the host policy is, which defaults to permissive. A community
+    # kit cannot rely on that — this repo's e2e runs every kit under
+    # `sbx policy init deny-all`, so the kit gets exactly the reachability it
+    # declares here and nothing more.
+    allow:
+      # Every domain either credential injects into — required here too, not
+      # just above: a domain absent from this list is unreachable regardless
+      # of what the credential block declares.
+      - api.factory.ai
+      - app.factory.ai
+      - relay.factory.ai
+      # The OAuth token endpoint.
+      - api.workos.com
+      # `apt-get update` (the startup hook below) refreshes metadata for every
+      # configured apt source and returns exit 100 if any one of them fails.
+      # The shell-docker base ships three sources, so all three must be
+      # reachable. Ubuntu serves amd64 from archive/security and arm64 from
+      # ports.ubuntu.com, so all three Ubuntu hosts are listed to keep the kit
+      # working cross-arch.
+      - archive.ubuntu.com        # Ubuntu archive (amd64 main)
+      - security.ubuntu.com       # Ubuntu security updates (amd64)
+      - ports.ubuntu.com          # Ubuntu archive/security (arm64)
+      - download.docker.com       # Docker's apt repo, pre-added by shell-docker
+      #
+      # TODO(droid-extraction): the domains above are the ones the
+      # credential block already declared; they have not been verified
+      # end-to-end under deny-all from this repo, and Droid CLI may reach
+      # further hosts (telemetry, self-update, extension registry). Confirm
+      # or widen from a live run:
+      #
+      #   sbx run --kit ./droid droid   # then attempt a prompt
+      #   sbx policy log                # lists every blocked host + reason
+
+setup:
+  install:
+    - command: mkdir -p /home/agent/.factory && chown agent:agent /home/agent/.factory
+      user: "0"
+      description: Ensure .factory is owned by agent before bind mounts run
+  startup:
+    - command: ["sh", "-c", "command -v apt-get > /dev/null 2>&1 && (apt-get update -qq -y > /dev/null 2>&1 || true) &"]
+      user: "root"
+      description: Update apt package cache in background
+
+agentInstructions:
+  filename: AGENTS.md

--- a/droid/testdata/tck.yaml
+++ b/droid/testdata/tck.yaml
@@ -1,0 +1,28 @@
+# TCK configuration for the droid kit.
+#
+# droid is still a built-in agent in released sbx builds, and sbx refuses to
+# load a kit whose name collides with a built-in ("built-in agents cannot be
+# overridden by a kit"). This flag turns that one specific `sbx create` failure
+# into a skip, so the kit can land and be reviewed here before the built-in is
+# removed from sbx.
+#
+# Nothing needs re-enabling later: once a released sbx no longer registers the
+# built-in, `sbx create` succeeds, the full e2e runs, and the test logs a notice
+# that this line is obsolete and can be deleted.
+extractedFromBuiltin: true
+#
+# `promptArgs` is deliberately omitted for now, which skips the e2e `prompt`
+# subtest. This is also the first kit extraction with an OAuth-bearing
+# credential: Droid falls back to an interactive device/token-exchange flow
+# whenever FACTORY_API_KEY is unset, so a non-interactive e2e prompt would
+# either need a real FACTORY_API_KEY on the runner or block on that flow.
+# Neither has been set up here, and the built-in agent's own e2e test never
+# exercises this path either. Wire `promptArgs` once a known-working
+# non-interactive recipe (with a real key) exists, rather than guessing at
+# flags that could flake or hang CI.
+#
+# The remaining subtests (env, files, tmpfs, agentContext) still run and are
+# what actually gate this kit.
+
+# Droid's startup hook does no MCP-gateway registration, so no `mcp:` block is
+# needed here.


### PR DESCRIPTION
## Summary

Phase A of extracting the built-in `droid` agent from `docker/sandboxes`
into this repo as a standalone community kit — the same playbook `kiro`'s
and `copilot`'s own extractions used (#177, #194). This is the first kit
extraction with an OAuth-bearing credential: Factory's `FACTORY_API_KEY`
apiKey plus a WorkOS-backed device/token-exchange flow declared on the same
`droid` credential.

- `droid/spec.yaml` — lifted from the embedded agent's spec (apiKey +
  oauth block ported close to verbatim), plus `sandbox.image` pointed at
  `docker.io/sbx/droid-image`, a new `permissions.network.allow` block, and
  `version`/`displayName`/`description`.
- `droid/Dockerfile` — installs Droid CLI on top of
  `docker/sandbox-templates:shell-docker`, matching the copilot/kiro
  Dockerfile shape (re-declared `BASE_IMAGE`/labels, `CMD ["droid"]`).
- `droid/testdata/tck.yaml` — `extractedFromBuiltin: true` (droid is still
  a built-in agent today, so `sbx create` would otherwise refuse the name
  collision); `promptArgs` deliberately omitted, since droid falls back to
  an interactive OAuth flow whenever no API key is bound.

## Open before merge

- `permissions.network.allow` is only as complete as the credential-inject
  domains (`api.factory.ai`, `app.factory.ai`, `relay.factory.ai`,
  `api.workos.com`) plus known apt hosts — not verified end-to-end under
  `sbx policy init deny-all` from a real `sbx run`.
- `apiKey.proxyManaged: true` is set on `FACTORY_API_KEY`, matching most
  (not all — `copilot`'s own credentials don't, with no recorded reason)
  apiKey-based kits here. **Not verified**: whether Droid's OAuth
  device/token-exchange flow still resolves correctly when
  `FACTORY_API_KEY` holds the proxy's sentinel value instead of a raw key.
  This is the one thing most worth checking live before calling this done
  — please run `./scripts/test-kit-e2e.sh droid` once the image is
  published and confirm the OAuth path actually completes.

## Test plan

- [x] `go run ./scripts/verify-kit-spec ./droid` — clean
- [x] `./scripts/test-kit.sh droid` — full TCK green, including a real
      `docker build` and the new `oauth_policy` subtest
- [ ] `./scripts/test-kit-e2e.sh droid` (real `sbx`, host-only) — not run
      from this sandbox; please run once the image is pushed, specifically
      to exercise the OAuth/skipIfEnv-adjacent flow for the first time
      from an external kit