### PR TITLE
fix(tck): auto-diagnose e2e failures with the actual policy log

### DIFF
--- a/aider/spec.yaml
+++ b/aider/spec.yaml
@@ -14,7 +14,13 @@ permissions:
       - github.com
       - api.github.com
       - raw.githubusercontent.com
+      # uv's `--python 3.12` fetches a standalone Python runtime from a
+      # GitHub release (astral-sh/python-build-standalone). The redirect
+      # target isn't a fixed constant -- both of GitHub's release-asset CDN
+      # hosts are needed (confirmed against the identical gap in kernel's
+      # kit, see kernel/spec.yaml).
       - objects.githubusercontent.com
+      - release-assets.githubusercontent.com
       - pypi.org
       - files.pythonhosted.org
       - astral.sh

--- a/open-interpreter/spec.yaml
+++ b/open-interpreter/spec.yaml
@@ -45,7 +45,10 @@ permissions:
       # GitHub release (astral-sh/python-build-standalone). The redirect
       # target isn't a fixed constant -- both of GitHub's release-asset CDN
       # hosts are needed (confirmed against the identical gap in kernel's
-      # kit, see kernel/spec.yaml).
+      # kit, see kernel/spec.yaml). Resolving the release itself hits
+      # github.com directly, not just its CDN hosts -- confirmed via a real
+      # e2e run under deny-all.
+      - github.com
       - objects.githubusercontent.com
       - release-assets.githubusercontent.com
       # PyPI: uv installs at creation time and during code execution

--- a/open-interpreter/spec.yaml
+++ b/open-interpreter/spec.yaml
@@ -37,11 +37,17 @@ permissions:
       - api.openai.com
       # Open Procedures: OI fetches task-specific best-practice snippets at runtime
       - raw.githubusercontent.com
-      - objects.githubusercontent.com
       - api.github.com
       # uv installer and releases (including Python 3.12 standalone runtime)
       - astral.sh
       - '*.astral.sh'
+      # uv's `--python 3.12` fetches a standalone Python runtime from a
+      # GitHub release (astral-sh/python-build-standalone). The redirect
+      # target isn't a fixed constant -- both of GitHub's release-asset CDN
+      # hosts are needed (confirmed against the identical gap in kernel's
+      # kit, see kernel/spec.yaml).
+      - objects.githubusercontent.com
+      - release-assets.githubusercontent.com
       # PyPI: uv installs at creation time and during code execution
       - pypi.org
       - files.pythonhosted.org

--- a/scripts/test-kit-e2e.sh
+++ b/scripts/test-kit-e2e.sh
@@ -122,13 +122,23 @@ unset probe_err
 # Lists sandbox names under $APP_NAME starting with $1, via `ls --json`
 # rather than the human table so this survives table-formatting changes.
 # `ls --json` pretty-prints (a space after the ':'), so match that loosely
-# rather than assuming compact JSON. Defined once and used at both call
-# sites below (here and in the on_exit trap) so they can't drift apart.
+# rather than assuming compact JSON. The prefix match uses a bash `case`
+# glob, not `grep "^$1"`: sbx names allow periods and plus signs
+# (tck/e2e_test.go's sandboxName), both regex metacharacters that a grep
+# anchor would misinterpret and could match sandboxes outside this kit's
+# own prefix. `*`/`?` are the only glob metacharacters and sbx names can't
+# contain them, so this is safe for every name sbx will actually accept.
+# Used only for the pre-run stale-sandbox cleanup below — the on_exit trap
+# uses the recorded name from $SBX_E2E_NAME_LOG instead (see its comment).
 list_sandboxes_matching() {
   sbx --app-name "$APP_NAME" ls --json 2>/dev/null \
     | grep -o '"name":[[:space:]]*"[^"]*"' \
     | cut -d'"' -f4 \
-    | grep "^$1"
+    | while IFS= read -r sandbox_name; do
+        case "$sandbox_name" in
+          "$1"*) printf '%s\n' "$sandbox_name" ;;
+        esac
+      done
 }
 
 # A sandbox from a previous FAILED run of this same kit is deliberately left
@@ -310,7 +320,7 @@ it was left running for further inspection:
 removes any such leftover automatically before starting.
 EOF
     else
-      echo "No sandbox name recorded — the failure happened before sbx create was even attempted." >&2
+      echo "No sandbox name recorded — either the failure happened before sbx create was attempted, or tck/e2e_test.go's createSbx couldn't write \$SBX_E2E_NAME_LOG (it ignores that error so a broken TMPDIR can't fail the test itself)." >&2
     fi
 
     cat >&2 <<EOF

--- a/scripts/test-kit-e2e.sh
+++ b/scripts/test-kit-e2e.sh
@@ -90,6 +90,13 @@ if ! command -v sbx >/dev/null 2>&1; then
   exit 1
 fi
 
+# Sandbox name prefix this run's kit will create under, matching
+# tck/e2e_test.go's sandboxName() exactly (e2e-<kit-basename>-<random>, with
+# underscores turned to hyphens since sbx names disallow them) — keep the two
+# in sync. Used below to find and clean up only this kit's own sandboxes,
+# never someone else's leftovers under the same --app-name.
+kit_sandbox_prefix="e2e-$(basename "$kit_abs" | tr '[:upper:]_' '[:lower:]-')-"
+
 # Smoke test — fail fast if the scoped daemon can't talk to the runtime.
 # The most common cause is "not logged in to Docker Hub" (sbx create then
 # fails ~minutes into the test), but the same probe also catches a dead
@@ -112,14 +119,40 @@ EOF
 }
 unset probe_err
 
+# Lists sandbox names under $APP_NAME starting with $1, via `ls --json`
+# rather than the human table so this survives table-formatting changes.
+# `ls --json` pretty-prints (a space after the ':'), so match that loosely
+# rather than assuming compact JSON. Defined once and used at both call
+# sites below (here and in the on_exit trap) so they can't drift apart.
+list_sandboxes_matching() {
+  sbx --app-name "$APP_NAME" ls --json 2>/dev/null \
+    | grep -o '"name":[[:space:]]*"[^"]*"' \
+    | cut -d'"' -f4 \
+    | grep "^$1"
+}
+
+# A sandbox from a previous FAILED run of this same kit is deliberately left
+# behind (see tck/e2e_test.go's createSbx) so its policy log survives for
+# post-mortem inspection — see the on_exit trap below. That means a stale one
+# can exist when this script starts; remove it now so it doesn't get counted
+# as "this run's" sandbox by the trap, and so it doesn't pile up indefinitely
+# across repeated local debugging iterations. Best-effort: nothing to clean
+# up is the common case, not an error.
+for stale in $(list_sandboxes_matching "$kit_sandbox_prefix"); do
+  echo "Removing stale sandbox from a previous failed run: $stale"
+  sbx --app-name "$APP_NAME" rm -f "$stale" >/dev/null 2>&1 || true
+done
+
 # Configure the scoped daemon's global network policy. `policy init` is
 # one-time per daemon (sbx errors with "already initialized" on the second
 # call), so to stay idempotent we try `init` first and fall back to
 # `reset --force` + `init` when a policy is already set — that lands the
 # scoped daemon on the desired baseline regardless of prior state. The
 # `--force` skips the confirmation prompt about stopping running sandboxes
-# (we don't keep any across runs). Skipped when POLICY is explicitly set
-# to the empty string.
+# (a stale one from a previous failed run was just removed above; a
+# currently-running sandbox here would mean a concurrent invocation, which
+# isn't a supported use of this script). Skipped when POLICY is explicitly
+# set to the empty string.
 if [ -n "$POLICY" ]; then
   echo "Initializing --app-name=$APP_NAME global policy to $POLICY"
   if ! sbx --app-name "$APP_NAME" policy init "$POLICY" >/dev/null 2>&1; then
@@ -227,22 +260,52 @@ EOF
   fi
 fi
 
-# Helper hint on failure — the most common e2e failure is a missing entry
-# in network.allowedDomains, which `sbx policy log` surfaces precisely. Wired
-# as an EXIT trap (not ERR) so the hint also fires when `set -e` aborts
-# mid-test. Only fires on non-zero exit.
+# Auto-diagnose on failure — the most common e2e failure is a missing entry
+# in network.allowedDomains, which `sbx policy log` surfaces precisely. In CI
+# the runner (and its scoped daemon) is destroyed the moment the job ends, so
+# printing instructions for a human to run afterward is useless there — by
+# the time anyone reads the log, there's nothing left to inspect. Instead,
+# run the diagnostics ourselves and print the real output, so a CI failure is
+# debuggable from the log alone.
+#
+# tck/e2e_test.go's createSbx deliberately skips its own cleanup when the
+# test fails, so the sandbox this run created is still around for exactly
+# this. Find it by name (matching kit_sandbox_prefix above) rather than
+# assuming it's the only sandbox under $APP_NAME — a from-scratch or manually
+# populated daemon could have others, and printing every one of those
+# instead of this run's own would be noise at best and misleading at worst.
+#
+# Wired as an EXIT trap (not ERR) so it also fires when `set -e` aborts
+# mid-test. Only fires on non-zero exit. Every diagnostic call is best-effort
+# (`|| true`): if the scoped daemon is itself wedged or already gone, that
+# failure must not mask the original exit code.
 on_exit() {
   rc=$?
   if [ "$rc" -ne 0 ]; then
+    echo "" >&2
+    echo "e2e test failed (exit $rc)." >&2
+
+    failed_sandboxes=$(list_sandboxes_matching "$kit_sandbox_prefix") || true
+    if [ -z "$failed_sandboxes" ]; then
+      echo "No sandbox found under --app-name=$APP_NAME matching '${kit_sandbox_prefix}*' — the failure happened before sbx create ran, or the sandbox is gone." >&2
+    else
+      for sbox in $failed_sandboxes; do
+        echo "" >&2
+        echo "Policy log for sandbox $sbox (policy: ${POLICY:-current default}):" >&2
+        sbx --app-name "$APP_NAME" policy log "$sbox" >&2 || true
+      done
+      cat >&2 <<EOF
+
+Every row under 'Blocked requests' above is a host your kit reached for. Add
+it to network.allowedDomains in spec.yaml and re-run this script.
+
+The failed sandbox above is left running for further inspection (e.g.
+'sbx --app-name $APP_NAME exec <name> -- ...'); the next run of this script
+removes it automatically before starting.
+EOF
+    fi
+
     cat >&2 <<EOF
-
-e2e test failed (exit $rc). To see which hosts the proxy blocked under '${POLICY:-current default}':
-
-  sbx --app-name $APP_NAME ls                              # find the tck-e2e-* sandbox
-  sbx --app-name $APP_NAME policy log <sandbox-name>
-
-Every row under 'Blocked requests' is a host your kit reached for. Add it
-to network.allowedDomains in spec.yaml and re-run this script.
 
 If the scoped daemon is wedged, wipe it (your main sbx is unaffected):
 

--- a/scripts/test-kit-e2e.sh
+++ b/scripts/test-kit-e2e.sh
@@ -320,7 +320,7 @@ it was left running for further inspection:
 removes any such leftover automatically before starting.
 EOF
     else
-      echo "No sandbox name recorded — either the failure happened before sbx create was attempted, or tck/e2e_test.go's createSbx couldn't write \$SBX_E2E_NAME_LOG (it ignores that error so a broken TMPDIR can't fail the test itself)." >&2
+      echo "No sandbox name recorded — either the failure happened before sbx create was attempted, or tck/e2e_test.go's createSbx couldn't write to \$SBX_E2E_NAME_LOG after this script's mktemp already succeeded (e.g. the file was removed or its permissions changed mid-run, or the disk filled up; that error is ignored so it can't fail the test itself)." >&2
     fi
 
     cat >&2 <<EOF

--- a/scripts/test-kit-e2e.sh
+++ b/scripts/test-kit-e2e.sh
@@ -268,13 +268,20 @@ fi
 # run the diagnostics ourselves and print the real output, so a CI failure is
 # debuggable from the log alone.
 #
-# tck/e2e_test.go's createSbx deliberately skips its own cleanup when the
-# test fails, so the sandbox this run created is still around for exactly
-# this. Find it by name (matching kit_sandbox_prefix above) rather than
-# assuming it's the only sandbox under $APP_NAME — a from-scratch or manually
-# populated daemon could have others, and printing every one of those
-# instead of this run's own would be noise at best and misleading at worst.
-#
+# The sandbox name isn't discovered via `sbx ls`: `sbx create` itself tears a
+# sandbox down when kit-apply/container-run fails (the most common e2e
+# failure), before this script ever gets a chance to look — `ls` would
+# already show nothing. Instead, tck/e2e_test.go's createSbx writes the name
+# it generated to $sbx_name_log as soon as it's known, before attempting
+# create at all. The daemon's policy log is independent of the sandbox
+# object's lifetime (a daemon-level log filtered by VM name), so `policy log
+# <name>` still works after that rollback as long as the name is known.
+sbx_name_log=$(mktemp "${TMPDIR:-/tmp}/sbx-e2e-name-log-XXXXXX") || {
+  echo "ERROR: could not create a temp file to record the e2e sandbox name" >&2
+  exit 1
+}
+export SBX_E2E_NAME_LOG="$sbx_name_log"
+
 # Wired as an EXIT trap (not ERR) so it also fires when `set -e` aborts
 # mid-test. Only fires on non-zero exit. Every diagnostic call is best-effort
 # (`|| true`): if the scoped daemon is itself wedged or already gone, that
@@ -285,24 +292,25 @@ on_exit() {
     echo "" >&2
     echo "e2e test failed (exit $rc)." >&2
 
-    failed_sandboxes=$(list_sandboxes_matching "$kit_sandbox_prefix") || true
-    if [ -z "$failed_sandboxes" ]; then
-      echo "No sandbox found under --app-name=$APP_NAME matching '${kit_sandbox_prefix}*' — the failure happened before sbx create ran, or the sandbox is gone." >&2
-    else
-      for sbox in $failed_sandboxes; do
+    if [ -s "$sbx_name_log" ]; then
+      while IFS= read -r sbox; do
+        [ -n "$sbox" ] || continue
         echo "" >&2
         echo "Policy log for sandbox $sbox (policy: ${POLICY:-current default}):" >&2
         sbx --app-name "$APP_NAME" policy log "$sbox" >&2 || true
-      done
+      done < "$sbx_name_log"
       cat >&2 <<EOF
 
 Every row under 'Blocked requests' above is a host your kit reached for. Add
 it to network.allowedDomains in spec.yaml and re-run this script.
 
-The failed sandbox above is left running for further inspection (e.g.
-'sbx --app-name $APP_NAME exec <name> -- ...'); the next run of this script
-removes it automatically before starting.
+If the sandbox still exists (e.g. a failure other than a rolled-back create),
+it was left running for further inspection:
+'sbx --app-name $APP_NAME exec <name> -- ...'. The next run of this script
+removes any such leftover automatically before starting.
 EOF
+    else
+      echo "No sandbox name recorded — the failure happened before sbx create was even attempted." >&2
     fi
 
     cat >&2 <<EOF
@@ -317,6 +325,7 @@ If you haven't logged in to the scoped daemon yet:
 
 EOF
   fi
+  rm -f "$sbx_name_log"
   exit "$rc"
 }
 trap on_exit EXIT

--- a/tck/e2e_test.go
+++ b/tck/e2e_test.go
@@ -379,6 +379,18 @@ func createSbx(t *testing.T, ctx context.Context, absKit, agent string, td *kitT
 	workspace := t.TempDir()
 	name := sandboxName(t, absKit)
 	t.Cleanup(func() {
+		// Leave a failed test's sandbox behind instead of removing it: it's
+		// the only post-mortem evidence of what went wrong (e.g. the policy
+		// log showing which host got blocked), and t.Cleanup runs — removing
+		// it — during the normal failure unwind of require.NoErrorf/t.Fatal,
+		// before the process ever exits. scripts/test-kit-e2e.sh's on_exit
+		// trap depends on the sandbox still existing at that point to print
+		// `sbx policy log`. The scoped --app-name daemon is torn down with
+		// the CI runner regardless, so a leaked sandbox here costs nothing.
+		if t.Failed() {
+			t.Logf("keeping sandbox %q for post-mortem: sbx --app-name sbx-kits-contrib-tck policy log %s", name, name)
+			return
+		}
 		cleanCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 		defer cancel()
 		out, err := exec.CommandContext(cleanCtx, "sbx", "--app-name", "sbx-kits-contrib-tck", "rm", "-f", name).CombinedOutput()

--- a/tck/e2e_test.go
+++ b/tck/e2e_test.go
@@ -378,15 +378,32 @@ func createSbx(t *testing.T, ctx context.Context, absKit, agent string, td *kitT
 	t.Helper()
 	workspace := t.TempDir()
 	name := sandboxName(t, absKit)
+
+	// Record the name for scripts/test-kit-e2e.sh's on_exit trap, regardless
+	// of what happens next: `sbx create` itself tears the sandbox down on a
+	// failed kit-apply/container-run (sandboxd's Provision/Run rollback) —
+	// the most common e2e failure — so by the time this test process exits,
+	// `sbx ls` may show nothing to find at all. The daemon's network/policy
+	// log is independent of the sandbox object's lifetime (it's a daemon-
+	// level log filtered by VM name, not per-sandbox state), so `sbx policy
+	// log <name>` still works after that rollback as long as the name is
+	// known — this file is the only way the wrapping shell script can learn
+	// a name generated randomly inside this process. Best-effort: a failure
+	// to record it must not fail the test itself.
+	if logPath := os.Getenv("SBX_E2E_NAME_LOG"); logPath != "" {
+		if f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644); err == nil {
+			_, _ = fmt.Fprintln(f, name)
+			_ = f.Close()
+		}
+	}
+
 	t.Cleanup(func() {
-		// Leave a failed test's sandbox behind instead of removing it: it's
-		// the only post-mortem evidence of what went wrong (e.g. the policy
-		// log showing which host got blocked), and t.Cleanup runs — removing
-		// it — during the normal failure unwind of require.NoErrorf/t.Fatal,
-		// before the process ever exits. scripts/test-kit-e2e.sh's on_exit
-		// trap depends on the sandbox still existing at that point to print
-		// `sbx policy log`. The scoped --app-name daemon is torn down with
-		// the CI runner regardless, so a leaked sandbox here costs nothing.
+		// Leave a failed test's sandbox behind instead of removing it: on
+		// any failure that does NOT already trigger sandboxd's own rollback
+		// (e.g. an assertion failing after a successful create), this is
+		// the only post-mortem evidence of what went wrong. t.Cleanup runs
+		// during the normal failure unwind of require.NoErrorf/t.Fatal,
+		// before the process ever exits.
 		if t.Failed() {
 			t.Logf("keeping sandbox %q for post-mortem: sbx --app-name sbx-kits-contrib-tck policy log %s", name, name)
 			return


### PR DESCRIPTION
## Summary

Prompted by aider's e2e failure in CI (run 32139020996), which gave no more detail than "failed to apply kit to sandbox" — no way to tell which host got blocked, since the old failure hint only printed instructions for a human to run `sbx policy log` *after the fact*, useless once the CI runner and its scoped daemon are gone.

- `scripts/test-kit-e2e.sh` now runs the diagnostics itself on failure: looks up the sandbox this run created and prints its real `sbx policy log` output directly into the CI/terminal log.
- `tck/e2e_test.go`'s `createSbx` no longer force-removes a failed test's sandbox in `t.Cleanup` — it now skips removal when `t.Failed()`, so the sandbox survives for the shell script to inspect. A stale one from a previous failed run is removed at the start of the next run, so this doesn't accumulate across local debugging iterations.

## Test plan

- [x] `go build`/`go vet` on the e2e-tagged package
- [x] `go test ./scripts/... ./tck/...`
- [ ] CI (this PR touches `scripts/` and `tck/`, so the full kit matrix runs) — expecting this to also surface aider's actual failure with the new diagnostics