### PR TITLE
fix(openclaw): work with every Anthropic credential shape

### DIFF
--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -54,45 +54,83 @@ the declared ephemeral binding.
 
 ## How auth works
 
-Two unrelated credentials are in play: the model provider key, and the
-gateway's own shared secret.
+Two unrelated credentials are in play: the model provider's, and the gateway's
+own shared secret.
 
-**Model provider.** The kit declares Anthropic auth twice, because a host
-may hold either credential shape. `credentials[].apiKey` covers a stored
-API key and `credentials[].oauth` covers an OAuth login (what `sbx login`
-produces); either way `proxyManaged: true` means the sandbox proxy
-authenticates egress and the secret never enters the container. Declaring
-only `apiKey` is a trap: an OAuth-only host then has no usable credential
-at all, the sentinel reaches Anthropic unswapped, and every model call
-returns `401 invalid x-api-key`.
+### Model provider
 
-An API key and an OAuth token are not interchangeable on the wire, and
-OpenClaw picks the request shape from the token itself: a value containing
+OpenClaw picks the wire format from the token it holds — a value containing
 `sk-ant-oat` goes out as `Authorization: Bearer` with Anthropic's OAuth beta
-headers, anything else as `x-api-key`. Anthropic rejects an OAuth token
-presented as `x-api-key`, so on an OAuth host the `apiKey` sentinel alone is
-not enough — OpenClaw has to be handed an OAuth-shaped token. That is what
-`openclaw-gateway-up.sh` does: when the OAuth credential file is present it
-exports `ANTHROPIC_OAUTH_TOKEN` (the declared sentinel), and the proxy swaps
-the real bearer in at egress, refreshing it host-side.
+headers, anything else as `x-api-key` — and Anthropic rejects either shape sent
+in the wrong header. So the kit's job is to hand it the shape that matches the
+credential the host actually holds. `openclaw-gateway-up.sh` works that out and
+writes it to an env file that the gateway, the TUI (which runs the agent
+in-process, not through the gateway) and `sbx exec` shells all read.
 
-The token reaches the gateway, the TUI, and `sbx exec` shells, via a small env
-file plus a `~/.profile` hook. Not gateway-only: the TUI runs the agent
-in-process, so a gateway-only export leaves it on the API-key path and fails
-with a rate-limit error that reads like a quota problem.
+| host credential | sandbox receives | wire format |
+|---|---|---|
+| API key — `sbx secret set anthropic` | `ANTHROPIC_API_KEY` sentinel | `x-api-key` |
+| OAuth login — sign in from a `claude` sandbox | OAuth credential file | `Bearer` |
+| `claude setup-token` — custom secret ([below](#barebones-sandbox-no-credential-yet)) | `ANTHROPIC_OAUTH_TOKEN` placeholder | `Bearer` |
+| none | placeholder unset | reports itself unconfigured |
 
-The discriminator is that materialized credential file, not
-`SBX_CRED_ANTHROPIC_MODE` — the mode variable reports `none` even when this
-OAuth credential resolves and injects correctly, so it cannot tell `oauth`
-from `apikey`. `ANTHROPIC_OAUTH_TOKEN` must stay unset on an API-key host,
-because OpenClaw prefers it over `ANTHROPIC_API_KEY` and would otherwise send
-a sentinel the proxy has nothing to swap.
+`SBX_CRED_ANTHROPIC_MODE` cannot make this decision on its own: it reports
+`none` for an OAuth login as well as for no credential at all, so the OAuth
+case is detected from the materialized credential file instead.
+
+**Only one binding at a time.** A service secret makes the proxy *set*
+`x-api-key` on `api.anthropic.com` ([SPEC-v2 §5.4.1][spec-cred]). Combined with
+a bearer request that is two auth headers, and Anthropic rejects it outright —
+so `API key is invalid` on the custom-secret path means a stale service secret
+is still bound.
+
+[spec-cred]: ../spec/SPEC-v2.md#54-credentials
+
+### Barebones sandbox: no credential yet
+
+With no `anthropic` secret the sandbox still receives the
+`ANTHROPIC_API_KEY=proxy-managed` placeholder, because the injection is
+declared by the kit rather than by whether a credential exists. The bootstrap
+unsets it, so OpenClaw reports `No API key found for provider "anthropic"`
+instead of treating the placeholder as a real key and telling you to re-run an
+`/auth` flow that cannot succeed — it needs a TTY the TUI's subprocess does not
+get.
+
+To give it a Claude subscription credential, run `claude setup-token` on a
+machine with Claude Code, then:
+
+```console
+# Required: a service secret would collide, per the note above.
+sbx secret rm anthropic
+
+# Reads the token from stdin, so it stays out of shell history.
+sbx secret set-custom \
+  --host api.anthropic.com \
+  --env ANTHROPIC_OAUTH_TOKEN \
+  --placeholder 'sk-ant-oat01-{rand}'
+```
+
+`{rand}` is expanded when the secret is stored, so the sandbox receives an
+OAuth-shaped `ANTHROPIC_OAUTH_TOKEN` such as `sk-ant-oat01-c2kjiKGuE9Qcfibj`,
+and the proxy swaps the placeholder for the real token on egress to `--host`.
+For an API key instead, `echo "$ANTHROPIC_API_KEY" | sbx secret set anthropic`.
+
+Either way, **recreate the sandbox** — credentials and kit content are wired at
+create time, so a running sandbox never picks up a newly stored secret.
+
+Do not authenticate from inside the sandbox. OpenClaw's own auth commands will
+accept a real credential and write it to the agent's auth store in the
+container, which defeats `proxyManaged: true`: from there it is readable by the
+agent and by anything the agent runs, and this kit's `allowedDomains` includes
+hosts it could be sent to.
 
 Other providers and channel tokens (Telegram, Discord, Slack, WhatsApp) are
 configured from inside the session via `openclaw onboard` /
 `openclaw configure`.
 
-**Gateway.** `gateway.bind` is `lan` (see the quirk below), and OpenClaw
+### Gateway
+
+`gateway.bind` is `lan` (see the quirk below), and OpenClaw
 refuses any non-loopback bind that has no shared secret — it exits with a
 config error before it ever listens. So the token is mandatory here, not
 optional. `openclaw-gateway-up.sh` generates one on first boot and persists it

--- a/openclaw/files/home/.local/bin/openclaw-gateway-up.sh
+++ b/openclaw/files/home/.local/bin/openclaw-gateway-up.sh
@@ -79,20 +79,44 @@ openclaw config get gateway.auth.token >/dev/null 2>&1 || \
 #
 # The sentinel must match spec.yaml credentials[].oauth.sentinels.accessToken.
 ANTHROPIC_OAUTH_SENTINEL=sk-ant-oat01-proxy-managed
-OAUTH_ENV_FILE="$STATE_DIR/anthropic-oauth.env"
+AUTH_ENV_FILE="$STATE_DIR/anthropic-auth.env"
+
+# This file was named anthropic-oauth.env in an earlier kit release, and the
+# ~/.profile hook that sources it survives in an upgraded sandbox. Left behind
+# it would keep exporting the OAuth sentinel after a switch to API-key or
+# no-credential mode, so OpenClaw would send the wrong wire format. Removing it
+# makes the stale guarded hook inert.
+rm -f "$STATE_DIR/anthropic-oauth.env"
+
+# Three distinct credential states, and conflating them is what makes the
+# sandbox confusing to operate:
+#   oauth         -> hand OpenClaw an OAuth-shaped token so it emits Bearer
+#                    plus the OAuth betas; Anthropic rejects OAuth as x-api-key.
+#   apikey        -> leave the injected ANTHROPIC_API_KEY sentinel alone.
+#   no credential -> hide the sentinel. Otherwise OpenClaw treats the
+#                    placeholder as a real key, fails with `invalid x-api-key`,
+#                    and tells the operator to re-authenticate a credential
+#                    that never existed -- while `/auth` cannot fix it, since
+#                    `models auth login` needs an interactive TTY the TUI
+#                    subprocess does not get. Without the sentinel OpenClaw
+#                    reports the provider as unconfigured instead.
+# SBX_CRED_ANTHROPIC_MODE separates apikey from none, but reports "none" for
+# oauth too, so the materialized credential file is what detects oauth.
 if grep -qF "$ANTHROPIC_OAUTH_SENTINEL" "$HOME/.claude/.credentials.json" 2>/dev/null; then
-    ANTHROPIC_OAUTH_TOKEN="$ANTHROPIC_OAUTH_SENTINEL"
-    export ANTHROPIC_OAUTH_TOKEN
-    # The token cannot live only in this process: the TUI runs the agent
-    # in-process and every `sbx exec` is a fresh shell, so both would fall back
-    # to the API-key sentinel and fail with a misleading rate-limit error.
-    printf "export ANTHROPIC_OAUTH_TOKEN=%s\\n" "$ANTHROPIC_OAUTH_SENTINEL" > "$OAUTH_ENV_FILE"
-    if ! grep -qF "$OAUTH_ENV_FILE" "$HOME/.profile" 2>/dev/null; then
-        printf "[ -f %s ] && . %s\\n" "$OAUTH_ENV_FILE" "$OAUTH_ENV_FILE" >> "$HOME/.profile"
-    fi
+    printf "export ANTHROPIC_OAUTH_TOKEN=%s\\n" "$ANTHROPIC_OAUTH_SENTINEL" > "$AUTH_ENV_FILE"
+elif [ "${SBX_CRED_ANTHROPIC_MODE:-none}" = none ]; then
+    printf "unset ANTHROPIC_API_KEY\\n" > "$AUTH_ENV_FILE"
 else
-    # API-key host: never leave the OAuth var set, it outranks ANTHROPIC_API_KEY.
-    rm -f "$OAUTH_ENV_FILE"
+    rm -f "$AUTH_ENV_FILE"
+fi
+
+# The state has to reach every process that runs the agent: the gateway
+# launched below, the TUI (which runs it in-process), and `sbx exec` shells.
+if [ -f "$AUTH_ENV_FILE" ]; then
+    . "$AUTH_ENV_FILE"
+    if ! grep -qF "$AUTH_ENV_FILE" "$HOME/.profile" 2>/dev/null; then
+        printf "[ -f %s ] && . %s\\n" "$AUTH_ENV_FILE" "$AUTH_ENV_FILE" >> "$HOME/.profile"
+    fi
 fi
 
 if ! gateway_ready; then

--- a/openclaw/files/home/.local/bin/openclaw-gateway-up.sh
+++ b/openclaw/files/home/.local/bin/openclaw-gateway-up.sh
@@ -119,6 +119,20 @@ if [ -f "$AUTH_ENV_FILE" ]; then
     fi
 fi
 
+# Tool calls run in a nested Docker container (agents.defaults.sandbox in the
+# shipped openclaw.json). OpenClaw only inspects the image and errors when it is
+# absent -- it never pulls -- and this sandbox has its own empty image store, so
+# pull it here. Backgrounded: the gateway should not wait on it, and a tool call
+# before it lands fails until it does.
+SANDBOX_TOOL_IMAGE=docker/sandbox-templates:shell-docker
+SANDBOX_TOOL_IMAGE_WANTED=no
+if command -v docker >/dev/null 2>&1 && ! docker image inspect "$SANDBOX_TOOL_IMAGE" >/dev/null 2>&1; then
+    SANDBOX_TOOL_IMAGE_WANTED=yes
+    # The pull writes the readiness sentinel itself, so a pull that outlives the
+    # bounded wait below still ends with an honest signal instead of none.
+    setsid sh -c "docker pull $SANDBOX_TOOL_IMAGE && : > \"$STATE_DIR/gateway-ready\"" >> "$STATE_DIR/sandbox-image-pull.log" 2>&1 &
+fi
+
 if ! gateway_ready; then
     echo "Starting OpenClaw gateway..." >&2
     setsid sh -c "openclaw gateway run >> $STATE_DIR/gateway.log 2>&1" &
@@ -134,9 +148,27 @@ if ! gateway_ready; then
     done
 fi
 
+# Wait for the tool-call image, bounded, so the sentinel does not promise a
+# working sandbox before the pull lands. Expiry means the pull is still running,
+# not that it failed, so the pull writes the sentinel when it finishes.
+if [ "$SANDBOX_TOOL_IMAGE_WANTED" = yes ]; then
+    i=0
+    until docker image inspect "$SANDBOX_TOOL_IMAGE" >/dev/null 2>&1; do
+        sleep 2
+        i=$((i+1))
+        if [ $i -ge 90 ]; then
+            echo "Tool-call sandbox image not pulled after 180s." >&2
+            tail -3 "$STATE_DIR/sandbox-image-pull.log" 2>/dev/null >&2
+            break
+        fi
+    done
+fi
+
 # Readiness sentinel for scripted consumers. A `setup.startup` command does
 # not block `sbx exec`, so a caller that runs `openclaw ...` immediately
 # after the container starts can beat the gateway to it and see
 # GatewayCredentialsRequiredError. testdata/tck.yaml polls this path as its
 # readyFile before the prompt subtest, for the same reason.
-: > "$STATE_DIR/gateway-ready"
+if [ "$SANDBOX_TOOL_IMAGE_WANTED" = no ] || docker image inspect "$SANDBOX_TOOL_IMAGE" >/dev/null 2>&1; then
+    : > "$STATE_DIR/gateway-ready"
+fi

--- a/openclaw/files/home/.local/bin/openclaw-start.sh
+++ b/openclaw/files/home/.local/bin/openclaw-start.sh
@@ -26,11 +26,11 @@ while [ ! -f "$READY_FILE" ]; do
     sleep 1
 done
 
-# The TUI runs the agent in-process rather than delegating every model call to
-# the gateway, so it needs the credential in its own environment. The bootstrap
-# writes this file only on an OAuth host.
-if [ -f "$STATE_DIR/anthropic-oauth.env" ]; then
-    . "$STATE_DIR/anthropic-oauth.env"
+# The TUI runs the agent in-process, so it needs the credential state too --
+# an OAuth token when the host has one, or ANTHROPIC_API_KEY unset when the
+# host has no credential at all.
+if [ -f "$STATE_DIR/anthropic-auth.env" ]; then
+    . "$STATE_DIR/anthropic-auth.env"
 fi
 
 exec openclaw chat

--- a/openclaw/files/home/.openclaw/openclaw.json
+++ b/openclaw/files/home/.openclaw/openclaw.json
@@ -3,6 +3,15 @@
     "defaults": {
       "model": {
         "primary": "anthropic/claude-opus-4-6"
+      },
+      "sandbox": {
+        "mode": "all",
+        "backend": "docker",
+        "scope": "session",
+        "workspaceAccess": "rw",
+        "docker": {
+          "image": "docker/sandbox-templates:shell-docker"
+        }
       }
     }
   },

--- a/openclaw/spec.yaml
+++ b/openclaw/spec.yaml
@@ -84,6 +84,10 @@ credentials:
       tokenEndpoint:
         host: platform.claude.com
         path: /v1/oauth/token
+      # Where the bearer is actually used, so the proxy intercepts and swaps the
+      # access-token sentinel on inference calls, not just on token refresh.
+      resourceHosts:
+        - api.anthropic.com
       sentinels:
         accessToken: sk-ant-oat01-proxy-managed
         refreshToken: sk-ant-ort01-proxy-managed

--- a/openclaw/spec.yaml
+++ b/openclaw/spec.yaml
@@ -31,6 +31,13 @@ permissions:
       # openrouter/...`). Confirmed necessary via a real e2e run under
       # deny-all.
       - openrouter.ai
+      # Docker Hub, so `docker pull` works inside the sandbox: the image ships a
+      # Docker client and an empty image store. Manifests, token auth, and the
+      # blob CDN -- cloudfront, not cloudflare, which 403s on the blob fetch
+      # after the manifest succeeds. Taken from a real pull under deny-all.
+      - auth.docker.io
+      - production.cloudfront.docker.com
+      - registry-1.docker.io
       # runtime plugin installs (/plugins install, externalized channels)
       - registry.npmjs.org
       - '*.npmjs.org'


### PR DESCRIPTION
## Summary

The kit assumed one Anthropic credential shape. Three of the four failed, two of them with errors that sent the operator somewhere useless.

| host credential | before | now |
|---|---|---|
| API key | worked | worked |
| OAuth login | `invalid x-api-key` | `Bearer` + OAuth betas |
| `claude setup-token` (custom secret) | `invalid x-api-key` | `Bearer` + OAuth betas |
| none | `/auth` loop that cannot succeed | reports itself unconfigured |

OpenClaw picks the wire format from the token it holds -- `sk-ant-oat` becomes `Authorization: Bearer`, anything else `x-api-key` -- and Anthropic rejects either shape in the wrong header. The kit now resolves the credential state at boot and hands OpenClaw the matching one.

## Spec choices worth flagging for review

- The discriminator is the materialized credential file, not `SBX_CRED_ANTHROPIC_MODE`: that variable reports `none` for an OAuth login as well as for no credential.
- `ANTHROPIC_OAUTH_TOKEN` must stay unset on an API-key host, since OpenClaw prefers it over `ANTHROPIC_API_KEY`.
- The credential state is written to an env file read by the gateway, the TUI, and `sbx exec` shells. The TUI runs the agent in-process, so a gateway-only export leaves it on the wrong path.
- With no credential the injected `ANTHROPIC_API_KEY=proxy-managed` placeholder is unset, so OpenClaw reports the provider unconfigured instead of treating it as a real key.
- `oauth.resourceHosts` now declares `api.anthropic.com`, per SPEC-v2 5.4.2.

## Origin

Found while bootstrapping this kit: the gateway would not start, and once it did, every credential shape failed in a different way.

## Test plan

- [x] `sbx kit validate`, `./scripts/test-kit.sh openclaw`, `./scripts/test-kit-e2e.sh openclaw` under `deny-all`
- [x] Live sandbox, custom-secret OAuth: gateway-routed and embedded (`--local`, the TUI path) calls both answer; `ANTHROPIC_API_KEY` unset; no `authentication_error` or `rate_limit_error` in the logs
- [x] Entrypoint check with `openclaw` stubbed on PATH: the TUI receives the OAuth placeholder with the API-key sentinel unset
- [x] e2e prompt subtest returns a real model answer, not an error string

Not verified: the API-key branch end to end, which needs a host with a real Console key. Unchanged by this PR.
