### PR TITLE
docs(spec): clarify setup.files permissions

### DIFF
--- a/skills/kit-author/topics/spec-anatomy.md
+++ b/skills/kit-author/topics/spec-anatomy.md
@@ -405,12 +405,13 @@ setup:
 |---|---|---|
 | `install[].command` | **`string` only** | Runs via `sh -c <string>`. Shell metachars (`&&`, `\|\|`, `;`, `\|`, redirects) work as written. A list form is a validation error. |
 | `startup[].command` | **`string` OR `list[string]`** | String form runs via `sh -c`; list form runs as `exec`-style argv with no shell processing. Use the list form when you need to avoid shell quoting issues; do **not** put shell metachars as bare argv tokens (e.g. `["apt-get", "update", "&&", "apt-get", "install", …]` will pass `&&` to `apt-get` literally). The canonical pattern for "list form but I need a shell" is `["sh", "-c", "<shell command>"]`. |
-| `files[].path` / `content` / `mode` / `onlyIfMissing` | strings / bool | No command runs — these are file writes. |
+| `files[].path` / `content` / `mode` / `onlyIfMissing` | strings / bool | Written via shell exec as uid `1000` (agent). |
 
 ### Other rules
 
 - Placeholders supported only in `files[].content`: **`${WORKDIR}`**. Anything else fails validation.
 - `install` user defaults to `"0"` (root); `startup` user defaults to `"1000"` (agent).
+- `files` paths must be writable by uid `1000`. To write to a root-owned path such as `/etc`, use an `install` command instead and set ownership appropriately if the agent must modify the file later.
 - `startup.background: true` detaches the command; the runtime moves on without waiting.
 
 Composition: all three lists **concatenate** in `--kit` order. `install` runs for every kit, built-in or user-supplied — use `command -v <binary>` guards or `setup.files` with `onlyIfMissing: true` to keep it idempotent.

--- a/spec/SPEC-v2.md
+++ b/spec/SPEC-v2.md
@@ -724,13 +724,16 @@ setup:
 |---|---|---|
 | `install[].command` | **string** (REQUIRED) | `sh -c <string>`; shell metacharacters work. A list is an error. |
 | `startup[].command` | **list<string>** (REQUIRED, non-empty) | Exec-style argv, no shell processing. For a shell, use `["sh", "-c", "<cmd>"]`. |
-| `files[]` | file write | `path` absolute; `mode` octal; only `${WORKDIR}` placeholder allowed in `content`. |
+| `files[]` | file write | Shell exec as uid `1000` (agent); `path` absolute; `mode` octal; only `${WORKDIR}` placeholder allowed in `content`. |
 
 - `install` runs **once** at sandbox creation, for every kit (built-in or
   user-supplied). Guard with `command -v <binary>` or use `files` with
   `onlyIfMissing: true` to stay idempotent.
 - `startup` runs on **every** container start (create, stop/start, daemon
   restart, host reboot). Author idempotent.
+- `files` paths MUST be writable by uid `1000`. A kit that needs to write to
+  a root-owned path such as `/etc` MUST use an `install` command instead and
+  set ownership appropriately if the agent needs to modify the file later.
 - Composition: all three lists concatenate in `--kit` order.
 - The environment these scripts run in (user model, write surface, tool
   floor, injected variables) is specified in [§9](#9-runtime-environment).


### PR DESCRIPTION
## Summary

Document that `setup.files` writes run as the non-root agent user (uid 1000), so target paths must be agent-writable. Direct kit authors to `setup.install` for root-owned paths and explain the ownership requirement for files the agent later modifies.

Closes docker/sbx-releases#467

## Spec choices worth flagging for review

The clarification is applied to both the normative v2 specification and the matching kit-author reference.

## Test plan

- `go test ./spec/...`
- `git diff --check`

Generated by Codex