### PR TITLE
feat(openclaw): sandbox tool calls in a nested Docker container

### DIFF
--- a/openclaw/files/home/.local/bin/openclaw-gateway-up.sh
+++ b/openclaw/files/home/.local/bin/openclaw-gateway-up.sh
@@ -110,9 +110,51 @@ if ! gateway_ready; then
     done
 fi
 
+# Tool calls run in a nested Docker sandbox (agents.defaults.sandbox in the
+# shipped openclaw.json), which needs `openclaw-sandbox:bookworm-slim` in this
+# sandbox's own Docker daemon. OpenClaw will not substitute a base image when
+# it is missing, and the error it raises points at a source-checkout script
+# this image does not have, so build it here. Started in the background so the
+# gateway does not wait on a Docker Hub pull plus an apt install.
+SANDBOX_IMAGE_REF=openclaw-sandbox:bookworm-slim
+SANDBOX_IMAGE_WANTED=no
+if command -v docker >/dev/null 2>&1 && ! docker image inspect "$SANDBOX_IMAGE_REF" >/dev/null 2>&1; then
+    SANDBOX_IMAGE_WANTED=yes
+    setsid sh -c "docker build -t $SANDBOX_IMAGE_REF - <<SANDBOX_IMAGE
+FROM debian:bookworm-slim
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \\
+  bash ca-certificates curl git jq python3 ripgrep \\
+  && rm -rf /var/lib/apt/lists/*
+RUN useradd --create-home --shell /bin/bash sandbox
+USER sandbox
+WORKDIR /home/sandbox
+CMD [\"sleep\", \"infinity\"]
+SANDBOX_IMAGE
+" >> "$STATE_DIR/sandbox-image-build.log" 2>&1 &
+fi
+
+# Wait for that image before declaring readiness, bounded. The sentinel means
+# "openclaw calls work here", and with sandboxing on every tool call needs the
+# image -- without this wait a consumer polling the sentinel races the build and
+# gets a missing-image error. Bounded rather than blocking: a build that fails
+# or is slow degrades to a gateway that answers, not a sandbox that never
+# reports ready.
+if [ "$SANDBOX_IMAGE_WANTED" = yes ]; then
+    i=0
+    until docker image inspect "$SANDBOX_IMAGE_REF" >/dev/null 2>&1; do
+        sleep 2
+        i=$((i+1))
+        if [ $i -ge 90 ]; then
+            echo "Sandbox image not built after 180s; tool calls will fail until it is." >&2
+            tail -5 "$STATE_DIR/sandbox-image-build.log" 2>/dev/null >&2
+            break
+        fi
+    done
+fi
+
 # Readiness sentinel for scripted consumers. A `setup.startup` command does
 # not block `sbx exec`, so a caller that runs `openclaw ...` immediately
-# after the container starts can beat the gateway to it and see
-# GatewayCredentialsRequiredError. testdata/tck.yaml polls this path as its
-# readyFile before the prompt subtest, for the same reason.
+# after the container starts can beat the gateway to it. testdata/tck.yaml
+# polls this path as its readyFile before the prompt subtest.
 : > "$STATE_DIR/gateway-ready"

--- a/openclaw/files/home/.openclaw/openclaw.json
+++ b/openclaw/files/home/.openclaw/openclaw.json
@@ -3,6 +3,12 @@
     "defaults": {
       "model": {
         "primary": "anthropic/claude-opus-4-6"
+      },
+      "sandbox": {
+        "mode": "all",
+        "backend": "docker",
+        "scope": "session",
+        "workspaceAccess": "rw"
       }
     }
   },

--- a/openclaw/spec.yaml
+++ b/openclaw/spec.yaml
@@ -31,6 +31,15 @@ permissions:
       # openrouter/...`). Confirmed necessary via a real e2e run under
       # deny-all.
       - openrouter.ai
+      # Building the nested tool-call sandbox image: Docker Hub manifests, auth,
+      # and the CloudFront blob CDN, plus the Debian mirrors its base image
+      # installs from. Verified against a real build under deny-all; the blob
+      # host is cloudfront, not cloudflare.
+      - auth.docker.io
+      - deb.debian.org
+      - production.cloudfront.docker.com
+      - registry-1.docker.io
+      - security.debian.org
       # runtime plugin installs (/plugins install, externalized channels)
       - registry.npmjs.org
       - '*.npmjs.org'


### PR DESCRIPTION
## Summary

A sandbox that runs OpenClaw should not hand the agent's shell the same filesystem the gateway keeps its token and credential state in. OpenClaw can sandbox tool execution itself, and this kit's image is `shell-docker`, so this turns it on:

```json
"sandbox": { "mode": "all", "backend": "docker", "scope": "session", "workspaceAccess": "rw" }
```

Verified nested, in a sandbox created from this kit with no manual steps:

| | user | host |
|---|---|---|
| outer sbx sandbox | `agent` | `auto` |
| tool call | `sandbox` | `ed812ed462ee` |

`docker ps` inside the sandbox shows `openclaw-sandbox:bookworm-slim` running as `openclaw-sbx-agent-main-main-*`, with `/workspace` mounted. That inner daemon has its own image store, so this is not the host's Docker socket and the Docker-out-of-Docker path-mapping caveat in [Sandboxing](https://docs.openclaw.ai/gateway/sandboxing) does not apply.

## What it needed

**The image has to exist in the inner daemon.** OpenClaw will not substitute a base image when `openclaw-sandbox:bookworm-slim` is missing — the bundled one carries `python3` for the write/edit helpers — and the error it raises points at `scripts/sandbox-setup.sh`, a source-checkout script this npm-installed image does not ship. The bootstrap builds it in the background instead.

**Egress for that build**, taken from a real build under `deny-all` rather than guessed:

| host | why |
|---|---|
| `registry-1.docker.io`, `auth.docker.io` | manifest + auth |
| `production.cloudfront.docker.com` | blob CDN |
| `deb.debian.org`, `security.debian.org` | apt for the base image's packages |

The blob host is **cloudfront**, not cloudflare — the Cloudflare guess fails with `403 Forbidden` on the blob fetch after the manifest succeeds, which is a confusing place to land.

**Readiness now waits for the image**, bounded at 180s. Without it the sentinel means "the gateway listens" while every tool call still fails on the missing image; the e2e prompt subtest hit exactly that and still passed, since any output satisfies its assertion. Bounded so a failed build degrades to a working gateway rather than a sandbox that never reports ready.

## Test plan

- [x] `sbx kit validate`, `test-kit.sh` (TCK), `test-kit-e2e.sh` under `deny-all`
- [x] Fresh sandbox, no manual steps: image built ~10s after boot, tool call lands in the nested container
- [x] e2e prompt subtest returns a real model answer where before the readiness gate it returned `Sandbox image not found`

Independent of #229 (credential modes); both touch `spec.yaml` in different places.
