### PR TITLE
fix(nanoclaw): set OneCLI gateway URL

### DIFF
--- a/nanoclaw/spec.yaml
+++ b/nanoclaw/spec.yaml
@@ -80,6 +80,7 @@ environment:
     NO_PROXY: 127.0.0.1,localhost
     NODE_NO_WARNINGS: "1"
     ONECLI_BIND_HOST: 0.0.0.0
+    ONECLI_GATEWAY_URL: http://127.0.0.1:10255
     ONECLI_URL: http://127.0.0.1:10254
     TZ: UTC
     no_proxy: 127.0.0.1,localhost


### PR DESCRIPTION
## Summary

Set `ONECLI_GATEWAY_URL` to the local OneCLI gateway at `http://127.0.0.1:10255`.

Without the explicit URL, NanoClaw's OneCLI SDK falls back to the gateway's advertised `0.0.0.0` address. In Docker Sandboxes that address is routed through the HTTP proxy, rejected as implied localhost, and retried continuously, causing high CPU/memory use and rapid daemon-log growth.

## Spec choices worth flagging for review

The loopback URL matches the OneCLI gateway port already published by this kit. No image, port, or network-policy changes are required.

## Origin

Derived from a live NanoClaw Docker Sandbox investigation and aligned with the canonical `nanoclaw-sbx` kit spec.

## Test plan

- [x] `sbx kit validate ./nanoclaw/`
- [x] `./scripts/test-kit.sh nanoclaw`
- [x] `POLICY= ./scripts/test-kit-e2e.sh nanoclaw` with the isolated daemon's existing `deny-all` policy
- [x] Manual smoke: created a temporary sandbox from `./nanoclaw`, verified the OCI runtime environment contains `ONECLI_GATEWAY_URL=http://127.0.0.1:10255`, then removed it
