### PR TITLE
docs: strip `$ ` prompt prefixes from console code blocks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,10 +51,10 @@ See [Declare every domain your kit needs](./README.md#declare-every-domain-your-
 Before opening a PR, run **all four** of these:
 
 ```console
-$ sbx kit validate ./my-kit/
-$ cd my-kit && ../scripts/test-kit.sh
-$ ../scripts/test-kit-e2e.sh           # under deny-all — see below
-$ sbx run --kit . <agent>              # quick manual smoke
+sbx kit validate ./my-kit/
+cd my-kit && ../scripts/test-kit.sh
+../scripts/test-kit-e2e.sh           # under deny-all — see below
+sbx run --kit . <agent>              # quick manual smoke
 ```
 
 The first two are what CI runs on every PR. **The third is not run on CI for PRs opened from a fork** — the CI e2e legs (`e2e-release`, which gates the PR, and the informational `e2e-nightly`) need `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN`, and GitHub doesn't expose secrets to fork-triggered workflows, so they are skipped silently and the reviewer sees a green check that does **not** include the e2e assertions. If you're contributing from a fork (the common case), your laptop is the only place those assertions ever run before merge.
@@ -66,7 +66,7 @@ The first two are what CI runs on every PR. **The third is not run on CI for PRs
 The wrapper script does the dance for you:
 
 ```console
-$ cd my-kit && ../scripts/test-kit-e2e.sh
+cd my-kit && ../scripts/test-kit-e2e.sh
 ```
 
 That single command:
@@ -80,14 +80,14 @@ The script is idempotent (re-runs converge on the same state) and non-interactiv
 One-time setup per machine — the scoped daemon has its own credential store, separate from any login on your main daemon:
 
 ```console
-$ sbx --app-name sbx-kits-contrib-tck login
+sbx --app-name sbx-kits-contrib-tck login
 ```
 
 When the test fails, the script prints how to dump the proxy log. The recurring fix is the same loop: read the log, add the blocked host to `network.allowedDomains`, re-run.
 
 ```console
-$ sbx --app-name sbx-kits-contrib-tck ls                          # find the tck-e2e-* sandbox
-$ sbx --app-name sbx-kits-contrib-tck policy log <sandbox-name>
+sbx --app-name sbx-kits-contrib-tck ls                          # find the tck-e2e-* sandbox
+sbx --app-name sbx-kits-contrib-tck policy log <sandbox-name>
 ```
 
 Every row under `Blocked requests` is a host your kit reached for under `deny-all`. See [Declare every domain your kit needs](./README.md#declare-every-domain-your-kit-needs) for the cross-arch gotchas (`archive.ubuntu.com`, `security.ubuntu.com`, **and** `ports.ubuntu.com`) and the package-manager refresh trap (`apt-get update` re-fetches every configured source).

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -26,7 +26,7 @@ a table, so it binds new kits automatically and has nothing to keep in sync. Run
 it yourself with:
 
 ```console
-$ ./scripts/check-image-ref.sh docker.io/sbx latest
+./scripts/check-image-ref.sh docker.io/sbx latest
 ```
 
 `spec.yaml`'s `sandbox.image` is the **source of truth** for what gets

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ Kits are passed to `sbx run` (or `sbx create`) via `--kit`. The flag accepts an 
 The primary way to consume a kit from this repo is its published OCI artifact on Docker Hub — every kit here is discovered and published automatically (see [`PUBLISHING.md`](./PUBLISHING.md)), so the artifact exists the moment a change merges to `main`:
 
 ```console
-$ sbx run --kit "docker.io/sbx/code-server-kit:latest" claude
+sbx run --kit "docker.io/sbx/code-server-kit:latest" claude
 ```
 
 Or target this repo directly over git:
 
 ```console
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=code-server" claude
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=code-server" claude
 ```
 
 The fragment after `#` accepts two parameters, both optional:
@@ -51,13 +51,13 @@ Combine them with `&`:
 
 ```console
 # Pin to a tag — the recommended form for production use
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#ref=v0.2.0&dir=code-server" claude
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#ref=v0.2.0&dir=code-server" claude
 
 # Track a branch (less stable; the kit may change under you)
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#ref=main&dir=code-server" claude
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#ref=main&dir=code-server" claude
 
 # Pin to an exact commit SHA — fully reproducible
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#ref=abc1234&dir=code-server" claude
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#ref=abc1234&dir=code-server" claude
 ```
 
 Without `ref`, sbx clones the default branch shallowly. With a branch or tag, sbx clones at that ref shallowly. With a commit SHA, sbx clones fully and checks out the commit.
@@ -65,13 +65,13 @@ Without `ref`, sbx clones the default branch shallowly. With a branch or tag, sb
 You can also use SSH instead of HTTPS for private repos:
 
 ```console
-$ sbx run --kit "git+ssh://git@github.com/docker/sbx-kits-contrib.git#dir=code-server" claude
+sbx run --kit "git+ssh://git@github.com/docker/sbx-kits-contrib.git#dir=code-server" claude
 ```
 
 For local development, point `--kit` at a directory:
 
 ```console
-$ sbx run --kit ./code-server/ claude
+sbx run --kit ./code-server/ claude
 ```
 
 ## Repository Structure

--- a/aider/README.md
+++ b/aider/README.md
@@ -22,7 +22,7 @@ provider's credential (or reuses one you've already stored). You can also set it
 up ahead of time:
 
 ```console
-$ sbx secret set anthropic   # or: openai, gemini
+sbx secret set anthropic   # or: openai, gemini
 ```
 
 To use OpenAI or Gemini instead of the default (Anthropic), pass Aider's own
@@ -31,26 +31,26 @@ To use OpenAI or Gemini instead of the default (Anthropic), pass Aider's own
 flag instead):
 
 ```console
-$ sbx run --kit "docker.io/sbx/aider-kit:latest" aider -- --model gpt-4o
-$ sbx run --kit "docker.io/sbx/aider-kit:latest" aider -- --model gemini/gemini-2.5-pro
+sbx run --kit "docker.io/sbx/aider-kit:latest" aider -- --model gpt-4o
+sbx run --kit "docker.io/sbx/aider-kit:latest" aider -- --model gemini/gemini-2.5-pro
 ```
 
 ## Usage
 
 ```console
-$ sbx run --kit "docker.io/sbx/aider-kit:latest" aider
+sbx run --kit "docker.io/sbx/aider-kit:latest" aider
 ```
 
 Or from a git URL targeting this repo:
 
 ```console
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=aider" aider
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=aider" aider
 ```
 
 Or with a local clone:
 
 ```console
-$ sbx run --kit ./aider/ aider
+sbx run --kit ./aider/ aider
 ```
 
 The first launch installs Aider (~2 minutes — uv downloads a Python 3.12
@@ -87,9 +87,9 @@ to override a kit's `environment.variables` at run time. Use Aider's own
 `--model` flag instead, passed after `--`:
 
 ```console
-$ sbx run aider -- --model opus
-$ sbx run aider -- --model o3-mini
-$ sbx run aider -- --model deepseek/deepseek-chat
+sbx run aider -- --model opus
+sbx run aider -- --model o3-mini
+sbx run aider -- --model deepseek/deepseek-chat
 ```
 
 For a full list of supported models and aliases, run `aider --list-models` inside
@@ -119,7 +119,7 @@ To give Aider project-specific style rules or context, create a `CONVENTIONS.md`
 in your repo and pass it at launch:
 
 ```console
-$ sbx run aider -- --read CONVENTIONS.md
+sbx run aider -- --read CONVENTIONS.md
 ```
 
 Or set it permanently in your project's `.aider.conf.yml`:
@@ -134,13 +134,13 @@ read:
 To remove stored secrets:
 
 ```console
-$ sbx secret rm anthropic
-$ sbx secret rm openai    # if set
-$ sbx secret rm gemini    # if set
+sbx secret rm anthropic
+sbx secret rm openai    # if set
+sbx secret rm gemini    # if set
 ```
 
 To remove the sandbox:
 
 ```console
-$ sbx rm aider
+sbx rm aider
 ```

--- a/amp/README.md
+++ b/amp/README.md
@@ -24,7 +24,7 @@ stores the value in the host secret store and exposes a placeholder
 inside every sandbox launched from this kit:
 
 ```console
-$ sbx secret set-custom -g \
+sbx secret set-custom -g \
     --host ampcode.com \
     --env AMP_API_KEY \
     --placeholder "sgamp-{rand}" \
@@ -47,19 +47,19 @@ Run the kit. Pass the kit's name (`amp`) as the agent argument. The primary
 form is its published OCI artifact on Docker Hub:
 
 ```console
-$ sbx run --kit "docker.io/sbx/amp-kit:latest" amp
+sbx run --kit "docker.io/sbx/amp-kit:latest" amp
 ```
 
 Or from a git URL targeting this repo:
 
 ```console
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=amp" amp
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=amp" amp
 ```
 
 Or with a local clone of this repo:
 
 ```console
-$ sbx run --kit ./amp/ amp
+sbx run --kit ./amp/ amp
 ```
 
 The first launch installs Amp via its `curl | bash` script and applies
@@ -92,7 +92,7 @@ To remove the entry created by `set-custom`, pass the host to
 `sbx secret rm`:
 
 ```console
-$ sbx secret rm -g --host ampcode.com
+sbx secret rm -g --host ampcode.com
 ```
 
 The `--host` flag on `sbx secret rm` isn't listed in

--- a/claude-acp/README.md
+++ b/claude-acp/README.md
@@ -15,13 +15,13 @@ For non-interactive API-key auth, seed the Anthropic credential with `sbx`
 before creating the sandbox:
 
 ```console
-$ echo "$ANTHROPIC_API_KEY" | sbx secret set -g anthropic
+echo "$ANTHROPIC_API_KEY" | sbx secret set -g anthropic
 ```
 
 You can also import a detected host environment variable:
 
 ```console
-$ sbx secret import anthropic
+sbx secret import anthropic
 ```
 
 For Claude subscription or console login, the Claude ACP adapter advertises
@@ -40,19 +40,19 @@ the sandbox so the built-in `claude` kit can refresh its Claude settings.
 Create a sandbox from its published OCI artifact on Docker Hub:
 
 ```console
-$ sbx create --kit "docker.io/sbx/claude-acp-kit:latest" --name my-task claude /path/to/task
+sbx create --kit "docker.io/sbx/claude-acp-kit:latest" --name my-task claude /path/to/task
 ```
 
 Or from a git URL targeting this repo:
 
 ```console
-$ sbx create --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=claude-acp" --name my-task claude /path/to/task
+sbx create --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=claude-acp" --name my-task claude /path/to/task
 ```
 
 Run the adapter over stdio:
 
 ```console
-$ sbx exec -i my-task /home/agent/.local/bin/claude-acp
+sbx exec -i my-task /home/agent/.local/bin/claude-acp
 ```
 
 Do not allocate a TTY for ACP sessions; the adapter expects newline-delimited

--- a/claude-model-runner/README.md
+++ b/claude-model-runner/README.md
@@ -21,14 +21,14 @@ cost-free experimentation, or testing custom local models with Claude Code.
 ## Usage
 
 ```console
-$ sbx run --kit "docker.io/sbx/claude-model-runner-kit:latest" claude ~/my-project
+sbx run --kit "docker.io/sbx/claude-model-runner-kit:latest" claude ~/my-project
 ```
 
 Or from a git URL or a local clone of this repo:
 
 ```console
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=claude-model-runner" claude ~/my-project
-$ sbx run --kit ./claude-model-runner/ claude ~/my-project
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=claude-model-runner" claude ~/my-project
+sbx run --kit ./claude-model-runner/ claude ~/my-project
 ```
 
 The agent name passed to `sbx run` (`claude`) is the base agent the mixin
@@ -40,17 +40,17 @@ directory, change the anchored value at `&model "gpt-oss"`, and pass
 `--kit` at that path:
 
 ```console
-$ mkdir claude-model-runner
-$ curl -o claude-model-runner/spec.yaml \
+mkdir claude-model-runner
+curl -o claude-model-runner/spec.yaml \
     https://raw.githubusercontent.com/docker/sbx-kits-contrib/main/claude-model-runner/spec.yaml
-$ # edit `&model "gpt-oss"` in claude-model-runner/spec.yaml
-$ sbx run --kit ./claude-model-runner claude ~/my-project
+# edit `&model "gpt-oss"` in claude-model-runner/spec.yaml
+sbx run --kit ./claude-model-runner claude ~/my-project
 ```
 
 For a larger context window than the default, package a variant first:
 
 ```console
-$ docker model package --from gpt-oss --context-size 32000 gpt-oss:32k
+docker model package --from gpt-oss --context-size 32000 gpt-oss:32k
 ```
 
 then point the anchored value at `gpt-oss:32k`.

--- a/claude-ollama/README.md
+++ b/claude-ollama/README.md
@@ -16,14 +16,14 @@ offline development, cost-free experimentation, or testing with custom local mod
 ## Usage
 
 ```console
-$ sbx run --kit "docker.io/sbx/claude-ollama-kit:latest" claude-ollama ~/my-project
+sbx run --kit "docker.io/sbx/claude-ollama-kit:latest" claude-ollama ~/my-project
 ```
 
 Or from a git URL or a local clone of this repo:
 
 ```console
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=claude-ollama" claude-ollama ~/my-project
-$ sbx run --kit ./claude-ollama/ claude-ollama ~/my-project
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=claude-ollama" claude-ollama ~/my-project
+sbx run --kit ./claude-ollama/ claude-ollama ~/my-project
 ```
 
 The agent name passed to `sbx run` (`claude-ollama`) matches the `name:` field in

--- a/claude-sbx-statusline/README.md
+++ b/claude-sbx-statusline/README.md
@@ -31,19 +31,19 @@ it reflects the sandbox's allocation, not the host's.
 Pair the mixin with the `claude` agent via `--kit`, from its published OCI artifact on Docker Hub:
 
 ```console
-$ sbx run claude --kit "docker.io/sbx/claude-sbx-statusline-kit:latest" .
+sbx run claude --kit "docker.io/sbx/claude-sbx-statusline-kit:latest" .
 ```
 
 Or pull it straight from this repo over git (pinned by ref):
 
 ```console
-$ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=claude-sbx-statusline" .
+sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=claude-sbx-statusline" .
 ```
 
 Or with a local clone of this repo:
 
 ```console
-$ sbx run claude --kit ./claude-sbx-statusline .
+sbx run claude --kit ./claude-sbx-statusline .
 ```
 
 ## How it works

--- a/code-server/README.md
+++ b/code-server/README.md
@@ -15,19 +15,19 @@ CLI agent.
 Pair it with the built-in `claude` agent, from its published OCI artifact on Docker Hub:
 
 ```console
-$ sbx run claude --kit "docker.io/sbx/code-server-kit:latest" ~/my-project
+sbx run claude --kit "docker.io/sbx/code-server-kit:latest" ~/my-project
 ```
 
 Or from a git URL targeting this repo:
 
 ```console
-$ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=code-server" ~/my-project
+sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=code-server" ~/my-project
 ```
 
 Once the sandbox is up, find the assigned host port:
 
 ```console
-$ sbx ports <sandbox-name>
+sbx ports <sandbox-name>
 ```
 
 Open `http://localhost:<host-port>/` in a browser. code-server opens
@@ -42,7 +42,7 @@ alongside the declared ephemeral binding.
 If the page doesn't load, check the startup log inside the sandbox:
 
 ```console
-$ sbx exec -it <sandbox-name> -- cat /tmp/code-server.log
+sbx exec -it <sandbox-name> -- cat /tmp/code-server.log
 ```
 
 ## How the workspace path gets set

--- a/codex-acp/README.md
+++ b/codex-acp/README.md
@@ -15,19 +15,19 @@ non-interactive ACP adapter can start authenticated.
 For ChatGPT OAuth:
 
 ```console
-$ sbx secret set -g openai --oauth
+sbx secret set -g openai --oauth
 ```
 
 For an OpenAI API key:
 
 ```console
-$ echo "$OPENAI_API_KEY" | sbx secret set -g openai
+echo "$OPENAI_API_KEY" | sbx secret set -g openai
 ```
 
 You can also import a detected host environment variable:
 
 ```console
-$ sbx secret import openai
+sbx secret import openai
 ```
 
 The Codex ACP adapter does not advertise a terminal-auth command. Keep provider
@@ -41,19 +41,19 @@ kit can refresh its Codex auth files.
 Create a sandbox from its published OCI artifact on Docker Hub:
 
 ```console
-$ sbx create --kit "docker.io/sbx/codex-acp-kit:latest" --name my-task codex /path/to/task
+sbx create --kit "docker.io/sbx/codex-acp-kit:latest" --name my-task codex /path/to/task
 ```
 
 Or from a git URL targeting this repo:
 
 ```console
-$ sbx create --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=codex-acp" --name my-task codex /path/to/task
+sbx create --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=codex-acp" --name my-task codex /path/to/task
 ```
 
 Run the adapter over stdio:
 
 ```console
-$ sbx exec -i my-task /home/agent/.local/bin/codex-acp
+sbx exec -i my-task /home/agent/.local/bin/codex-acp
 ```
 
 Do not allocate a TTY for ACP sessions; the adapter expects newline-delimited

--- a/codex-app-server/README.md
+++ b/codex-app-server/README.md
@@ -122,7 +122,7 @@ EOF
 Then run a sandbox:
 
 ```console
-$ sbx_codex myproject ~/myproject
+sbx_codex myproject ~/myproject
 ready — add SSH Connection in Codex Mac app:  Host: myproject
 ```
 
@@ -141,18 +141,18 @@ If you'd rather not paste a function into your rc, the same logic is
 shipped as standalone scripts under `bin/`:
 
 ```console
-$ ln -s $(pwd)/bin/sbx-codex-{attach,detach} ~/.local/bin/
+ln -s $(pwd)/bin/sbx-codex-{attach,detach} ~/.local/bin/
 ```
 
 Then per sandbox:
 
 ```console
-$ sbx create --kit "docker.io/sbx/codex-app-server-kit:latest" --name myproject codex ~/myproject
+sbx create --kit "docker.io/sbx/codex-app-server-kit:latest" --name myproject codex ~/myproject
 # Or from a git URL targeting this repo:
 # $ sbx create --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=codex-app-server" --name myproject codex ~/myproject
-$ sbx-codex-attach myproject
+sbx-codex-attach myproject
 # … later, when done with the GUI integration for this sandbox …
-$ sbx-codex-detach myproject
+sbx-codex-detach myproject
 ```
 
 The first `sbx-codex-attach` run adds the `Include ~/.sbx/ssh/codex/*.conf`
@@ -220,8 +220,8 @@ before the bridge was installed (e.g. after a kit update on a
 long-lived sandbox). Kill it and let the GUI respawn:
 
 ```console
-$ sbx exec <sandbox-name> -- pkill -f 'codex app-server'
-$ sbx exec <sandbox-name> -- rm -f /home/agent/.codex/app-server-control/app-server-control.sock
+sbx exec <sandbox-name> -- pkill -f 'codex app-server'
+sbx exec <sandbox-name> -- rm -f /home/agent/.codex/app-server-control/app-server-control.sock
 ```
 
 If `sbx-codex-attach` complains about a missing tool, install it

--- a/copilot/README.md
+++ b/copilot/README.md
@@ -32,19 +32,19 @@ two credential services (`github` and `copilot`) instead of one.
 ## Usage
 
 ```console
-$ sbx run --kit "docker.io/sbx/copilot-kit:latest" copilot
+sbx run --kit "docker.io/sbx/copilot-kit:latest" copilot
 ```
 
 Or from a git URL targeting this repo:
 
 ```console
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=copilot" copilot
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=copilot" copilot
 ```
 
 Or with a local clone of this repo:
 
 ```console
-$ sbx run --kit ./copilot/ copilot
+sbx run --kit ./copilot/ copilot
 ```
 
 The trailing `copilot` is required, not redundant: for `kind: sandbox` kits,
@@ -134,7 +134,7 @@ parts are below.
 ### Building locally
 
 ```console
-$ docker build -t docker.io/sbx/copilot-image:latest copilot
+docker build -t docker.io/sbx/copilot-image:latest copilot
 ```
 
 `BASE_IMAGE` is a build arg, so the base can be re-pointed or digest-pinned

--- a/crush/README.md
+++ b/crush/README.md
@@ -31,19 +31,19 @@ You only need keys for the providers you intend to use.
 ## Usage
 
 ```console
-$ sbx run --kit "docker.io/sbx/crush-kit:latest" crush
+sbx run --kit "docker.io/sbx/crush-kit:latest" crush
 ```
 
 Or from a git URL targeting this repo:
 
 ```console
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=crush" crush
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=crush" crush
 ```
 
 Or with a local clone of this repo:
 
 ```console
-$ sbx run --kit ./crush/ crush
+sbx run --kit ./crush/ crush
 ```
 
 The first launch installs Crush via the Charm apt repository and applies

--- a/droid/README.md
+++ b/droid/README.md
@@ -25,19 +25,19 @@ Either of these works — you do not need both:
 ## Usage
 
 ```console
-$ sbx run --kit "docker.io/sbx/droid-kit:latest" droid
+sbx run --kit "docker.io/sbx/droid-kit:latest" droid
 ```
 
 Or from a git URL targeting this repo:
 
 ```console
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=droid" droid
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=droid" droid
 ```
 
 Or with a local clone of this repo:
 
 ```console
-$ sbx run --kit ./droid/ droid
+sbx run --kit ./droid/ droid
 ```
 
 The trailing `droid` is required, not redundant: for `kind: sandbox` kits,
@@ -133,7 +133,7 @@ are below.
 ### Building locally
 
 ```console
-$ docker build -t docker.io/sbx/droid-image:latest droid
+docker build -t docker.io/sbx/droid-image:latest droid
 ```
 
 `BASE_IMAGE` is a build arg, so the base can be re-pointed or digest-pinned

--- a/git-ssh-sign/README.md
+++ b/git-ssh-sign/README.md
@@ -14,25 +14,25 @@ for the underlying mechanism this kit builds on.
 On the host, load your SSH key into the agent:
 
 ```console
-$ ssh-add ~/.ssh/id_ed25519
+ssh-add ~/.ssh/id_ed25519
 ```
 
 Then start the sandbox with the kit attached, from its published OCI artifact on Docker Hub:
 
 ```console
-$ sbx run claude --kit "docker.io/sbx/git-ssh-sign-kit:latest" ~/my-project
+sbx run claude --kit "docker.io/sbx/git-ssh-sign-kit:latest" ~/my-project
 ```
 
 Or from a git URL targeting this repo:
 
 ```console
-$ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=git-ssh-sign" ~/my-project
+sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=git-ssh-sign" ~/my-project
 ```
 
 Inside the sandbox, verify that the forwarded agent exposes your key:
 
 ```console
-$ ssh-add -L
+ssh-add -L
 ssh-ed25519 AAAA... you@example.com
 ```
 
@@ -43,7 +43,7 @@ if no key is available.
 ## Verifying
 
 ```console
-$ git log --show-signature -1
+git log --show-signature -1
 commit abc1234...
 Good "git" signature for you@example.com with ED25519 key SHA256:...
 ```
@@ -91,7 +91,7 @@ To also enable SSH push/pull to GitHub from the sandbox, combine this kit
 with [github-ssh](../github-ssh/):
 
 ```console
-$ sbx run \
+sbx run \
   --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=git-ssh-sign" \
   --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=github-ssh" \
   claude

--- a/github-ssh/README.md
+++ b/github-ssh/README.md
@@ -12,13 +12,13 @@ Your SSH key must be loaded in the agent on the host and registered with your
 GitHub account. Start the sandbox with this kit attached, from its published OCI artifact on Docker Hub:
 
 ```console
-$ sbx run --kit "docker.io/sbx/github-ssh-kit:latest" claude
+sbx run --kit "docker.io/sbx/github-ssh-kit:latest" claude
 ```
 
 Or from a git URL targeting this repo:
 
 ```console
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=github-ssh" claude
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=github-ssh" claude
 ```
 
 ## Usage
@@ -27,8 +27,8 @@ Once the kit is installed, SSH operations to GitHub work without any
 additional configuration:
 
 ```console
-$ git clone git@github.com:org/repo.git
-$ git push origin my-branch
+git clone git@github.com:org/repo.git
+git push origin my-branch
 ```
 
 ## Composing with git-ssh-sign
@@ -37,7 +37,7 @@ If you also want SSH commit signing, combine this kit with
 [git-ssh-sign](../git-ssh-sign/):
 
 ```console
-$ sbx run \
+sbx run \
   --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=github-ssh" \
   --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=git-ssh-sign" \
   claude

--- a/hermes-agent/README.md
+++ b/hermes-agent/README.md
@@ -24,7 +24,7 @@ in the host secret store and never enters the sandbox directly.
 ### Anthropic
 
 ```console
-$ sbx secret set-custom -g \
+sbx secret set-custom -g \
     --host api.anthropic.com \
     --env ANTHROPIC_API_KEY \
     --placeholder "sk-ant-{rand}" \
@@ -34,7 +34,7 @@ $ sbx secret set-custom -g \
 ### OpenAI
 
 ```console
-$ sbx secret set-custom -g \
+sbx secret set-custom -g \
     --host api.openai.com \
     --env OPENAI_API_KEY \
     --placeholder "sk-{rand}" \
@@ -44,7 +44,7 @@ $ sbx secret set-custom -g \
 ### OpenRouter (200+ models)
 
 ```console
-$ sbx secret set-custom -g \
+sbx secret set-custom -g \
     --host openrouter.ai \
     --env OPENROUTER_API_KEY \
     --placeholder "sk-or-{rand}" \
@@ -54,19 +54,19 @@ $ sbx secret set-custom -g \
 ## Usage
 
 ```console
-$ sbx run --kit "docker.io/sbx/hermes-agent-kit:latest" hermes-agent
+sbx run --kit "docker.io/sbx/hermes-agent-kit:latest" hermes-agent
 ```
 
 Or from a git URL targeting this repo:
 
 ```console
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=hermes-agent" hermes-agent
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=hermes-agent" hermes-agent
 ```
 
 Or with a local clone of this repo:
 
 ```console
-$ sbx run --kit ./hermes-agent/ hermes-agent
+sbx run --kit ./hermes-agent/ hermes-agent
 ```
 
 Once inside the agent, use `hermes model` to choose a provider and model, then
@@ -99,7 +99,7 @@ file `~/.hermes-installed` is written on success. The entrypoint at
 ## Removing stored secrets
 
 ```console
-$ sbx secret rm -g --host api.anthropic.com
-$ sbx secret rm -g --host api.openai.com
-$ sbx secret rm -g --host openrouter.ai
+sbx secret rm -g --host api.anthropic.com
+sbx secret rm -g --host api.openai.com
+sbx secret rm -g --host openrouter.ai
 ```

--- a/junie/README.md
+++ b/junie/README.md
@@ -32,19 +32,19 @@ Run the kit. Pass the kit's name (`junie`) as the agent argument. The primary
 form is its published OCI artifact on Docker Hub:
 
 ```console
-$ sbx run --kit "docker.io/sbx/junie-kit:latest" junie
+sbx run --kit "docker.io/sbx/junie-kit:latest" junie
 ```
 
 Or from a git URL targeting this repo:
 
 ```console
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=junie" junie
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=junie" junie
 ```
 
 Or with a local clone of this repo:
 
 ```console
-$ sbx run --kit ./junie/ junie
+sbx run --kit ./junie/ junie
 ```
 
 The first launch installs Junie via its official install script. Subsequent launches reuse the sandbox.

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -21,23 +21,23 @@ managed auth, and live session replay built in.
 ## Usage
 
 ```console
-$ sbx run claude --kit "docker.io/sbx/kernel-kit:latest"
+sbx run claude --kit "docker.io/sbx/kernel-kit:latest"
 ```
 
 Or from a git URL targeting this repo:
 
 ```console
 # From this repo (tracks default branch)
-$ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=kernel"
+sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=kernel"
 
 # Pinned to a tag — recommended for production
-$ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#ref=v1.0.0&dir=kernel"
+sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#ref=v1.0.0&dir=kernel"
 
 # Local development
-$ sbx run claude --kit ./kernel/
+sbx run claude --kit ./kernel/
 
 # Stack with another mixin
-$ sbx run claude --kit ./kernel/ --kit ./ruff-lint/
+sbx run claude --kit ./kernel/ --kit ./ruff-lint/
 ```
 
 The kit works with any agent that ships npm. It installs the `kernel` CLI

--- a/kiro/README.md
+++ b/kiro/README.md
@@ -18,19 +18,19 @@ authenticates only via device flow, which needs a browser on your host.
 ## Usage
 
 ```console
-$ sbx run --kit "docker.io/sbx/kiro-kit:latest" kiro
+sbx run --kit "docker.io/sbx/kiro-kit:latest" kiro
 ```
 
 Or from a git URL targeting this repo:
 
 ```console
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=kiro" kiro
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=kiro" kiro
 ```
 
 Or with a local clone of this repo:
 
 ```console
-$ sbx run --kit ./kiro/ kiro
+sbx run --kit ./kiro/ kiro
 ```
 
 The trailing `kiro` is required, not redundant: for `kind: sandbox` kits, `sbx`
@@ -52,7 +52,7 @@ sandbox, so it survives restarts of the same sandbox but not recreation.
 To re-run the login explicitly:
 
 ```console
-$ sbx run --kit ./kiro/ kiro --name <sandbox-name> -- login --use-device-flow
+sbx run --kit ./kiro/ kiro --name <sandbox-name> -- login --use-device-flow
 ```
 
 ## Passing arguments
@@ -135,7 +135,7 @@ sample. It also catches drift in the floating base image.
 ### Building locally
 
 ```console
-$ docker build -t docker.io/sbx/kiro-image:latest kiro
+docker build -t docker.io/sbx/kiro-image:latest kiro
 ```
 
 The build needs egress to `cli.kiro.dev` (install script) **and**

--- a/mise/README.md
+++ b/mise/README.md
@@ -10,14 +10,14 @@ agent can resolve and install per-project tool versions from
 `mise` is agent-agnostic — pair it with whichever agent you're using:
 
 ```console
-$ sbx run claude --kit "docker.io/sbx/mise-kit:latest" ~/my-project
+sbx run claude --kit "docker.io/sbx/mise-kit:latest" ~/my-project
 ```
 
 Or from a git URL targeting this repo:
 
 ```console
-$ sbx run shell --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=mise" ~/my-project
-$ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=mise" ~/my-project
+sbx run shell --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=mise" ~/my-project
+sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=mise" ~/my-project
 ```
 
 Once attached, any interactive shell has `mise` on PATH and shell hooks

--- a/nanobot/README.md
+++ b/nanobot/README.md
@@ -12,19 +12,19 @@ attach.
 ## Usage
 
 ```console
-$ sbx run --kit "docker.io/sbx/nanobot-kit:latest" nanobot
+sbx run --kit "docker.io/sbx/nanobot-kit:latest" nanobot
 ```
 
 Or from a git URL targeting this repo:
 
 ```console
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=nanobot" nanobot
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=nanobot" nanobot
 ```
 
 Or with a local clone of this repo:
 
 ```console
-$ sbx run --kit ./nanobot/ nanobot
+sbx run --kit ./nanobot/ nanobot
 ```
 
 The first launch installs nanobot via `pip install nanobot-ai` and
@@ -37,7 +37,7 @@ If you need the upstream onboarding flow (creates `SOUL.md`,
 from another terminal and run:
 
 ```console
-$ nanobot onboard
+nanobot onboard
 ```
 
 Nanobot's "Next steps" output mentions OpenRouter — that message is

--- a/nanoclaw/README.md
+++ b/nanoclaw/README.md
@@ -12,19 +12,19 @@ starting OneCLI/Postgres, and walking through NanoClaw setup.
 ## Usage
 
 ```console
-$ sbx run --name nanoclaw --kit "docker.io/sbx/nanoclaw-kit:latest" nanoclaw
+sbx run --name nanoclaw --kit "docker.io/sbx/nanoclaw-kit:latest" nanoclaw
 ```
 
 Or from a git URL targeting this repository:
 
 ```console
-$ sbx run --name nanoclaw --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=nanoclaw" nanoclaw
+sbx run --name nanoclaw --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=nanoclaw" nanoclaw
 ```
 
 Or with a local clone of this repository:
 
 ```console
-$ sbx run --name nanoclaw --kit ./nanoclaw nanoclaw
+sbx run --name nanoclaw --kit ./nanoclaw nanoclaw
 ```
 
 The `--name nanoclaw` flag gives the sandbox a stable name for follow-up
@@ -59,7 +59,7 @@ To customize NanoClaw after setup, keep the original sandbox session open and
 open Claude Code in a second terminal:
 
 ```console
-$ sbx exec -it -w /home/agent/nanoclaw nanoclaw claude
+sbx exec -it -w /home/agent/nanoclaw nanoclaw claude
 ```
 
 From there, use NanoClaw skills such as `/add-telegram`, `/add-slack`,
@@ -74,7 +74,7 @@ with `502 Bad Gateway`, it may be blocked by the sandbox network policy.
 Inspect the active policy from the host:
 
 ```console
-$ sbx policy ls nanoclaw --type network
+sbx policy ls nanoclaw --type network
 ```
 
 The OneCLI dashboard and gateway are published by the sandbox. Use the port

--- a/neovim/README.md
+++ b/neovim/README.md
@@ -7,14 +7,14 @@ A mixin that installs the latest stable [Neovim](https://neovim.io) release and 
 Pair with any agent. The primary form is its published OCI artifact on Docker Hub:
 
 ```console
-$ sbx run claude --kit "docker.io/sbx/neovim-kit:latest" ~/my-project
+sbx run claude --kit "docker.io/sbx/neovim-kit:latest" ~/my-project
 ```
 
 Or from a git URL targeting this repo:
 
 ```console
-$ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=neovim" ~/my-project
-$ sbx run shell  --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=neovim" ~/my-project
+sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=neovim" ~/my-project
+sbx run shell  --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=neovim" ~/my-project
 ```
 
 ## Bringing your own config

--- a/open-interpreter/README.md
+++ b/open-interpreter/README.md
@@ -28,20 +28,20 @@ are present on the host — the real values never enter the sandbox.
 ## Usage
 
 ```console
-$ sbx run --kit "docker.io/sbx/open-interpreter-kit:latest" open-interpreter
+sbx run --kit "docker.io/sbx/open-interpreter-kit:latest" open-interpreter
 ```
 
 Or from a git URL targeting this repo:
 
 ```console
 # From this repo (tracks default branch)
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=open-interpreter" open-interpreter
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=open-interpreter" open-interpreter
 
 # Pinned to a tag
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#ref=v1.0.0&dir=open-interpreter" open-interpreter
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#ref=v1.0.0&dir=open-interpreter" open-interpreter
 
 # Local development
-$ sbx run --kit ./open-interpreter/ open-interpreter
+sbx run --kit ./open-interpreter/ open-interpreter
 ```
 
 You attach directly to the Open Interpreter REPL. Type a natural language request
@@ -58,10 +58,10 @@ The default profile sets `model: gpt-4o`. Override at launch:
 
 ```console
 # Use Claude (requires ANTHROPIC_API_KEY)
-$ sbx run --kit ./open-interpreter/ open-interpreter -- --model claude-3-5-sonnet-20241022
+sbx run --kit ./open-interpreter/ open-interpreter -- --model claude-3-5-sonnet-20241022
 
 # Use a local Ollama model (no API key needed)
-$ sbx run --kit ./open-interpreter/ open-interpreter -- --model ollama/llama3
+sbx run --kit ./open-interpreter/ open-interpreter -- --model ollama/llama3
 
 # Or update ~/.config/open-interpreter/profiles/default.yaml inside the sandbox
 ```

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -14,13 +14,13 @@ applies policy, so a new sandbox is chatting in seconds.
 ## Usage
 
 ```console
-$ sbx run --kit "docker.io/sbx/openclaw-kit:latest" openclaw
+sbx run --kit "docker.io/sbx/openclaw-kit:latest" openclaw
 ```
 
 Or from a git URL targeting this repo:
 
 ```console
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=openclaw" openclaw
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=openclaw" openclaw
 ```
 
 On attach, the entrypoint starts the gateway in the background, waits for
@@ -88,8 +88,8 @@ Upstream versions are date-based and release ~daily; bump
 ### Building locally
 
 ```console
-$ docker build -t docker.io/sbx/openclaw-image:latest openclaw
-$ ./scripts/test-kit.sh openclaw
+docker build -t docker.io/sbx/openclaw-image:latest openclaw
+./scripts/test-kit.sh openclaw
 ```
 
 `scripts/test-kit.sh` builds the kit's own image before running the suite
@@ -98,9 +98,9 @@ $ ./scripts/test-kit.sh openclaw
 ## Debugging
 
 ```console
-$ sbx exec <sandbox> -- tail -f /home/agent/.openclaw/gateway.log
-$ sbx exec <sandbox> -- curl -s http://127.0.0.1:18789/healthz
-$ sbx exec <sandbox> -- openclaw doctor
+sbx exec <sandbox> -- tail -f /home/agent/.openclaw/gateway.log
+sbx exec <sandbox> -- curl -s http://127.0.0.1:18789/healthz
+sbx exec <sandbox> -- openclaw doctor
 ```
 
 See [`docs/recipe-prebaked-image-kit.md`](../docs/recipe-prebaked-image-kit.md)

--- a/opencode-model-runner/README.md
+++ b/opencode-model-runner/README.md
@@ -21,14 +21,14 @@ cost-free experimentation, or testing custom local models with the OpenCode UI.
 ## Usage
 
 ```console
-$ sbx run --kit "docker.io/sbx/opencode-model-runner-kit:latest" opencode-model-runner ~/my-project
+sbx run --kit "docker.io/sbx/opencode-model-runner-kit:latest" opencode-model-runner ~/my-project
 ```
 
 Or from a git URL or a local clone of this repo:
 
 ```console
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=opencode-model-runner" opencode-model-runner ~/my-project
-$ sbx run --kit ./opencode-model-runner/ opencode-model-runner ~/my-project
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=opencode-model-runner" opencode-model-runner ~/my-project
+sbx run --kit ./opencode-model-runner/ opencode-model-runner ~/my-project
 ```
 
 The agent name passed to `sbx run` (`opencode-model-runner`) matches the

--- a/openhands/README.md
+++ b/openhands/README.md
@@ -27,7 +27,7 @@ provider's credential (or reuses one you've already stored). You can also set it
 up ahead of time:
 
 ```console
-$ sbx secret set anthropic   # or: openai, google
+sbx secret set anthropic   # or: openai, google
 ```
 
 To use OpenAI or Gemini instead of the default (Anthropic): there's no supported
@@ -37,9 +37,9 @@ has no `--model` flag either. Once attached, edit the seeded
 the sandbox:
 
 ```console
-$ sbx run --kit "docker.io/sbx/openhands-kit:latest" openhands
+sbx run --kit "docker.io/sbx/openhands-kit:latest" openhands
 # inside the sandbox:
-$ vi ~/.openhands/settings.json   # set llm_config.model to e.g. "openai/gpt-4o"
+vi ~/.openhands/settings.json   # set llm_config.model to e.g. "openai/gpt-4o"
 ```
 
 ### Optional: Tavily web search
@@ -49,7 +49,7 @@ there's no automatic proxy injection for it — register the raw key as a custom
 secret instead:
 
 ```console
-$ sbx secret set-custom -g \
+sbx secret set-custom -g \
     --host api.tavily.com \
     --env TAVILY_API_KEY \
     --placeholder "tvly-{rand}" \
@@ -63,19 +63,19 @@ $ sbx secret set-custom -g \
 ## Usage
 
 ```console
-$ sbx run --kit "docker.io/sbx/openhands-kit:latest" openhands
+sbx run --kit "docker.io/sbx/openhands-kit:latest" openhands
 ```
 
 Or from a git URL targeting this repo:
 
 ```console
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=openhands" openhands
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=openhands" openhands
 ```
 
 Or with a local clone:
 
 ```console
-$ sbx run --kit ./openhands/ openhands
+sbx run --kit ./openhands/ openhands
 ```
 
 The first launch installs OpenHands (takes ~2 minutes; subsequent starts reuse the
@@ -122,7 +122,7 @@ run time. Once attached, edit `~/.openhands/settings.json`'s `llm_config.model`
 and restart OpenHands:
 
 ```console
-$ vi ~/.openhands/settings.json   # set llm_config.model to e.g. "anthropic/claude-sonnet-4-5"
+vi ~/.openhands/settings.json   # set llm_config.model to e.g. "anthropic/claude-sonnet-4-5"
 ```
 
 ## Cleanup
@@ -130,14 +130,14 @@ $ vi ~/.openhands/settings.json   # set llm_config.model to e.g. "anthropic/clau
 To remove stored secrets:
 
 ```console
-$ sbx secret rm -g --host api.anthropic.com
-$ sbx secret rm -g --host api.openai.com    # if set
-$ sbx secret rm -g --host generativelanguage.googleapis.com  # if set
-$ sbx secret rm -g --host api.tavily.com    # if set
+sbx secret rm -g --host api.anthropic.com
+sbx secret rm -g --host api.openai.com    # if set
+sbx secret rm -g --host generativelanguage.googleapis.com  # if set
+sbx secret rm -g --host api.tavily.com    # if set
 ```
 
 To remove the sandbox:
 
 ```console
-$ sbx rm openhands
+sbx rm openhands
 ```

--- a/packages-through-sfw/README.md
+++ b/packages-through-sfw/README.md
@@ -15,29 +15,29 @@ Enterprise or a forked kit with the right network and credential wiring.
 Run it with any agent kit or built-in agent, from its published OCI artifact on Docker Hub:
 
 ```console
-$ sbx run --kit "docker.io/sbx/packages-through-sfw-kit:latest" <agent>
+sbx run --kit "docker.io/sbx/packages-through-sfw-kit:latest" <agent>
 ```
 
 Or from a git URL targeting this repo:
 
 ```console
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=packages-through-sfw" <agent>
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=packages-through-sfw" <agent>
 ```
 
 For local development, point `--kit` at this directory:
 
 ```console
-$ sbx run --kit ./packages-through-sfw/ <agent>
+sbx run --kit ./packages-through-sfw/ <agent>
 ```
 
 After the sandbox starts, package-manager commands invoked by name are routed
 through `sfw`:
 
 ```console
-$ sfw --version
-$ npm view is-odd version
-$ python3 -m pip index versions pyfiglet
-$ pip index versions pyfiglet
+sfw --version
+npm view is-odd version
+python3 -m pip index versions pyfiglet
+pip index versions pyfiglet
 ```
 
 ## How the install works

--- a/paperclip/README.md
+++ b/paperclip/README.md
@@ -15,17 +15,17 @@ sandbox serves the web UI in seconds.
 ## Usage
 
 ```console
-$ sbx run --kit "docker.io/sbx/paperclip-kit:latest" paperclip
+sbx run --kit "docker.io/sbx/paperclip-kit:latest" paperclip
 ```
 
 Or from a git URL targeting this repo:
 
 ```console
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=paperclip" paperclip
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=paperclip" paperclip
 ```
 
 ```console
-$ sbx ports <sandbox> --publish 3100/tcp   # then open the printed host port
+sbx ports <sandbox> --publish 3100/tcp   # then open the printed host port
 ```
 
 On attach the entrypoint runs `paperclipai onboard --yes` — idempotent:
@@ -97,8 +97,8 @@ the same way it does for `kiro`/`copilot`.
 ### Building locally
 
 ```console
-$ docker build -t docker.io/sbx/paperclip-image:latest paperclip
-$ ./scripts/test-kit.sh paperclip
+docker build -t docker.io/sbx/paperclip-image:latest paperclip
+./scripts/test-kit.sh paperclip
 ```
 
 `scripts/test-kit.sh` builds the kit's own image before running the suite
@@ -111,9 +111,9 @@ $ ./scripts/test-kit.sh paperclip
 ## Debugging
 
 ```console
-$ sbx exec <sandbox> -- tail -f /home/agent/.paperclip/instances/default/logs/*.log
-$ sbx exec <sandbox> -- curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:3100/
-$ sbx exec <sandbox> -- paperclipai doctor
+sbx exec <sandbox> -- tail -f /home/agent/.paperclip/instances/default/logs/*.log
+sbx exec <sandbox> -- curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:3100/
+sbx exec <sandbox> -- paperclipai doctor
 ```
 
 See [`docs/recipe-prebaked-image-kit.md`](../docs/recipe-prebaked-image-kit.md)

--- a/pi/README.md
+++ b/pi/README.md
@@ -9,19 +9,19 @@ it as the entrypoint when you attach.
 ## Usage
 
 ```console
-$ sbx run --kit "docker.io/sbx/pi-kit:latest" pi
+sbx run --kit "docker.io/sbx/pi-kit:latest" pi
 ```
 
 Or from a git URL targeting this repo:
 
 ```console
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=pi" pi
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=pi" pi
 ```
 
 Or with a local clone of this repo:
 
 ```console
-$ sbx run --kit ./pi/ pi
+sbx run --kit ./pi/ pi
 ```
 
 The first launch installs the agent via `npm install -g`. Subsequent

--- a/picoclaw/README.md
+++ b/picoclaw/README.md
@@ -14,13 +14,13 @@ for when a pre-baked image *is* worth it.)
 ## Usage
 
 ```console
-$ sbx run --kit "docker.io/sbx/picoclaw-kit:latest" picoclaw
+sbx run --kit "docker.io/sbx/picoclaw-kit:latest" picoclaw
 ```
 
 Or from a git URL targeting this repo:
 
 ```console
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=picoclaw" picoclaw
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=picoclaw" picoclaw
 ```
 
 On attach you land in `picoclaw agent` (interactive chat). The channel
@@ -52,7 +52,7 @@ The seeded config uses the native Anthropic Messages API
 ## Debugging
 
 ```console
-$ sbx exec <sandbox> -- cat /home/agent/.picoclaw/gateway.log
-$ sbx exec <sandbox> -- curl -s http://127.0.0.1:18790/health
-$ sbx exec <sandbox> -- picoclaw status
+sbx exec <sandbox> -- cat /home/agent/.picoclaw/gateway.log
+sbx exec <sandbox> -- curl -s http://127.0.0.1:18790/health
+sbx exec <sandbox> -- picoclaw status
 ```

--- a/playwright/README.md
+++ b/playwright/README.md
@@ -5,19 +5,19 @@ A mixin kit that installs the **Playwright** browser-automation toolchain inside
 ## Usage
 
 ```console
-$ sbx run claude --kit "docker.io/sbx/playwright-kit:latest" .
+sbx run claude --kit "docker.io/sbx/playwright-kit:latest" .
 ```
 
 Or straight from this repository over git:
 
 ```console
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=playwright" claude
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=playwright" claude
 ```
 
 Or with a local clone of this repo:
 
 ```console
-$ sbx run claude --kit ./playwright/ .
+sbx run claude --kit ./playwright/ .
 ```
 
 Prerequisites:
@@ -27,9 +27,9 @@ Prerequisites:
 Inside the sandbox:
 
 ```console
-$ playwright --version                       # CLI on PATH for every user
-$ npx playwright test                        # run a project's test suite
-$ npx playwright screenshot http://localhost:3000 page.png
+playwright --version                       # CLI on PATH for every user
+npx playwright test                        # run a project's test suite
+npx playwright screenshot http://localhost:3000 page.png
 ```
 
 Driving a browser from code works with the globally installed library or a project-local one:

--- a/skills/kit-author/topics/image-publishing.md
+++ b/skills/kit-author/topics/image-publishing.md
@@ -42,7 +42,7 @@ namespace, at the rolling tag. `scripts/check-image-ref.sh` derives all three
 from the kit directory and fails the build otherwise:
 
 ```console
-$ ./scripts/check-image-ref.sh docker.io/sbx latest
+./scripts/check-image-ref.sh docker.io/sbx latest
 ```
 
 The `-image` suffix keeps `docker.io/sbx/<kit>-kit` free for the kit artifact
@@ -93,8 +93,8 @@ first publish happens when the PR merges to `main`. Expect that window, and
 verify the build locally in the meantime:
 
 ```console
-$ docker build -t docker.io/sbx/my-kit-image:latest my-kit
-$ ./scripts/test-kit.sh my-kit
+docker build -t docker.io/sbx/my-kit-image:latest my-kit
+./scripts/test-kit.sh my-kit
 ```
 
 `scripts/test-kit.sh` builds a kit's own image before running the suite, so the

--- a/smolagents/README.md
+++ b/smolagents/README.md
@@ -10,14 +10,14 @@ and exposes the upstream `smolagent` and `webagent` CLIs on `PATH`.
 Pair it with whichever sandbox agent you want to work from, from its published OCI artifact on Docker Hub:
 
 ```console
-$ sbx run claude --kit "docker.io/sbx/smolagents-kit:latest" ~/my-project
+sbx run claude --kit "docker.io/sbx/smolagents-kit:latest" ~/my-project
 ```
 
 Or from a git URL targeting this repo:
 
 ```console
-$ sbx run shell --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=smolagents" ~/my-project
-$ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=smolagents" ~/my-project
+sbx run shell --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=smolagents" ~/my-project
+sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=smolagents" ~/my-project
 ```
 
 Once attached, the command-line tools are available:
@@ -82,9 +82,9 @@ To update the kit, change `SMOLAGENTS_VERSION` in `spec.yaml`, run the TCK,
 and verify the CLIs in a real sandbox:
 
 ```console
-$ cd smolagents
-$ ../scripts/test-kit.sh
-$ sbx run shell --kit ./ ~/tmp-project
+cd smolagents
+../scripts/test-kit.sh
+sbx run shell --kit ./ ~/tmp-project
 ```
 
 If the new release adds dependencies or changes provider hosts, update the

--- a/task/README.md
+++ b/task/README.md
@@ -8,26 +8,26 @@ agents can run `Taskfile.yml` tasks from the workspace.
 Run it with any agent kit or built-in agent, from its published OCI artifact on Docker Hub:
 
 ```console
-$ sbx run --kit "docker.io/sbx/task-kit:latest" claude
+sbx run --kit "docker.io/sbx/task-kit:latest" claude
 ```
 
 Or from a git URL targeting this repo:
 
 ```console
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=task" claude
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=task" claude
 ```
 
 For local development, point `--kit` at this directory:
 
 ```console
-$ sbx run --kit ./task/ claude
+sbx run --kit ./task/ claude
 ```
 
 After the sandbox starts, `task` is available on `PATH`:
 
 ```console
-$ task --version
-$ task --list
+task --version
+task --list
 ```
 
 ## Versioning

--- a/trivy/README.md
+++ b/trivy/README.md
@@ -22,21 +22,21 @@ and the install is digest-pinned against tag-rewrite attacks.
 ## Usage
 
 ```console
-$ cd ~/work/some-project
-$ sbx run --kit "docker.io/sbx/trivy-kit:latest" trivy .
+cd ~/work/some-project
+sbx run --kit "docker.io/sbx/trivy-kit:latest" trivy .
 agent@trivy-some-project:/Users/mark/work/some-project$ trivy fs .
 ```
 
 Or from a git URL targeting this repo:
 
 ```console
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=trivy" trivy .
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=trivy" trivy .
 ```
 
 Or with a local clone of this repo:
 
 ```console
-$ sbx run --kit ./trivy/ trivy .
+sbx run --kit ./trivy/ trivy .
 ```
 
 The first launch downloads, verifies, and installs Trivy. Subsequent
@@ -78,7 +78,7 @@ mirrors, your reporting endpoint — should be added with a per-sandbox or
 operator-level allow rule, *not* in the kit:
 
 ```console
-$ sbx policy allow network --sandbox trivy-some-project "registry-1.docker.io,auth.docker.io,production.cloudflare.docker.com"
+sbx policy allow network --sandbox trivy-some-project "registry-1.docker.io,auth.docker.io,production.cloudflare.docker.com"
 ```
 
 This keeps the kit's default footprint minimal and forces deliberate

--- a/vale/README.md
+++ b/vale/README.md
@@ -5,20 +5,20 @@ A mixin kit (`kind: mixin`) that installs the latest [Vale](https://vale.sh/) pr
 ## Usage
 
 ```console
-$ sbx run --kit "docker.io/sbx/vale-kit:latest" claude
+sbx run --kit "docker.io/sbx/vale-kit:latest" claude
 agent@...$ vale --version
 ```
 
 Or from a git URL targeting this repo:
 
 ```console
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=vale" claude
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=vale" claude
 ```
 
 Or with a local clone:
 
 ```console
-$ sbx run --kit ./vale/ claude
+sbx run --kit ./vale/ claude
 ```
 
 Vale is on `PATH` after install. To lint a directory:


### PR DESCRIPTION
Lines inside ```console (and `sh`/`bash`/`shell`) fenced blocks were prefixed with `$ ` to mimic a terminal prompt. When users click GitHub's copy button, the `$ ` is included in the copied text, breaking the command when pasted.

This PR strips the leading `$ ` from every such line across all human-facing markdown files.

- 39 files changed, 210 lines cleaned
- Only lines inside `console`/`sh`/`bash`/`shell` fenced blocks are touched
- Output lines, `# comment` lines, and continuation lines are untouched
- No source code, spec files, or `spec/testdata/` touched
- Single commit, verified with independent reviewer