### PR TITLE
feat(t3code): new mixin — build toolchain and t3 npm package for T3 Code

### DIFF
--- a/t3code/README.md
+++ b/t3code/README.md
@@ -1,0 +1,72 @@
+# t3code
+
+A mixin kit that prepares a sandbox for [T3 Code](https://docs.docker.com/ai/sandboxes/integrations/t3-code/)'s SSH integration: it installs the build toolchain (`g++`, `make`, `python3`) that `node-pty` needs to compile on Linux, then installs the `t3` npm package itself. Pair it with any agent kit so the first T3 Code connection doesn't have to compile anything or reach the npm registry.
+
+## Usage
+
+```console
+sbx run claude --kit "docker.io/sbx/t3code-kit:latest" .
+```
+
+Or straight from this repository over git:
+
+```console
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=t3code" claude
+```
+
+Or with a local clone of this repo:
+
+```console
+sbx run claude --kit ./t3code/ .
+```
+
+Prerequisites:
+
+- A base image with Node.js ≥ 18 and npm — all standard agent templates ship it. The install fails loudly with a clear message if npm is missing.
+
+Inside the sandbox:
+
+```console
+t3 --version
+g++ --version
+```
+
+Then connect the sandbox to T3 Code over SSH as usual — see
+[Connect T3 Code to a sandbox](https://docs.docker.com/ai/sandboxes/integrations/t3-code/).
+
+## How it works
+
+### Why a toolchain, not just `t3`
+
+`t3` depends on `node-pty`, which ships prebuilt binaries only for macOS and
+Windows. On a Linux sandbox, `node-pty` always compiles from source, and that
+build needs a C++ compiler, `make`, and `python3`. Without them, the `npm
+install` step fails silently — the install command still exits 0 in some
+failure modes, leaving no `t3` executable behind, and T3 Code reports nothing
+more specific than a connection timeout.
+
+### Why `t3` is installed at build time
+
+T3 Code's own remote bootstrap resolves `t3` by falling back to `npx
+--package t3@latest` when it isn't already on `PATH`. That works, but it
+means every first connection depends on npm registry access and a from-source
+`node-pty` build happening live, during the connection attempt. Installing
+`t3` globally at kit-install time does that work once, up front, so
+connecting is just SSH plus starting an already-installed binary.
+
+### Why these domains
+
+`permissions.network.allow` is the kit's complete outbound contract — CI runs e2e under a `deny-all` policy.
+
+| Domain | Why |
+| --- | --- |
+| `registry.npmjs.org` | npm tarballs for `t3` and its dependencies, including `node-pty` (install time) |
+| `archive.ubuntu.com` | Ubuntu apt archive, amd64 |
+| `security.ubuntu.com` | Ubuntu security pocket, amd64 — refreshed by the same `apt-get update` |
+| `ports.ubuntu.com` | Ubuntu archive/security for arm64 (Apple Silicon sandboxes) |
+| `download.docker.com` | Docker's apt repo, pre-added by the `*-docker` templates — `apt-get update` refreshes every configured source and fails if any is blocked |
+
+## Cleanup
+
+Everything is sandbox-local: the toolchain and the global `t3` npm package
+both disappear with the sandbox (`sbx rm <name>`). Nothing touches the host.

--- a/t3code/spec.yaml
+++ b/t3code/spec.yaml
@@ -1,0 +1,59 @@
+schemaVersion: "2"
+kind: mixin
+name: t3code
+displayName: T3 Code
+description: Build toolchain and the t3 npm package that T3 Code's SSH integration needs to run inside a sandbox — node-pty, a t3 dependency, has no Linux prebuilt binaries and must compile from source.
+agentInstructions:
+  content: |
+    ## T3 Code
+
+    This sandbox has the build toolchain (`g++`, `make`, `python3`) and the
+    `t3` npm package pre-installed so T3 Code's SSH integration can connect
+    without compiling anything on first connect.
+
+    - `t3` is on PATH. T3 Code's remote bootstrap finds it directly instead
+      of falling back to `npx --package t3@latest`, so the first connection
+      does not depend on npm registry access or a slow from-source build.
+    - The toolchain exists only to satisfy `node-pty`, a t3 dependency that
+      ships prebuilt binaries for macOS and Windows but not Linux. Removing
+      `g++`, `make`, or `python3` breaks any future `npm install` or
+      `npm rebuild` that touches `node-pty`.
+permissions:
+  network:
+    allow:
+      # npm package (install time): the t3 tarball and its dependencies,
+      # including node-pty, which compiles from source on Linux.
+      - registry.npmjs.org:443
+      # apt-get update refreshes every configured source, so all template
+      # apt sources must be reachable even though we only install from
+      # Ubuntu's main archive. amd64 uses archive/security, arm64 uses
+      # ports.ubuntu.com. download.docker.com is pre-added to apt sources on
+      # shell-docker / *-docker templates.
+      - archive.ubuntu.com:80
+      - security.ubuntu.com:80
+      - ports.ubuntu.com:80
+      - download.docker.com:443
+setup:
+  install:
+    - command: |
+        set -euo pipefail
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update
+        apt-get install -y g++ make python3
+        rm -rf /var/lib/apt/lists/*
+      user: "0"
+      description: Install the build toolchain node-pty needs to compile from source on Linux
+    - command: |
+        set -euo pipefail
+        command -v npm >/dev/null || { echo "npm not found: this mixin needs a base image with Node.js >= 18 (all standard agent templates ship it)" >&2; exit 1; }
+        if [ -n "${HTTP_PROXY:-}" ]; then
+          npm config set proxy "$HTTP_PROXY"
+        fi
+        if [ -n "${HTTPS_PROXY:-${HTTP_PROXY:-}}" ]; then
+          npm config set https-proxy "${HTTPS_PROXY:-$HTTP_PROXY}"
+        fi
+        npm install -g t3@latest
+        ln -sf "$(command -v t3)" /usr/local/bin/t3
+        t3 --version
+      user: "0"
+      description: Install the t3 npm package globally


### PR DESCRIPTION
## Summary

New mixin kit, `t3code`. T3 depends on `node-pty`, which has no Linux prebuilt binaries, so a sandbox needs a compiler, `make`, and `python3` before `t3` itself can install. This kit installs both — the toolchain, then `t3` globally — so a sandbox is ready for T3 Code's SSH integration on the first connection instead of compiling live during it.

## Spec choices worth flagging for review

- `t3@latest` is unpinned, matching what T3 Code's own remote bootstrap does (`npx --package t3@latest`). Happy to pin to a specific version if reviewers prefer reproducibility over always tracking upstream.
- Verified `t3 --version` actually works (prints `t3 v0.0.33`) before using it as the install-time check, rather than guessing at the CLI.

## Origin

Written from a real T3 Code + Docker Sandboxes SSH setup session, and companion to the T3 Code integration docs I added to docker/docs (docker/docs#25892, docker/docs#25894).

## Test plan

- [x] `./scripts/test-kit.sh t3code` passes (the TCK) — both install steps ran successfully against a real container.
- [ ] `sbx kit validate ./t3code/` — not run; I don't have `sbx` on this machine, will run before merge.
- [ ] `./scripts/test-kit-e2e.sh t3code` — not run; requires a real `sbx` CLI, will run before merge.
- [ ] Manual smoke (`sbx run --kit ./t3code/ <agent>`) — not run; will do before merge.