### PR TITLE
Add glab kit

### DIFF
--- a/glab/README.md
+++ b/glab/README.md
@@ -1,0 +1,59 @@
+# glab — GitLab CLI
+
+A mixin kit that installs the [GitLab CLI (`glab`)](https://gitlab.com/gitlab-org/cli) and wires up personal access token (PAT) authentication for gitlab.com through the sandbox proxy. Pairs with any base agent (claude, codex, gemini, …).
+
+GitLab is not one of sbx's built-in auto-sign-on services (GitHub is), so out of the box `glab` inside a sandbox has no credentials and `sbx secret set -g gitlab` alone has no effect — nothing binds it. This kit closes that gap: it declares a `gitlab` credential and injects it into outbound `gitlab.com` requests at the proxy, so the token is stored on the host and never lands inside the sandbox. The container only ever sees a proxy-managed placeholder in `GITLAB_TOKEN`.
+
+## Usage
+
+Store your GitLab PAT (needs the `api` scope) once on the host:
+
+```console
+sbx secret set gitlab
+```
+
+Then create a sandbox with the kit:
+
+```console
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=glab" claude
+```
+
+Verify inside the sandbox:
+
+```console
+glab auth status
+glab api user
+```
+
+## How auth works
+
+- The kit declares a `gitlab` credential with `proxyManaged: true`. Inside the container, `GITLAB_TOKEN` is set to a sentinel value, which is enough for `glab` to consider itself logged in.
+- On any request to `gitlab.com`, the sandbox proxy replaces the `Authorization` header with `Bearer <your-real-PAT>`. The real token never enters the sandbox filesystem or environment.
+- Git-over-HTTPS push credentials are **not** wired up by this kit — git sends Basic auth, which the kit does not rewrite. Use `glab api`, or public read-only clones. (Native GitLab sign-on, including git, is on the sbx roadmap.)
+
+## Self-managed GitLab
+
+The kit's spec targets gitlab.com. For a self-managed instance (e.g. `gitlab.example.com`), add on the host:
+
+```console
+sbx secret set-custom --host gitlab.example.com --env GITLAB_TOKEN --value <your-PAT>
+sbx policy allow network "gitlab.example.com:443"
+```
+
+and inside the sandbox (or a project kit):
+
+```console
+export GITLAB_HOST=gitlab.example.com
+```
+
+Note `sbx secret set-custom` is experimental; flags may change.
+
+## Why the install is pinned
+
+The install hook downloads a specific glab release tarball and verifies its SHA256 against a checksum recorded in this spec (same pattern as the `trivy` kit) rather than piping an install script to a shell. To bump the version, update `GLAB_VERSION` and both per-arch checksums from the release's `checksums.txt`.
+
+## Cleanup
+
+```console
+sbx secret rm -g --service gitlab
+```

--- a/glab/spec.yaml
+++ b/glab/spec.yaml
@@ -1,0 +1,72 @@
+schemaVersion: "2"
+kind: mixin
+name: glab
+displayName: GitLab CLI (glab)
+description: Installs the GitLab CLI (glab) with proxy-injected personal access token auth for gitlab.com, so agents can work with GitLab projects the way gh works with GitHub.
+
+permissions:
+  network:
+    allow:
+      # glab API traffic and the pinned release tarball download (install
+      # time). Release assets are served from gitlab.com directly — verified
+      # under deny-all e2e; no object-storage host needed.
+      - gitlab.com:443
+
+credentials:
+  - service: gitlab
+    description: GitLab personal access token (api scope). Stored on the host; the sandbox only sees a placeholder and the proxy injects the real value on requests to gitlab.com.
+    required: true
+    apiKey:
+      # glab reads GITLAB_TOKEN and treats itself as logged in. proxyManaged
+      # sets it to the sentinel inside the container; the proxy replaces the
+      # Authorization header with the real token on outbound gitlab.com calls.
+      name: GITLAB_TOKEN
+      proxyManaged: true
+      inject:
+        - domain: gitlab.com
+          header: Authorization
+          format: Bearer %s
+
+agentInstructions:
+  content: |
+    ## GitLab CLI
+
+    `glab` is installed and authenticated against gitlab.com through the
+    sandbox proxy — `GITLAB_TOKEN` is a proxy-managed placeholder, never the
+    real token. Use `glab api ...` for arbitrary GitLab REST calls and the
+    usual `glab mr` / `glab issue` / `glab repo` subcommands. Verify auth
+    with `glab auth status`. Git-over-HTTPS push auth is not wired up by
+    this kit; use `glab api` or read-only clones of public repos.
+
+setup:
+  install:
+    # Install glab from a pinned, digest-verified GitLab release (same
+    # pattern as the trivy kit: no curl|sh, version AND SHA256 pinned in
+    # git). To bump: change GLAB_VERSION plus the per-arch SHA256 below,
+    # sourced from the release's checksums.txt.
+    - command: |
+        set -euo pipefail
+        GLAB_VERSION=1.114.0
+        ARCH=$(dpkg --print-architecture)
+        case "$ARCH" in
+          amd64)
+            SHA256="00e892a80d586a1e8b8fdc035321923db99dce0caa3b0c4fd72c5337ffdb1c48"
+            ;;
+          arm64)
+            SHA256="d34d7ddb96ce5e5f3423d7e8053cb14c36bd93984e4b96320f7e20a341b83498"
+            ;;
+          *)
+            echo "unsupported sandbox arch: $ARCH (expected amd64 or arm64)" >&2
+            exit 1
+            ;;
+        esac
+        TARBALL="glab_${GLAB_VERSION}_linux_${ARCH}.tar.gz"
+        URL="https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/${TARBALL}"
+        curl --proto '=https' --tlsv1.2 -fsSL -o /tmp/glab.tgz "$URL"
+        echo "${SHA256}  /tmp/glab.tgz" | sha256sum -c -
+        tar -C /tmp -xzf /tmp/glab.tgz bin/glab
+        install -m 0755 /tmp/bin/glab /usr/local/bin/glab
+        rm -rf /tmp/glab.tgz /tmp/bin
+        glab --version
+      user: "0"
+      description: "Install glab v1.114.0, version+digest pinned"


### PR DESCRIPTION
## Summary

Adds a `glab` mixin kit: installs the GitLab CLI (pinned, digest-verified)
and wires personal access token auth for gitlab.com through the sandbox
proxy. GitLab is not one of sbx's built-in sign-on services (GitHub is), so
today `glab` inside a sandbox has no working auth and `sbx secret set -g
gitlab` has nothing to bind to. This kit closes that gap until native
GitLab sign-on lands.

## Spec choices worth flagging for review

- Credential is injected as `Authorization: Bearer %s` on `gitlab.com` with
  `proxyManaged: true` (amp-kit pattern): the container only ever sees a
  sentinel in `GITLAB_TOKEN`, which is enough for glab to consider itself
  logged in; the proxy swaps in the real token on outbound requests.
- Install is version + per-arch SHA256 pinned from the release's
  checksums.txt, no `curl | sh` (trivy-kit pattern).
- `network.allowedDomains` is exactly `gitlab.com:443`. I initially allowed
  an object-storage host for the release download redirect, then removed it
  and re-ran e2e under deny-all — release tarballs are served from
  gitlab.com directly, so the narrow allowlist is verified, not guessed.
- Git-over-HTTPS push auth is out of scope — empirically confirmed during
  testing: `git push` fails ("could not read Username"; no credential helper
  or SSH key in the sandbox, and the sentinel token is not usable by git),
  while all `glab` / REST API operations authenticate fine. Documented in
  the kit README, along with a docs-level path for self-managed instances
  via `sbx secret set-custom`.

## Origin

Built to unblock GitLab CLI usage in sandboxes, hit while reproducing a
customer-reported gap (GitLab absent from the typed-service list).

## Test plan

- [x] `sbx kit validate ./glab/` passes
- [x] `./scripts/test-kit.sh glab` passes (the TCK, incl. container install execution)
- [x] `./scripts/test-kit-e2e.sh glab` passes under the deny-all baseline on
      the scoped daemon
- [x] Manual smoke: `sbx run --kit ./glab/ claude` with a real PAT stored via
      `sbx secret set gitlab` — `glab auth status` and `glab api user`
      succeed inside the sandbox with the proxy-injected token
- [x] Manual functional test: from inside the sandbox, created repositories
      in a gitlab.com group, populated them via the REST Commits API
      (content verified byte-for-byte by git blob SHA), and deleted them.
      GET/POST/PUT/DELETE all pass through the proxy with the injected
      token — observed failures were GitLab's own permission model (403 at
      Maintainer, resolved at Owner), not the sandbox.
