### PR TITLE
feat(kits): add experimental vscode mixin using --display

### DIFF
--- a/vscode/README.md
+++ b/vscode/README.md
@@ -1,0 +1,97 @@
+# vscode
+
+> **Experimental.** This kit depends on `--display`, which is an experimental
+> sbx feature gated behind a feature flag. See [Prerequisites](#prerequisites).
+
+A mixin that installs [Visual Studio Code](https://code.visualstudio.com/) and
+launches it as a native window on the host desktop. The editor opens the
+sandbox workspace on startup, so files you create or edit through the agent are
+immediately visible in VS Code, and edits you make in the editor are immediately
+visible to the agent.
+
+> **Alternative:** if you want browser-accessible VS Code without the `--display`
+> flag, use the [`code-server`](../code-server/) kit instead.
+
+## Prerequisites
+
+**sbx v0.39.0 or later** is required. Earlier versions set `WAYLAND_DISPLAY`
+container-wide in a way that caused the clipboard bridge to clobber the
+compositor socket, so VS Code never mapped a window.
+
+VS Code renders to the host compositor via `--display`, which requires enabling
+a feature flag:
+
+```console
+$ sbx settings set platform.allowExperimentalFeatures true
+$ sbx settings set feature.sandbox-display true
+```
+
+## Usage
+
+```console
+$ sbx run claude \
+    --display \
+    --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=vscode" \
+    ~/my-project
+```
+
+The VS Code window appears on your host desktop. The `claude` terminal session
+runs concurrently in the same sandbox — both share the workspace at the path
+you passed.
+
+You can use any agent that accepts `--kit`:
+
+```console
+$ sbx run shell --display --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=vscode" ~/my-project
+```
+
+## First install
+
+On the first `sbx run`/`sbx create` with this kit, VS Code is downloaded and
+installed from Microsoft's apt repository inside the sandbox. This takes roughly
+30–60 seconds depending on network speed. Subsequent starts reuse the installed
+binary from the sandbox's persistent overlay.
+
+## How the display surface works
+
+`--display` provisions a Wayland socket inside the microVM and connects it to
+the host compositor. VS Code is started with `--ozone-platform=wayland`, so its
+window is a first-class Wayland surface on the host — resize, focus, and
+clipboard work as expected.
+
+The startup command runs as root and immediately drops to uid 1000 via `setpriv`
+before exec'ing VS Code. This keeps the kit portable across base templates that
+use different usernames at uid 1000 (e.g. `agent` in the standard
+`docker/sandbox-templates`).
+
+## Troubleshooting
+
+**VS Code window doesn't appear**
+
+Check that you passed `--display` to `sbx run`/`sbx create` and that
+`feature.sandbox-display` is enabled:
+
+```console
+$ sbx settings get feature.sandbox-display
+```
+
+Also check that sbx is v0.39.0 or later (`sbx version`).
+
+**VS Code window was closed — how to reopen it**
+
+The launch wrapper is on PATH inside the sandbox. Run it from any terminal
+session in the sandbox:
+
+```console
+$ code &
+```
+
+**Extension marketplace is unavailable**
+
+The kit allows `marketplace.visualstudio.com` and its CDN hosts. If you're
+seeing marketplace errors, check that your sandbox's network policy isn't
+overriding the allow-list with a more restrictive rule:
+
+```console
+$ sbx policy log <sandbox-name>
+```

--- a/vscode/spec.yaml
+++ b/vscode/spec.yaml
@@ -1,0 +1,126 @@
+schemaVersion: "2"
+kind: mixin
+name: vscode
+displayName: Visual Studio Code (native, via --display)
+description: Installs VS Code from Microsoft's apt repository and starts it as a Wayland client on the host desktop, opening the sandbox workspace. Requires `--display` at sandbox creation time and the `feature.sandbox-display` feature flag — see the README.
+permissions:
+  network:
+    allow:
+      # setup.install runs apt-get update, which refreshes every configured
+      # apt source. The claude-code-docker base template pre-configures
+      # Docker's apt repo, so download.docker.com must be allowed even though
+      # this kit doesn't install anything from it — apt-get exits 100 on the
+      # first source metadata fetch that returns non-2xx. Ubuntu hosts amd64
+      # packages on archive/security and arm64 packages on ports.ubuntu.com,
+      # so all three Ubuntu hosts are listed for cross-arch coverage.
+      - archive.ubuntu.com
+      - security.ubuntu.com
+      - ports.ubuntu.com
+      - download.docker.com
+      # Install-time: Microsoft's apt repo (signing key + .deb).
+      - packages.microsoft.com
+      # Runtime: VS Code's own update / telemetry / download endpoints.
+      - update.code.visualstudio.com
+      - vscode.download.prss.microsoft.com
+      # Extensions: marketplace + CDN.
+      - marketplace.visualstudio.com
+      - "*.vscode-cdn.net"
+      - "*.gallerycdn.vsassets.io"
+agentInstructions:
+  content: |
+    ## VS Code
+
+    VS Code is running inside this sandbox. Its window is visible on the
+    host desktop — it opened the sandbox workspace on startup, so any
+    file you create or edit in the terminal is immediately visible in the
+    editor, and vice versa.
+
+    If the user closes the VS Code window and wants to reopen it, run
+    `code &` from any terminal inside the sandbox.
+
+    If the VS Code window is not visible at all, check that `--display`
+    was passed at sandbox creation time and that the host compositor is
+    running. The process runs backgrounded; it does not produce a log
+    file by default.
+setup:
+  install:
+    - command: |
+        set -euo pipefail
+
+        # apt's InRelease verification uses O_TMPFILE, which is incompatible
+        # with the virtiofs overlay backing the container. Route the lists
+        # directory through /dev/shm (a plain tmpfs) instead. The .deb cache
+        # stays at its default location (/var/cache/apt/archives) because
+        # /dev/shm's 64 MiB ceiling is too small for the full package set.
+        mkdir -p /dev/shm/apt-lists
+        APT_OPTS="-o DPkg::Lock::Timeout=600 -o Dir::State::Lists=/dev/shm/apt-lists"
+        export TMPDIR=/dev/shm
+
+        apt-get $APT_OPTS update
+        apt-get $APT_OPTS install -yy --no-install-recommends ca-certificates curl gnupg
+
+        install -d -m 0755 /usr/share/keyrings
+        curl -fsSL https://packages.microsoft.com/keys/microsoft.asc \
+            | gpg --dearmor > /usr/share/keyrings/packages.microsoft.gpg
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/packages.microsoft.gpg] https://packages.microsoft.com/repos/code stable main" \
+            > /etc/apt/sources.list.d/vscode.list
+
+        apt-get $APT_OPTS update
+        apt-get $APT_OPTS install -yy --no-install-recommends code dbus-x11
+
+        rm -rf /dev/shm/apt-lists
+        apt-get clean
+      user: "0"
+      description: |
+        Install Visual Studio Code from Microsoft's official APT repository,
+        plus dbus-x11 (which provides dbus-run-session, needed by Electron to
+        wire its IPC bus when no session bus is present in the container).
+
+  files:
+    - path: /home/agent/.local/bin/code
+      mode: "0755"
+      description: Launch wrapper written at each startup so WORKSPACE_DIR is resolved at runtime.
+      content: |
+        #!/bin/sh
+        if [ ! -S /run/display/wayland-0 ]; then
+          echo "code: display socket not found at /run/display/wayland-0" >&2
+          echo "This sandbox was not created with --display." >&2
+          echo "" >&2
+          echo "To fix, enable the experimental display feature and recreate:" >&2
+          echo "  sbx settings set platform.allowExperimentalFeatures true" >&2
+          echo "  sbx settings set feature.sandbox-display true" >&2
+          echo "  sbx run claude --display --kit <this-kit> <workspace>" >&2
+          exit 1
+        fi
+        export WAYLAND_DISPLAY=/run/display/wayland-0
+        HOME_DIR=$(getent passwd 1000 | cut -d: -f6)
+        if [ -z "$HOME_DIR" ]; then
+          echo "code: no user at uid 1000" >&2
+          exit 1
+        fi
+        export HOME="$HOME_DIR"
+        LAUNCH_DIR="$WORKSPACE_DIR"
+        if [ -z "$LAUNCH_DIR" ]; then LAUNCH_DIR="$HOME_DIR"; fi
+        exec dbus-run-session /usr/share/code/code \
+          --ozone-platform=wayland \
+          --disable-gpu \
+          --disable-gpu-compositing \
+          --no-sandbox \
+          --disable-dev-shm-usage \
+          --user-data-dir="$HOME_DIR/.vscode-user" \
+          "$LAUNCH_DIR"
+
+  startup:
+    - command:
+        - setpriv
+        - --reuid=1000
+        - --regid=1000
+        - --init-groups
+        - /home/agent/.local/bin/code
+      user: "0"
+      background: true
+      description: |
+        Launch VS Code as a Wayland client opening the sandbox's workspace.
+        Runs as root then drops to uid 1000 via setpriv. The window appears
+        on the host compositor via the display surface provisioned by
+        --display. Backgrounded so the agent's terminal keeps focus.

--- a/vscode/spec.yaml
+++ b/vscode/spec.yaml
@@ -1,8 +1,8 @@
 schemaVersion: "2"
 kind: mixin
 name: vscode
-displayName: Visual Studio Code (native, via --display)
-description: Installs VS Code from Microsoft's apt repository and starts it as a Wayland client on the host desktop, opening the sandbox workspace. Requires `--display` at sandbox creation time and the `feature.sandbox-display` feature flag — see the README.
+displayName: Visual Studio Code
+description: Installs VS Code from Microsoft's apt repository, runs it in the sandbox and opens the display on the host. Requires `--display` at sandbox creation time and the `feature.sandbox-display` feature flag — see the README.
 permissions:
   network:
     allow:


### PR DESCRIPTION


<!--
Thanks for contributing to sbx-kits-contrib!

PRs from forks have CI's `test-kit-e2e` job SKIPPED because GitHub does not
expose `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` to fork-triggered workflows.
The e2e assertions will not run on your PR — your laptop is the only place
they run before merge. See the checklist below.
-->

## Summary

<!-- What changed and why. -->

Add kit which runs VS Code inside the sandbox and forwards the display to the host using the `--display` experimental option.

## Spec choices worth flagging for review

<!-- Decisions a reviewer should sanity-check: unusual image, deliberately narrow
allowedDomains, workaround for a known bug, etc. -->

My first kit, so it's hard to tell!

## Origin

It's a simple wrapper of Linux VS Code. Previously VS Code always ran on the host and could connect into the sandbox. This kit colocates VS Code in the sandbox.

## Test plan

For manual testing with sbx 0.39:
```
sbx settings set platform.allowExperimentalFeatures true
sbx settings set feature.sandbox-display true
sbx settings set kit.allowedSources '["docker.io/","github.com/djs55/"]'

sbx run claude \
    --display \
    --kit "git+https://github.com/djs55/sbx-kits-contrib.git#ref=94e2af7fa4ab12173faea660a2cc4a12db453ad5&dir=vscode" \
    ~/my-project
```

CI runs `kit validate` and the TCK on every PR. CI does **not** run e2e on
fork PRs (Docker Hub secrets aren't exposed there), so the e2e step below is
required from your side before requesting review.

- [x] `sbx kit validate ./<kit>/` passes
- [x] `./scripts/test-kit.sh <kit>` passes (the TCK)
- [x] `./scripts/test-kit-e2e.sh <kit>` passes. The script applies the same
      `deny-all` baseline CI uses and scopes everything to its own daemon
      (`--app-name sbx-kits-contrib-tck`), so my main sbx state is untouched.
      Every entry I added to `network.allowedDomains` came from
      `sbx --app-name sbx-kits-contrib-tck policy log <tck-e2e-…>`, not a guess.
- [x] Manual smoke: `sbx run --kit ./<kit>/ <agent>` and verified the kit's
      binary / files / env are inside the running container.

All three re-verified at 94e2af7, after the apt fix in that commit — the
earlier e2e tick predated it and had gone stale. `test-kit-e2e.sh vscode`
passes under `deny-all` (real `sbx create` on `claude-code-docker`, install
hook OK in 38.1s, files / tmpfs / agentContext subtests PASS), and the manual
smoke confirmed `code` 1.138.0 installed, `dbus-run-session` present,
`/run/display/wayland-0` live, and VS Code running with a GPU process on
`--ozone-platform=wayland` with the workspace open.

One-time setup if you haven't run e2e on this machine before:
`sbx --app-name sbx-kits-contrib-tck login`.

See [CONTRIBUTING.md → Verifying locally](../CONTRIBUTING.md#verifying-locally)
and [README → Declare every domain your kit needs](../README.md#declare-every-domain-your-kit-needs)
for the cross-arch domain gotchas (`archive.ubuntu.com`,
`security.ubuntu.com`, `ports.ubuntu.com`) and the package-manager refresh trap.



