### PR TITLE
pi: fix egress policy, support Claude Pro/Max OAuth, pre-bake the image

### DIFF
--- a/pi/Dockerfile
+++ b/pi/Dockerfile
@@ -18,6 +18,32 @@ FROM ${BASE_IMAGE}
 # expand to an empty string.
 ARG BASE_IMAGE
 
+# pi's `find` tool is fd underneath. On first use pi probes the system for `fd`
+# or `fdfind` and, finding neither, downloads a release binary from GitHub
+# (sharkdp/fd) into its own bin dir. This repo's e2e runs every kit under
+# `sbx policy init deny-all` and the kit's allowlist names no GitHub release
+# host, so that download cannot succeed and `find` is simply broken; even where
+# egress is permissive, every fresh sandbox pays the probe and then the download
+# the first time the agent looks for a file. Baking the package settles it for
+# every sandbox at build time.
+#
+# Ubuntu's package is `fd-find` and it installs the binary as `fdfind`. pi's
+# probe accepts that name as-is; the symlink is for humans at the shell, who
+# expect `fd`.
+#
+# ripgrep needs no equivalent layer -- pi probes the system for `rg` exactly the
+# same way, and the template already ships /usr/bin/rg. Nothing to add here.
+#
+# Deliberately placed above the ARG PI_VERSION / ADD section below: every layer
+# after that ADD re-runs whenever upstream publishes a release, and this one has
+# nothing to do with which pi version is installed. Kept up here it stays a
+# cache hit across the nightly rebuilds.
+USER root
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends fd-find && \
+    rm -rf /var/lib/apt/lists/* && \
+    ln -sf "$(command -v fdfind)" /usr/local/bin/fd
+
 # Rolling updates by design: pi tracks the `latest` dist-tag, and the nightly
 # scheduled run of build-and-publish-kits.yml rebuilds this image against it.
 # The ADD below is what makes that work under CI's layer cache: BuildKit

--- a/pi/Dockerfile
+++ b/pi/Dockerfile
@@ -1,38 +1,109 @@
 # syntax=docker/dockerfile:1.7
-# Pi sandbox image.
+# Base image for the `pi` sandbox kit.
 #
 # pi is pre-baked so sandbox creation is fast: the kit used to npm-install it
 # at create time, which put a multi-minute download in front of every new
-# sandbox. The kit (spec.yaml) now only applies policy and names `pi` as the
-# entrypoint.
+# sandbox.
 #
 # Built and published by build-and-publish-kits.yml, the shared kit-image
 # pipeline (see ../PUBLISHING.md) -- no bespoke workflow needed, same as
 # openclaw/kiro/copilot.
+#
+# The base is a floating tag, which is why CI also rebuilds on a schedule.
+ARG BASE_IMAGE=docker/sandbox-templates:shell-docker
+FROM ${BASE_IMAGE}
 
-FROM docker/sandbox-templates:shell-docker
+# Re-declared inside the stage: an ARG defined before the first FROM is a global
+# build arg, visible only to FROM lines. Without this, the LABEL below would
+# expand to an empty string.
+ARG BASE_IMAGE
 
-# Upstream releases frequently. Bump deliberately, and keep this in step with
-# the version named in README.md.
-ARG PI_VERSION=0.84.2
+# Rolling updates by design: pi tracks the `latest` dist-tag, and the nightly
+# scheduled run of build-and-publish-kits.yml rebuilds this image against it.
+# The ADD below is what makes that work under CI's layer cache: BuildKit
+# re-downloads the URL on every build to compute its digest, so the install
+# layer re-runs exactly when the fetched packument changes and is a cache hit
+# otherwise. Without it, the unchanging RUN line would hit the gha cache
+# forever and the nightly rebuild would ship a stale binary.
+#
+# PI_VERSION is part of the URL, so overriding it reproduces a specific
+# version *and* keeps the cache key stable: a pinned build fetches that
+# version's document, which does not change when upstream publishes something
+# unrelated.
+ARG PI_VERSION=latest
 
+# --chmod=644 because a URL ADD lands 0600 root-owned by default, and the RUN
+# below reads this file as agent.
 USER root
+ADD --chmod=644 https://registry.npmjs.org/@earendil-works%2Fpi-coding-agent/${PI_VERSION} /tmp/pi-latest.json
 # No Node install step: the template already ships Node 22.22.1, which
 # satisfies pi's `engines.node >= 22.19.0`. (openclaw's image has to run
 # `n 22` because openclaw needs a newer minor than the template had at the
 # time -- pi does not.)
 #
-# chown afterwards because the global prefix is agent-owned in the template
-# and a root install would leave it root-owned: `pi update --self` and
-# `pi install` run as agent inside the sandbox and would then fail on EACCES.
-# The kit's old create-time install ran as uid 1000 for the same reason.
-RUN npm install -g "@earendil-works/pi-coding-agent@${PI_VERSION}" && \
-    chown -R agent:agent "$(npm prefix -g)"
+# The version installed is read out of the document ADDed above rather than
+# re-resolved from the registry at RUN time, so what lands in the image is a
+# pure function of that layer's content. Within a single build that pins both
+# architectures together: amd64 and arm64 resolve the same packument layer, so
+# one manifest list cannot mix two releases. Across separate builds it does
+# not -- each buildx invocation re-fetches the URL, so a release published in
+# between changes the digest and the later build installs something the
+# earlier one never saw. What covers that is the `pi --version` gate below: it
+# re-runs inside whichever build cache-misses, so a broken release fails that
+# build rather than being published.
+#
+# The install runs as agent because the global prefix is agent-owned in the
+# template, so installing as agent gets the ownership `pi update --self` and
+# `pi install` need (they run as agent inside the sandbox and would otherwise
+# fail on EACCES). Installing as root and chowning afterwards would be worse
+# on both counts: root-owned files land in the tree first, and a recursive
+# chown -- even to the owner the files already have -- copies the template's
+# entire npm tree up into this image's layer, adding megabytes to every
+# nightly rebuild. The kit's old create-time install ran as uid 1000 for the
+# same ownership reason.
+#
+# `pi --version` is a build-time gate, not a smoke test for its own sake: npm
+# only WARNS on an engines mismatch (EBADENGINE, exit 0), and CI's image
+# verification only checks that the binary is on PATH. Executing pi is what
+# actually fails the build -- and so blocks the nightly publish -- when
+# upstream ships a release this image's Node cannot run, or one whose bin
+# exists but whose entry module throws.
+#
+# /tmp/pi-latest.json is deliberately not removed: it lives in the ADD's own
+# layer, so deleting it here would only add a whiteout on top of the ~5 KB
+# that ships either way.
+USER agent
+RUN version="$(node -p 'require("/tmp/pi-latest.json").version')" && \
+    npm install -g "@earendil-works/pi-coding-agent@${version}" && \
+    pi --version
 
 # The global bin dir is on PATH in this image, but not in every context that
 # may invoke the binary (startup commands and some exec paths run with a
-# minimal PATH). A symlink somewhere always on PATH costs nothing.
+# minimal PATH). A symlink somewhere always on PATH costs nothing. /usr/local/bin
+# is root-owned, so this one step goes back to root.
+USER root
 RUN ln -sf "$(npm prefix -g)/bin/pi" /usr/local/bin/pi
+
+# Inherited from the base image, but re-declared deliberately so the value is
+# owned here rather than depending on inheritance from an image this repository
+# does not own.
+#
+# This is a *request* to the runtime, not a description of the image: setting it
+# over a base with no Docker engine yields a sandbox started in Docker mode with
+# nothing to run. Since BASE_IMAGE is overridable, CI asserts the engine is
+# really present rather than trusting this label.
+LABEL com.docker.sandboxes.start-docker="true"
+
+# Both of the labels below OVERRIDE values inherited from the base image, which
+# describe the base rather than this image. Overriding is not optional for
+# `flavor`: left inherited it would read "shell-docker", and sbx would report
+# this image's agent as "shell-docker". So it must be the kit's own name: `pi`.
+LABEL com.docker.sandboxes.flavor="pi"
+
+# Informational only -- nothing in sbx reads this. Worth setting because the
+# base is a floating tag rebuilt nightly, so this is the one place the produced
+# image records what it was actually built on.
+LABEL com.docker.sandboxes.base="${BASE_IMAGE}"
 
 USER agent
 WORKDIR /home/agent

--- a/pi/Dockerfile
+++ b/pi/Dockerfile
@@ -1,0 +1,39 @@
+# syntax=docker/dockerfile:1.7
+# Pi sandbox image.
+#
+# pi is pre-baked so sandbox creation is fast: the kit used to npm-install it
+# at create time, which put a multi-minute download in front of every new
+# sandbox. The kit (spec.yaml) now only applies policy and names `pi` as the
+# entrypoint.
+#
+# Built and published by build-and-publish-kits.yml, the shared kit-image
+# pipeline (see ../PUBLISHING.md) -- no bespoke workflow needed, same as
+# openclaw/kiro/copilot.
+
+FROM docker/sandbox-templates:shell-docker
+
+# Upstream releases frequently. Bump deliberately, and keep this in step with
+# the version named in README.md.
+ARG PI_VERSION=0.84.2
+
+USER root
+# No Node install step: the template already ships Node 22.22.1, which
+# satisfies pi's `engines.node >= 22.19.0`. (openclaw's image has to run
+# `n 22` because openclaw needs a newer minor than the template had at the
+# time -- pi does not.)
+#
+# chown afterwards because the global prefix is agent-owned in the template
+# and a root install would leave it root-owned: `pi update --self` and
+# `pi install` run as agent inside the sandbox and would then fail on EACCES.
+# The kit's old create-time install ran as uid 1000 for the same reason.
+RUN npm install -g "@earendil-works/pi-coding-agent@${PI_VERSION}" && \
+    chown -R agent:agent "$(npm prefix -g)"
+
+# The global bin dir is on PATH in this image, but not in every context that
+# may invoke the binary (startup commands and some exec paths run with a
+# minimal PATH). A symlink somewhere always on PATH costs nothing.
+RUN ln -sf "$(npm prefix -g)/bin/pi" /usr/local/bin/pi
+
+USER agent
+WORKDIR /home/agent
+CMD ["pi"]

--- a/pi/README.image.md
+++ b/pi/README.image.md
@@ -12,6 +12,11 @@ chain plus a Docker engine, requesting Docker-in-Docker via
 - [`@earendil-works/pi-coding-agent`](https://www.npmjs.com/package/@earendil-works/pi-coding-agent),
   installed globally at the latest upstream release (rebuilt nightly),
   plus a `/usr/local/bin/pi` symlink
+- `fd-find` (apt), which backs pi's `find` tool, plus a `/usr/local/bin/fd`
+  symlink for the canonical name — without it pi downloads a binary from
+  GitHub releases on first use, which a locked-down sandbox blocks
+- no ripgrep layer — pi probes the system for `rg` just as it does for `fd`,
+  and the template already ships it
 - no Node layer — the template already ships Node 22.22.1, and pi requires
   `>= 22.19.0`
 

--- a/pi/README.image.md
+++ b/pi/README.image.md
@@ -5,10 +5,13 @@ Base image for the pi agent kit for
 
 ## Contents
 
-Built on `docker/sandbox-templates:shell-docker`. On top of that:
+Built on `docker/sandbox-templates:shell-docker`: the standard sandbox tool
+chain plus a Docker engine, requesting Docker-in-Docker via
+`com.docker.sandboxes.start-docker=true`. On top of that:
 
 - [`@earendil-works/pi-coding-agent`](https://www.npmjs.com/package/@earendil-works/pi-coding-agent),
-  installed globally at a pinned version, plus a `/usr/local/bin/pi` symlink
+  installed globally at the latest upstream release (rebuilt nightly),
+  plus a `/usr/local/bin/pi` symlink
 - no Node layer — the template already ships Node 22.22.1, and pi requires
   `>= 22.19.0`
 

--- a/pi/README.image.md
+++ b/pi/README.image.md
@@ -1,0 +1,22 @@
+# sbx/pi-image
+
+Base image for the pi agent kit for
+[Docker Sandboxes](https://docs.docker.com/ai/sandboxes/).
+
+## Contents
+
+Built on `docker/sandbox-templates:shell-docker`. On top of that:
+
+- [`@earendil-works/pi-coding-agent`](https://www.npmjs.com/package/@earendil-works/pi-coding-agent),
+  installed globally at a pinned version, plus a `/usr/local/bin/pi` symlink
+- no Node layer — the template already ships Node 22.22.1, and pi requires
+  `>= 22.19.0`
+
+The npm global prefix stays owned by `agent`, so `pi install` and
+`pi update --self` work inside the sandbox.
+
+Runs as the non-root `agent` user, with `CMD ["pi"]`.
+
+## Kit
+
+[`docker.io/sbx/pi-kit`](https://hub.docker.com/r/sbx/pi-kit)

--- a/pi/README.md
+++ b/pi/README.md
@@ -152,9 +152,8 @@ wait everywhere else. ripgrep needs no such layer: pi probes for `rg` the same
 way and the template already ships it.
 
 No Node layer: the template already ships Node 22.22.1 and pi requires
-`>= 22.19.0`. The npm global prefix is chowned back to `agent` after the
-root-user install, so `pi install` and `pi update --self` still work inside
-the sandbox.
+`>= 22.19.0`. The npm install runs as `agent` — the template's global prefix is
+agent-owned — so `pi install` and `pi update --self` work inside the sandbox.
 
 The `-image` suffix distinguishes the base image from the kit itself: the kit
 is published separately as an OCI artifact at `docker.io/sbx/pi-kit` (see

--- a/pi/README.md
+++ b/pi/README.md
@@ -47,6 +47,8 @@ which one materializes:
 |---|---|---|
 | API key — `sbx secret set anthropic` | `ANTHROPIC_API_KEY` sentinel | `x-api-key` |
 | OAuth login (Claude Pro/Max) — `sbx login` | `~/.pi/agent/auth.json` with OAuth sentinels | `Bearer` |
+| `claude setup-token` — custom secret ([below](#barebones-sandbox-no-credential-yet)) | `ANTHROPIC_OAUTH_TOKEN` placeholder | `Bearer` |
+| none | `ANTHROPIC_API_KEY` sentinel, nothing to swap it for | 401 ([below](#barebones-sandbox-no-credential-yet)) |
 
 An API key wins when the host has one. Without the `oauth:` block a host whose
 only Anthropic credential is an OAuth login would get no usable credential at
@@ -75,3 +77,49 @@ Every domain the kit needs is declared in `permissions.network.allow`:
 - `registry.npmjs.org` — the create-time install, plus pi's own runtime
   package installs (`pi install npm:...`, `pi update`).
 - `platform.claude.com:443` — the OAuth token endpoint, for the refresh.
+
+### Barebones sandbox: no credential yet
+
+With no Anthropic credential on the host the sandbox still receives
+`ANTHROPIC_API_KEY=proxy-managed`, because the injection is declared by the
+kit rather than by whether a credential exists. pi has no way to tell that
+placeholder from a real key, so instead of "no API key found" you get an
+opaque `401` on the first model call. This kit is deliberately script-free —
+there is no wrapper entrypoint unsetting the placeholder for you — so treat a
+bare 401 as "no credential wired", not as "wrong key".
+
+To give it a Claude subscription credential, run `claude setup-token` on a
+machine with Claude Code, then, on the host:
+
+```console
+# Required: a service secret would collide, per the note below.
+sbx secret rm anthropic
+
+# Reads the token from stdin, so it stays out of shell history.
+sbx secret set-custom \
+  --host api.anthropic.com \
+  --env ANTHROPIC_OAUTH_TOKEN \
+  --placeholder 'sk-ant-oat01-{rand}'
+```
+
+`ANTHROPIC_OAUTH_TOKEN` is pi's own variable for this, and it is preferred
+over `ANTHROPIC_API_KEY` when both are set. `{rand}` is expanded when the
+secret is stored, so the sandbox receives an OAuth-shaped placeholder such as
+`sk-ant-oat01-c2kjiKGuE9Qcfibj` — the `oat` shape is what makes pi send it as
+a Bearer — and the proxy swaps it for the real token on egress to `--host`.
+For an API key instead, `echo "$ANTHROPIC_API_KEY" | sbx secret set anthropic`.
+
+**Only one binding at a time.** A bound `anthropic` service secret makes the
+proxy *set* `x-api-key` on `api.anthropic.com`. Combined with a Bearer request
+that is two auth headers, and Anthropic rejects it outright — so
+`API key is invalid` on the custom-secret path means a stale service secret is
+still bound. `sbx secret rm anthropic` first.
+
+Either way, **recreate the sandbox**: credentials and kit content are wired at
+create time, so a running sandbox never picks up a newly stored secret.
+
+Do not authenticate from inside the sandbox. pi's `/login` will happily
+complete and write a *real* token into `~/.pi/agent/auth.json` in the
+container, which defeats `proxyManaged: true` — from there it is readable by
+the agent and by anything the agent runs, and the kit's allowlist includes
+hosts it could be sent to. Keep credentials host-side.

--- a/pi/README.md
+++ b/pi/README.md
@@ -140,9 +140,16 @@ and publishes its own, from the `Dockerfile` in this directory:
 ```
 docker.io/sbx/pi-image
 └── FROM docker/sandbox-templates:shell-docker
+    ├── fd-find (apt, + /usr/local/bin/fd symlink)
     └── @earendil-works/pi-coding-agent @ latest
         npm global install (+ /usr/local/bin symlink)
 ```
+
+fd is what pi's `find` tool runs. Without it in the image pi probes for
+`fd`/`fdfind` on first use and then downloads a binary from GitHub releases —
+unreachable under this repo's deny-all e2e policy, and a needless first-use
+wait everywhere else. ripgrep needs no such layer: pi probes for `rg` the same
+way and the template already ships it.
 
 No Node layer: the template already ships Node 22.22.1 and pi requires
 `>= 22.19.0`. The npm global prefix is chowned back to `agent` after the

--- a/pi/README.md
+++ b/pi/README.md
@@ -3,8 +3,13 @@
 A standalone sandbox kit (`kind: sandbox`, the v2 spec naming) for the
 [`@earendil-works/pi-coding-agent`](https://www.npmjs.com/package/@earendil-works/pi-coding-agent)
 CLI — a minimal terminal coding agent with extensible tools, skills, and
-TUI. The kit installs `pi` via npm at sandbox creation time and runs
-it as the entrypoint when you attach.
+TUI.
+
+Unlike the previous version of this kit (which npm-installed pi at sandbox
+creation, minutes on first boot), this kit uses a **pre-baked sandbox
+image**: pi ships inside the image at a pinned version. The kit itself only
+applies policy and runs `pi` as the entrypoint, so a new sandbox is ready in
+seconds.
 
 ## Usage
 
@@ -24,10 +29,8 @@ Or with a local clone of this repo:
 sbx run --kit ./pi/ pi
 ```
 
-The first launch installs the agent via `npm install -g`, at the version
-pinned in `spec.yaml` — upstream releases frequently, so the pin is what
-keeps two sandboxes created a week apart running the same agent. Subsequent
-launches reuse the sandbox.
+Attaching drops you straight into pi's TUI; nothing is installed at create
+time.
 
 ## How auth works
 
@@ -74,8 +77,10 @@ Every domain the kit needs is declared in `permissions.network.allow`:
   implicitly, so the domain has to be listed here as well as in the
   credential block. This repo's e2e runs every kit under
   `sbx policy init deny-all`, where anything unlisted is simply unreachable.
-- `registry.npmjs.org` — the create-time install, plus pi's own runtime
-  package installs (`pi install npm:...`, `pi update`).
+- `registry.npmjs.org` — kept even though pi is baked into the image: pi
+  installs packages (extensions, skills, prompt templates, themes) from npm
+  at runtime, via `pi install npm:@scope/pkg`, `pi -e npm:...` and
+  `pi update`, and fetches any packages listed in settings on startup.
 - `platform.claude.com:443` — the OAuth token endpoint, for the refresh.
 
 ### Barebones sandbox: no credential yet
@@ -123,3 +128,50 @@ complete and write a *real* token into `~/.pi/agent/auth.json` in the
 container, which defeats `proxyManaged: true` — from there it is readable by
 the agent and by anything the agent runs, and the kit's allowlist includes
 hosts it could be sent to. Keep credentials host-side.
+
+## Base image
+
+Unlike most kits here — which are `kind: mixin` and layer onto an existing
+`docker/sandbox-templates` image — a `kind: sandbox` kit *is* the whole
+environment, so it names the image the sandbox boots from. This kit builds
+and publishes its own, from the `Dockerfile` in this directory:
+
+```
+docker.io/sbx/pi-image
+└── FROM docker/sandbox-templates:shell-docker
+    └── @earendil-works/pi-coding-agent @ pinned version
+        npm global install (+ /usr/local/bin symlink)
+```
+
+No Node layer: the template already ships Node 22.22.1 and pi requires
+`>= 22.19.0`. The npm global prefix is chowned back to `agent` after the
+root-user install, so `pi install` and `pi update --self` still work inside
+the sandbox.
+
+The `-image` suffix distinguishes the base image from the kit itself: the kit
+is published separately as an OCI artifact at `docker.io/sbx/pi-kit` (see
+[Usage](#usage) above).
+
+### Building and publishing
+
+How the image is named, tagged, verified and pushed is the same for every kit
+in this repo that builds its own image — see
+**[PUBLISHING.md](../PUBLISHING.md)** for the pipeline. There is no
+kit-specific build script or workflow; CI builds and publishes this image the
+same way it does for `openclaw`/`kiro`/`copilot`.
+
+Upstream releases frequently; bump `PI_VERSION` in the `Dockerfile`
+deliberately rather than tracking `latest`, so two sandboxes created a week
+apart run the same agent.
+
+### Building locally
+
+```console
+docker build -t docker.io/sbx/pi-image:latest pi
+./scripts/test-kit.sh pi
+```
+
+`scripts/test-kit.sh` builds the kit's own image before running the suite
+(`SBX_KIT_SKIP_IMAGE_BUILD=1` to skip and reuse what's already built). Until
+the image is first published — pull requests build it but never push it — the
+TCK's `container` subtest can only pull it locally, so build before you test.

--- a/pi/README.md
+++ b/pi/README.md
@@ -9,7 +9,8 @@ Unlike the previous version of this kit (which npm-installed pi at sandbox
 creation, minutes on first boot), this kit uses a **pre-baked sandbox
 image**: pi ships inside the image, rebuilt nightly against the latest
 upstream release. The kit itself applies policy, points npm at the sandbox
-proxy, and runs `pi` as the entrypoint, so a new sandbox is ready in seconds.
+proxy, and runs `pi` as the entrypoint, so creating a sandbox no longer waits
+on an npm install.
 
 ## Usage
 
@@ -29,8 +30,9 @@ Or with a local clone of this repo:
 sbx run --kit ./pi/ pi
 ```
 
-Attaching drops you straight into pi's TUI; nothing is downloaded at create
-time — the only setup step is a one-line npm proxy config.
+Attaching drops you straight into pi's TUI; setup downloads and installs
+nothing — the only step is a one-line npm proxy config. The image itself still
+has to be pulled the first time, if it isn't cached locally.
 
 ## How auth works
 

--- a/pi/README.md
+++ b/pi/README.md
@@ -7,9 +7,9 @@ TUI.
 
 Unlike the previous version of this kit (which npm-installed pi at sandbox
 creation, minutes on first boot), this kit uses a **pre-baked sandbox
-image**: pi ships inside the image at a pinned version. The kit itself only
-applies policy and runs `pi` as the entrypoint, so a new sandbox is ready in
-seconds.
+image**: pi ships inside the image, rebuilt nightly against the latest
+upstream release. The kit itself applies policy, points npm at the sandbox
+proxy, and runs `pi` as the entrypoint, so a new sandbox is ready in seconds.
 
 ## Usage
 
@@ -29,8 +29,8 @@ Or with a local clone of this repo:
 sbx run --kit ./pi/ pi
 ```
 
-Attaching drops you straight into pi's TUI; nothing is installed at create
-time.
+Attaching drops you straight into pi's TUI; nothing is downloaded at create
+time — the only setup step is a one-line npm proxy config.
 
 ## How auth works
 
@@ -49,7 +49,7 @@ which one materializes:
 | host credential | sandbox receives | wire format |
 |---|---|---|
 | API key — `sbx secret set anthropic` | `ANTHROPIC_API_KEY` sentinel | `x-api-key` |
-| OAuth login (Claude Pro/Max) — `sbx login` | `~/.pi/agent/auth.json` with OAuth sentinels | `Bearer` |
+| OAuth login — sign in from a `claude` sandbox | `~/.pi/agent/auth.json` with OAuth sentinels | `Bearer` |
 | `claude setup-token` — custom secret ([below](#barebones-sandbox-no-credential-yet)) | `ANTHROPIC_OAUTH_TOKEN` placeholder | `Bearer` |
 | none | `ANTHROPIC_API_KEY` sentinel, nothing to swap it for | 401 ([below](#barebones-sandbox-no-credential-yet)) |
 
@@ -89,9 +89,10 @@ With no Anthropic credential on the host the sandbox still receives
 `ANTHROPIC_API_KEY=proxy-managed`, because the injection is declared by the
 kit rather than by whether a credential exists. pi has no way to tell that
 placeholder from a real key, so instead of "no API key found" you get an
-opaque `401` on the first model call. This kit is deliberately script-free —
-there is no wrapper entrypoint unsetting the placeholder for you — so treat a
-bare 401 as "no credential wired", not as "wrong key".
+opaque `401` on the first model call. The kit runs no scripts beyond a
+one-line npm proxy config — there is no wrapper entrypoint unsetting the
+placeholder for you — so treat a bare 401 as "no credential wired", not as
+"wrong key".
 
 To give it a Claude subscription credential, run `claude setup-token` on a
 machine with Claude Code, then, on the host:
@@ -139,7 +140,7 @@ and publishes its own, from the `Dockerfile` in this directory:
 ```
 docker.io/sbx/pi-image
 └── FROM docker/sandbox-templates:shell-docker
-    └── @earendil-works/pi-coding-agent @ pinned version
+    └── @earendil-works/pi-coding-agent @ latest
         npm global install (+ /usr/local/bin symlink)
 ```
 
@@ -160,9 +161,11 @@ in this repo that builds its own image — see
 kit-specific build script or workflow; CI builds and publishes this image the
 same way it does for `openclaw`/`kiro`/`copilot`.
 
-Upstream releases frequently; bump `PI_VERSION` in the `Dockerfile`
-deliberately rather than tracking `latest`, so two sandboxes created a week
-apart run the same agent.
+Coding agents move fast, so this image rolls: it tracks the npm `latest`
+dist-tag, and the pipeline's nightly scheduled rebuild picks up new releases
+within a day of publish. On days with no release the install layer is a cache
+hit (the Dockerfile comment explains the mechanics). To reproduce a specific
+version, build with `--build-arg PI_VERSION=<version>`.
 
 ### Building locally
 

--- a/pi/README.md
+++ b/pi/README.md
@@ -34,10 +34,39 @@ launches reuse the sandbox.
 Anthropic calls inside the sandbox flow through the sandbox proxy
 automatically: `NODE_USE_ENV_PROXY=1` (set globally by sbx) makes Node.js
 honor `HTTP_PROXY`/`HTTPS_PROXY`, and the proxy substitutes the real
-Anthropic API key for the `proxy-managed` sentinel pi finds in
-`ANTHROPIC_API_KEY`. The agent never sees the real key.
+credential for the `proxy-managed` sentinel on its way out. The agent never
+sees the real one.
 
-Both domains the kit needs are declared in `permissions.network.allow`:
+pi picks the wire format from the token it holds — a value containing
+`sk-ant-oat` goes out as `Authorization: Bearer`, anything else as
+`x-api-key` — and Anthropic rejects either shape sent in the wrong header. So
+the kit declares both credential shapes, and the host's credential decides
+which one materializes:
+
+| host credential | sandbox receives | wire format |
+|---|---|---|
+| API key — `sbx secret set anthropic` | `ANTHROPIC_API_KEY` sentinel | `x-api-key` |
+| OAuth login (Claude Pro/Max) — `sbx login` | `~/.pi/agent/auth.json` with OAuth sentinels | `Bearer` |
+
+An API key wins when the host has one. Without the `oauth:` block a host whose
+only Anthropic credential is an OAuth login would get no usable credential at
+all: the API-key sentinel would reach Anthropic unswapped and every model call
+would 401.
+
+The OAuth path needs no bootstrap script, because the credential file the
+engine materializes *is* pi's own auth store — pi reads
+`~/.pi/agent/auth.json` natively, and a credential found there outranks the
+environment in pi's resolution order (`--api-key` > `auth.json` > env >
+`models.json`). The file holds sentinels, not real tokens; the proxy swaps
+them on egress to `api.anthropic.com` and performs the refresh against
+`platform.claude.com` when the access token nears expiry.
+
+Two things worth knowing about that file: the engine writes it at sandbox
+start, so entries you add *inside* the sandbox for other providers do not
+survive a restart, and `SBX_CRED_ANTHROPIC_MODE` reports `none` for an OAuth
+login just as it does for no credential at all — don't key anything off it.
+
+Every domain the kit needs is declared in `permissions.network.allow`:
 
 - `api.anthropic.com` — a credential's inject domains are **not** allowed
   implicitly, so the domain has to be listed here as well as in the
@@ -45,3 +74,4 @@ Both domains the kit needs are declared in `permissions.network.allow`:
   `sbx policy init deny-all`, where anything unlisted is simply unreachable.
 - `registry.npmjs.org` — the create-time install, plus pi's own runtime
   package installs (`pi install npm:...`, `pi update`).
+- `platform.claude.com:443` — the OAuth token endpoint, for the refresh.

--- a/pi/README.md
+++ b/pi/README.md
@@ -1,6 +1,6 @@
 # pi
 
-A standalone agent kit (`kind: agent`) for the
+A standalone sandbox kit (`kind: sandbox`, the v2 spec naming) for the
 [`@earendil-works/pi-coding-agent`](https://www.npmjs.com/package/@earendil-works/pi-coding-agent)
 CLI — a minimal terminal coding agent with extensible tools, skills, and
 TUI. The kit installs `pi` via npm at sandbox creation time and runs
@@ -24,18 +24,24 @@ Or with a local clone of this repo:
 sbx run --kit ./pi/ pi
 ```
 
-The first launch installs the agent via `npm install -g`. Subsequent
+The first launch installs the agent via `npm install -g`, at the version
+pinned in `spec.yaml` — upstream releases frequently, so the pin is what
+keeps two sandboxes created a week apart running the same agent. Subsequent
 launches reuse the sandbox.
 
 ## How auth works
 
-Anthropic SDK calls inside the sandbox flow through the sandbox proxy
-automatically: `NODE_USE_ENV_PROXY=1` (set globally by sbx) makes
-Node.js honor `HTTP_PROXY`/`HTTPS_PROXY`, and the proxy substitutes
-the real Anthropic credentials in place of the `proxy-managed`
-sentinel that's already in the default sandbox environment. The agent
-never sees the real key.
+Anthropic calls inside the sandbox flow through the sandbox proxy
+automatically: `NODE_USE_ENV_PROXY=1` (set globally by sbx) makes Node.js
+honor `HTTP_PROXY`/`HTTPS_PROXY`, and the proxy substitutes the real
+Anthropic API key for the `proxy-managed` sentinel pi finds in
+`ANTHROPIC_API_KEY`. The agent never sees the real key.
 
-`registry.npmjs.org` is the only domain the kit adds to
-`allowedDomains` — it's needed for the install. `api.anthropic.com`
-is reached via default sandbox policy, not a kit allowlist entry.
+Both domains the kit needs are declared in `permissions.network.allow`:
+
+- `api.anthropic.com` — a credential's inject domains are **not** allowed
+  implicitly, so the domain has to be listed here as well as in the
+  credential block. This repo's e2e runs every kit under
+  `sbx policy init deny-all`, where anything unlisted is simply unreachable.
+- `registry.npmjs.org` — the create-time install, plus pi's own runtime
+  package installs (`pi install npm:...`, `pi update`).

--- a/pi/spec.yaml
+++ b/pi/spec.yaml
@@ -4,11 +4,12 @@ name: pi
 displayName: Pi
 description: Minimal terminal coding agent with extensible tools, skills, and TUI
 sandbox:
-  # Pre-baked image: pi at a pinned version, on the shell-docker template.
-  # Built and published by build-and-publish-kits.yml, the shared kit-image
-  # pipeline (see ../PUBLISHING.md) -- no bespoke workflow needed, same as
-  # openclaw/kiro/copilot. Creating a sandbox no longer waits on an npm
-  # install; bumping pi is a Dockerfile change.
+  # Pre-baked image: pi at the latest upstream release, on the shell-docker
+  # template. Built and published by build-and-publish-kits.yml, the shared
+  # kit-image pipeline (see ../PUBLISHING.md) -- no bespoke workflow needed,
+  # same as openclaw/kiro/copilot. Creating a sandbox no longer waits on an
+  # npm install; the pipeline's nightly rebuild keeps pi current (rolling
+  # updates, no deliberate version bump -- see the Dockerfile).
   image: docker.io/sbx/pi-image:latest
   entrypoint:
     - pi
@@ -17,21 +18,13 @@ agentInstructions:
 permissions:
   network:
     allow:
-      # Every domain the anthropic credential injects into -- required here
-      # too, not just in the credential block: there is no auto-derived egress
-      # from `credentials`, and this repo's e2e runs every kit under
-      # `sbx policy init deny-all`, so a domain absent from this list is
-      # unreachable regardless of what the credential declares.
+      # A credential's inject domains are not allowed implicitly, and e2e runs
+      # every kit under deny-all -- see README, "How auth works".
       - api.anthropic.com
-      # Kept after the install moved into the image: pi installs packages
-      # (extensions, skills, prompt templates, themes) from npm at runtime --
-      # `pi install npm:@scope/pkg`, `pi -e npm:...`, `pi update` -- and
-      # settings.json packages are fetched on startup. Without this they all
-      # fail under deny-all.
+      # pi's runtime package installs (extensions, skills, prompt templates,
+      # themes) and the packages named in settings, fetched on startup.
       - registry.npmjs.org
-      # The oauth credential's token endpoint. pi POSTs the sentinel refresh
-      # token here once the access token nears expiry; the proxy intercepts
-      # the call, refreshes with the real token, and re-masks the response.
+      # The oauth block's token-refresh endpoint.
       - platform.claude.com:443
 credentials:
   - service: anthropic
@@ -39,51 +32,54 @@ credentials:
       name: ANTHROPIC_API_KEY
       proxyManaged: true
       inject:
-        # The only host pi ever sends an Anthropic API key to. claude.ai and
-        # console.anthropic.com are boilerplate copied between kits; pi never
-        # calls them, so listing them would be credential-exposure surface
-        # bought for nothing.
+        # pi only sends x-api-key to api.anthropic.com; no other host needs
+        # the key, so no other host gets it.
         - domain: api.anthropic.com
           header: x-api-key
           format: '%s'
-    # Without this block a host whose stored anthropic credential is an OAuth
-    # login -- what `sbx login` produces, and what CONTRIBUTING documents as
-    # the one-time e2e setup -- has no usable credential here at all: the
-    # apiKey sentinel reaches Anthropic unswapped and every model call is a
-    # 401. Declaring oauth lets the proxy authenticate egress with it, while
-    # "api key wins when found" keeps the API-key path above untouched.
-    #
-    # Unlike openclaw, pi needs no bootstrap script to pick this up:
-    # credentialFile *is* pi's native auth store, and pi resolves credentials
-    # `--api-key` > auth.json > env > models.json -- so the materialized file
-    # outranks the apiKey sentinel in the environment, which is exactly the
-    # precedence this needs.
+    # For a host whose stored anthropic credential is an OAuth login -- signed
+    # in from a `claude` sandbox. Without this block such a host has no usable
+    # credential here: the apiKey sentinel reaches Anthropic unswapped and
+    # every model call is a 401. An API key still wins when the host has one.
     oauth:
       tokenEndpoint:
         host: platform.claude.com
         path: /v1/oauth/token
-      # Where the bearer is actually used, so the proxy swaps the access-token
-      # sentinel on inference calls and not only on token refresh. pi picks
-      # the wire format from the token value -- anything containing
-      # `sk-ant-oat` goes out as `Authorization: Bearer`, everything else as
-      # `x-api-key` -- so the sentinel below is what selects Bearer here.
+      # Where the bearer is used, so the access-token sentinel is swapped on
+      # inference calls and not only on refresh. pi sends a value containing
+      # `sk-ant-oat` as `Authorization: Bearer`, so the sentinel below is what
+      # selects that format -- see README, "How auth works".
       resourceHosts:
         - api.anthropic.com
       sentinels:
         accessToken: sk-ant-oat01-proxy-managed
         refreshToken: sk-ant-ort01-proxy-managed
       credentialFile:
-        # pi reads this file itself; nothing in the kit has to translate it.
+        # pi's native auth store, which pi prefers over the environment, so
+        # nothing in the kit has to translate it.
         path: ~/.pi/agent/auth.json
         structure:
           anthropic:
             type: oauth
             access: "{{.AccessToken}}"
             refresh: "{{.RefreshToken}}"
-            # A standalone {{.ExpiresAt}} is rendered as a JSON number rather
-            # than a string, which is what pi's store wants here: `expires` is
-            # typed `number` (Unix ms), and pi refreshes once it is within
-            # five minutes of it.
+            # A standalone {{.ExpiresAt}} (SPEC-v2 §5.4.2, Unix ms) materializes
+            # as a JSON number in practice -- the type pi's store wants. Observed
+            # behavior, not something the spec text promises.
             expires: "{{.ExpiresAt}}"
-# No setup.install: the Dockerfile bakes pi in. Re-declaring the npm install
-# here would run it again on every create and every recreate, for nothing.
+setup:
+  # Config only -- pi itself is baked into the image, so nothing is installed
+  # here. This is the re-export pattern of SPEC-v2 §9.5, and it is idempotent,
+  # so re-running it on recreate is fine.
+  #
+  # Guarded on HTTP_PROXY being non-empty: npm rejects an empty value for a
+  # url-typed config key, so an unset or empty variable would fail the step and
+  # take sandbox creation down with it -- a proxy-less runtime is something
+  # every sibling kit tolerates, and this one should too. HTTPS_PROXY is
+  # preferred for https-proxy when the runtime provides a dedicated one, with
+  # HTTP_PROXY as the fallback. Both keys go in a single `npm config set` so
+  # sandbox creation pays for one Node startup rather than two.
+  install:
+    - command: 'if [ -n "${HTTP_PROXY:-}" ]; then npm config set proxy="$HTTP_PROXY" https-proxy="${HTTPS_PROXY:-$HTTP_PROXY}"; fi'
+      user: "1000"
+      description: Point npm at the sandbox proxy in ~/.npmrc so pi's runtime npm use (`pi install npm:...`, `pi update`, startup package fetches) works in exec contexts that do not inherit the proxy environment variables

--- a/pi/spec.yaml
+++ b/pi/spec.yaml
@@ -4,7 +4,12 @@ name: pi
 displayName: Pi
 description: Minimal terminal coding agent with extensible tools, skills, and TUI
 sandbox:
-  image: docker/sandbox-templates:shell-docker
+  # Pre-baked image: pi at a pinned version, on the shell-docker template.
+  # Built and published by build-and-publish-kits.yml, the shared kit-image
+  # pipeline (see ../PUBLISHING.md) -- no bespoke workflow needed, same as
+  # openclaw/kiro/copilot. Creating a sandbox no longer waits on an npm
+  # install; bumping pi is a Dockerfile change.
+  image: docker.io/sbx/pi-image:latest
   entrypoint:
     - pi
 agentInstructions:
@@ -18,8 +23,11 @@ permissions:
       # `sbx policy init deny-all`, so a domain absent from this list is
       # unreachable regardless of what the credential declares.
       - api.anthropic.com
-      # The install below, and pi's runtime package installs
-      # (`pi install npm:...`, `pi update`).
+      # Kept after the install moved into the image: pi installs packages
+      # (extensions, skills, prompt templates, themes) from npm at runtime --
+      # `pi install npm:@scope/pkg`, `pi -e npm:...`, `pi update` -- and
+      # settings.json packages are fetched on startup. Without this they all
+      # fail under deny-all.
       - registry.npmjs.org
       # The oauth credential's token endpoint. pi POSTs the sentinel refresh
       # token here once the access token nears expiry; the proxy intercepts
@@ -77,18 +85,5 @@ credentials:
             # typed `number` (Unix ms), and pi refreshes once it is within
             # five minutes of it.
             expires: "{{.ExpiresAt}}"
-setup:
-  install:
-    # Pinned deliberately: upstream releases frequently, and an unpinned
-    # `npm install -g` means two sandboxes created a week apart run different
-    # agents.
-    #
-    # `until <install>; do ...; done` rather than the `while [ $i -lt 5 ]; do
-    # <install> && break; ...; done` shape: the latter leaves the loop cleanly
-    # once the counter runs out, so five consecutive failures still exit 0 and
-    # creation reports success with no `pi` binary in the sandbox. The
-    # trailing `command -v pi` is the outcome check that the install's exit
-    # code alone does not give us.
-    - command: npm config set proxy "$HTTP_PROXY" && npm config set https-proxy "$HTTP_PROXY" && i=0 && until npm install -g --maxsockets=1 --fetch-timeout=600000 @earendil-works/pi-coding-agent@0.84.2; do i=$((i+1)); [ $i -ge 5 ] && exit 1; echo "Retrying ($i/5)..."; done && command -v pi
-      user: "1000"
-      description: Configure npm proxy and install pi coding agent globally (with retries)
+# No setup.install: the Dockerfile bakes pi in. Re-declaring the npm install
+# here would run it again on every create and every recreate, for nothing.

--- a/pi/spec.yaml
+++ b/pi/spec.yaml
@@ -21,6 +21,10 @@ permissions:
       # The install below, and pi's runtime package installs
       # (`pi install npm:...`, `pi update`).
       - registry.npmjs.org
+      # The oauth credential's token endpoint. pi POSTs the sentinel refresh
+      # token here once the access token nears expiry; the proxy intercepts
+      # the call, refreshes with the real token, and re-masks the response.
+      - platform.claude.com:443
 credentials:
   - service: anthropic
     apiKey:
@@ -34,6 +38,45 @@ credentials:
         - domain: api.anthropic.com
           header: x-api-key
           format: '%s'
+    # Without this block a host whose stored anthropic credential is an OAuth
+    # login -- what `sbx login` produces, and what CONTRIBUTING documents as
+    # the one-time e2e setup -- has no usable credential here at all: the
+    # apiKey sentinel reaches Anthropic unswapped and every model call is a
+    # 401. Declaring oauth lets the proxy authenticate egress with it, while
+    # "api key wins when found" keeps the API-key path above untouched.
+    #
+    # Unlike openclaw, pi needs no bootstrap script to pick this up:
+    # credentialFile *is* pi's native auth store, and pi resolves credentials
+    # `--api-key` > auth.json > env > models.json -- so the materialized file
+    # outranks the apiKey sentinel in the environment, which is exactly the
+    # precedence this needs.
+    oauth:
+      tokenEndpoint:
+        host: platform.claude.com
+        path: /v1/oauth/token
+      # Where the bearer is actually used, so the proxy swaps the access-token
+      # sentinel on inference calls and not only on token refresh. pi picks
+      # the wire format from the token value -- anything containing
+      # `sk-ant-oat` goes out as `Authorization: Bearer`, everything else as
+      # `x-api-key` -- so the sentinel below is what selects Bearer here.
+      resourceHosts:
+        - api.anthropic.com
+      sentinels:
+        accessToken: sk-ant-oat01-proxy-managed
+        refreshToken: sk-ant-ort01-proxy-managed
+      credentialFile:
+        # pi reads this file itself; nothing in the kit has to translate it.
+        path: ~/.pi/agent/auth.json
+        structure:
+          anthropic:
+            type: oauth
+            access: "{{.AccessToken}}"
+            refresh: "{{.RefreshToken}}"
+            # A standalone {{.ExpiresAt}} is rendered as a JSON number rather
+            # than a string, which is what pi's store wants here: `expires` is
+            # typed `number` (Unix ms), and pi refreshes once it is within
+            # five minutes of it.
+            expires: "{{.ExpiresAt}}"
 setup:
   install:
     # Pinned deliberately: upstream releases frequently, and an unpinned

--- a/pi/spec.yaml
+++ b/pi/spec.yaml
@@ -12,6 +12,14 @@ agentInstructions:
 permissions:
   network:
     allow:
+      # Every domain the anthropic credential injects into -- required here
+      # too, not just in the credential block: there is no auto-derived egress
+      # from `credentials`, and this repo's e2e runs every kit under
+      # `sbx policy init deny-all`, so a domain absent from this list is
+      # unreachable regardless of what the credential declares.
+      - api.anthropic.com
+      # The install below, and pi's runtime package installs
+      # (`pi install npm:...`, `pi update`).
       - registry.npmjs.org
 credentials:
   - service: anthropic
@@ -19,17 +27,25 @@ credentials:
       name: ANTHROPIC_API_KEY
       proxyManaged: true
       inject:
+        # The only host pi ever sends an Anthropic API key to. claude.ai and
+        # console.anthropic.com are boilerplate copied between kits; pi never
+        # calls them, so listing them would be credential-exposure surface
+        # bought for nothing.
         - domain: api.anthropic.com
-          header: x-api-key
-          format: '%s'
-        - domain: claude.ai
-          header: x-api-key
-          format: '%s'
-        - domain: console.anthropic.com
           header: x-api-key
           format: '%s'
 setup:
   install:
-    - command: npm config set proxy $HTTP_PROXY && npm config set https-proxy $HTTP_PROXY && i=0; while [ $i -lt 5 ]; do npm install -g --maxsockets=1 --fetch-timeout=600000 @earendil-works/pi-coding-agent && break; i=$((i+1)); echo "Retrying ($i/5)..."; done
+    # Pinned deliberately: upstream releases frequently, and an unpinned
+    # `npm install -g` means two sandboxes created a week apart run different
+    # agents.
+    #
+    # `until <install>; do ...; done` rather than the `while [ $i -lt 5 ]; do
+    # <install> && break; ...; done` shape: the latter leaves the loop cleanly
+    # once the counter runs out, so five consecutive failures still exit 0 and
+    # creation reports success with no `pi` binary in the sandbox. The
+    # trailing `command -v pi` is the outcome check that the install's exit
+    # code alone does not give us.
+    - command: npm config set proxy "$HTTP_PROXY" && npm config set https-proxy "$HTTP_PROXY" && i=0 && until npm install -g --maxsockets=1 --fetch-timeout=600000 @earendil-works/pi-coding-agent@0.84.2; do i=$((i+1)); [ $i -ge 5 ] && exit 1; echo "Retrying ($i/5)..."; done && command -v pi
       user: "1000"
       description: Configure npm proxy and install pi coding agent globally (with retries)


### PR DESCRIPTION
## What

One commit per concern, all confined to `pi/`:

1. **Correctness** — the kit injected the anthropic credential into `api.anthropic.com` without allowing that domain, so under `deny-all` (how this repo's e2e runs every kit) no model call could get through. Also fixes the npm install retry loop that exited 0 when all attempts failed. Inject list trimmed to `api.anthropic.com` only — pi never sends `x-api-key` to the other two domains the kit listed.
2. **Claude Pro/Max OAuth** — an `oauth:` credential block, same pattern as openclaw's, but simpler: the credential file targets pi's own `~/.pi/agent/auth.json` in its native format, which pi reads directly and prefers over env vars, so no bootstrap script is needed. Token refresh goes through `platform.claude.com`, now allowed.
3. **Credential-path docs** — README covers all four host states (API key, OAuth login from a `claude` sandbox, `claude setup-token` via `ANTHROPIC_OAUTH_TOKEN`, none), including the stale-service-secret double-auth-header trap and why authenticating inside the sandbox must be avoided.
4. **Pre-baked image** — `docker.io/sbx/pi-image:latest` built from a new `pi/Dockerfile`; `setup.install` no longer installs anything, so first boot drops from minutes to seconds.
5. **Rolling updates** — the image tracks the npm `latest` dist-tag and the pipeline's nightly rebuild picks up new releases: an `ADD` of the registry's version document busts the layer cache exactly when upstream publishes (and keeps pinned `--build-arg PI_VERSION=<v>` builds reproducible), the install reads the version out of that document so one manifest list cannot mix releases, and an in-layer `pi --version` gate fails the build on a release the image's Node can't run — npm alone only warns. The kit keeps one config-only install step (guarded npm proxy re-export, the SPEC-v2 §9.5 pattern) so pi's runtime `pi install npm:...` keeps working.
6. **fd baked into the image** — pi's `find` tool probes for `fd`/`fdfind` and otherwise downloads a binary from GitHub releases at runtime, which `deny-all` blocks (no GitHub release host is allowlisted) — so `find` was broken under the e2e policy and a first-use wait everywhere else. `fd-find` now ships in the image (apt, plus an `fd` symlink), in a layer placed above the version-document ADD so it stays cached across nightly rebuilds. ripgrep needs no equivalent: pi probes for `rg` the same way and the base image already ships it.

## Testing

- [x] `go run ./scripts/verify-kit-spec ./pi` — valid, no warnings (after each commit)
- [x] `./scripts/test-kit.sh pi` (TCK, locally built image) — all legs pass, incl. the `oauth_policy/anthropic` subtests and `install_execution` for the proxy step
- [x] `./scripts/check-image-ref.sh docker.io/sbx latest` — image name passes CI's guard
- [x] Image checks: `fd --version` = 10.3.0, `pi --version` = 0.84.2 (current latest), runs as `agent`, agent-owned module tree, labels `flavor=pi` / `start-docker=true` / `base` set, pinned build `--build-arg PI_VERSION=0.84.2` reproduces 0.84.2
- [ ] `./scripts/test-kit-e2e.sh pi` under `deny-all`, both credential modes — host-only, pending (draft until done)

Note: `docker.io/sbx/pi-image` doesn't exist on Hub yet; first publish happens on merge, so pre-merge TCK runs need a local `docker build -t docker.io/sbx/pi-image:latest pi` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
