### PR TITLE
fix(droid): mark the droid credential required

### DIFF
--- a/droid/spec.yaml
+++ b/droid/spec.yaml
@@ -30,6 +30,12 @@ sandbox:
 
 credentials:
   - service: droid
+    # Droid cannot authenticate at all without this service — either the
+    # apiKey below or the OAuth block. Marked required so that `sbx create`
+    # says so up front when no credential is available: without it the
+    # sandbox starts clean and the first sign of trouble is the CLI failing
+    # with an opaque 401 once you are already inside.
+    required: true
     apiKey:
       name: FACTORY_API_KEY
       # Most apiKey-based kits in this repo set this (pi, nanobot, crush,


### PR DESCRIPTION
## Summary

Droid can't authenticate without its credential — either `FACTORY_API_KEY` or
the OAuth block — but nothing said so at create time. With no credential
available the sandbox started clean and the first sign of trouble was an opaque
401 once you were already inside. `required: true` surfaces it up front.

## Spec choices worth flagging for review

- **`copilot` is deliberately left alone.** It declares `github` and `copilot`
  as alternatives, and `required` has no one-of semantics, so marking either
  would warn people on a setup that works.
- **No other kit in this repo sets `required:`.** droid is the first, so it's
  worth a sanity-check that this is the intent rather than an oversight
  everywhere else.

## Origin

Existing kit; no new sourcing. Follow-up to the droid extraction (#209).

## Test plan

- [x] `./scripts/test-kit.sh droid` passes (the TCK) — including the
      `credential_policy/droid` and `oauth_policy/droid` subtests
- [x] `go test ./spec/... ./tck/... ./scripts/...` passes
- [ ] `sbx kit validate ./droid/` — not run
- [ ] `./scripts/test-kit-e2e.sh droid` — not run
- [ ] Manual smoke — not run

The three unchecked items need `sbx`, which needs nested virtualisation and so
can't run where I made this change. This is a branch on this repo rather than a
fork, so CI's `test-kit-e2e` job should cover the e2e leg — but I haven't run
it myself and am not claiming otherwise.
