### PR TITLE
spec: per-field runtime support ledger with refuse/warn evaluator

### DIFF
--- a/spec/SPEC-v2.md
+++ b/spec/SPEC-v2.md
@@ -188,6 +188,7 @@ A sandbox kit is a complete agent. It **MUST** declare a `sandbox:` block and
 | [`environment`](#55-environment) | optional | Static environment variables. |
 | [`setup`](#56-setup) | optional | `install` / `startup` / `files`. |
 | [`volumes`](#57-volumes) | optional | Block and tmpfs mounts. |
+| `security` | optional | `security.privileged` only. Needs the host-kernel capability; see [§10](#10-runtime-support). |
 | `files/` tree | optional | Static files (see [§5.8](#58-files-directory)). |
 
 ### 3.2 The `sandbox:` block
@@ -267,6 +268,11 @@ The effective argv per mode:
 as-is. There is **no** `pipeMode` field in v2 (the v1 `entrypoint.pipeMode` was
 dropped).
 
+Precedence when the runtime caller also supplies a command: an explicit
+runtime command (a CLI flag, an API start command) beats `entrypoint` +
+`command`, and the kit beats the image's own entrypoint/CMD. This holds on
+every backend, including server-applied ones.
+
 #### 3.2.4 `resources`
 
 Optional container limits. Any unset field means "no constraint from the spec".
@@ -276,6 +282,12 @@ Optional container limits. Any unset field means "no constraint from the spec".
 | `cpu` | float | Cores. MUST be non-negative. |
 | `memory` | string | Byte-size string (`units.RAMInBytes`, e.g. `4096m`, `8g`, `2gib`). MUST parse. |
 | `gpu` | string | Consumer-defined selector (`"1"`, `"all"`, …). |
+
+Precedence: an explicit caller request (CLI flags, API resource fields) beats
+the kit's declared `resources`, and the declaration beats the platform
+default. `gpu` is refused on a runtime that does not declare the
+gpu-selector capability, rather than silently ignored (see
+[§10](#10-runtime-support)).
 
 ### 3.3 Agent instructions for a sandbox
 
@@ -764,6 +776,12 @@ volumes:
 Volumes are **creation-time only** — `sbx kit add` cannot attach volumes to a
 running container. Composition: union by `path`, last-wins.
 
+Identity: a kit volume is sandbox-scoped. It is auto-provisioned for the
+sandbox at create, one volume per (sandbox, kit, path), sized as declared,
+and reclaimed with the sandbox. A runtime without the kit-volumes
+capability surfaces the gap per [§10](#10-runtime-support) instead of
+dropping the declaration.
+
 ### 5.8 `files/` directory
 
 Static files packed alongside `spec.yaml` and copied into the container at
@@ -954,9 +972,69 @@ reading what the runtime sets.
 ### 9.6 Lifecycle
 
 - `setup.install` runs once, before the sandbox's entrypoint first runs.
-- `setup.startup` MAY run on every sandbox start (create, stop and start,
+- `setup.startup` runs on every sandbox start (create, stop and start,
   daemon restart, host reboot). Entries MUST be idempotent ([§5.6](#56-setup)).
+  Running once at apply time was considered and rejected: the field's
+  contract is start-time state, and a backend that does not yet re-run it
+  tracks the gap per [§10](#10-runtime-support).
 - A long-running background process started by kit content MUST be started as
   a process group leader (for example with `setsid`), with stdio redirected
   away from the launching script, so it outlives its setup command and can be
   signaled as a unit.
+
+## 10. Runtime support
+
+A kit authored and verified on one runtime must behave the same on any
+other, or fail loudly. The rule for every declared field: a runtime honours
+the field with the semantics this spec defines, or it refuses or visibly
+skips the application, naming the field. Silent dropping is not a permitted
+outcome. Silent reinterpretation is not one either: mapping a declared field
+onto a different mechanism the author did not declare is the same defect,
+and the correct move is a refusal whose message names the portable
+alternative.
+
+Some fields need a runtime capability beyond the core contract: a shared
+host kernel for `security.privileged`, a gpu selector, kit volume
+auto-provisioning, kit port publication, mixin agent-context delivery. A
+runtime declares the set it implements (`CapabilitySet`), and the
+machine-readable ledger, `EvaluateSupport` in the `spec` package
+(`spec/support.go`), returns the declared fields whose capability the
+runtime lacks, each with an action:
+
+| Action | Applier obligation |
+|---|---|
+| `refuse` | Fail the whole application, naming every refused field in one error. |
+| `warn` | Apply the rest, and surface the skipped field visibly (a warning, operation metadata). Never silently. |
+
+The action encodes the field's failure severity, so it holds for every
+runtime lacking the capability: running a workload unprivileged when it
+declared `privileged` is a security divergence and refuses, while an
+undelivered convenience degrades with a visible skip. A field with no
+ledger entry needs no capability beyond the core contract. A test in the
+package forces every grammar field to be classified, so a new field cannot
+ship unclassified. An undeclared capability reads as not implemented, so an
+applier that declares nothing fails closed.
+
+Three duties follow for appliers:
+
+1. Evaluate the ledger before applying: in the serving runtime where the
+   runtime applies the kit, in the client where the client projects it.
+2. Where a client projects a kit toward a serving runtime, the serving
+   runtime's evaluation governs when the two pin different releases of this
+   module. The client check is advisory preflight.
+3. A `warn`-tier gap is transitional for a runtime that can build the
+   capability, and the target state is a declared capability, not a
+   standing warning.
+
+A capability can also be permanently absent: the runtime's substrate does
+not have the thing the field names, and no roadmap closes it. A runtime
+whose sandboxes share no host kernel refuses `security.privileged`
+permanently. Authors carve runtime-specific intent out of an otherwise
+portable kit with mixins. There is no per-field conditionality mechanism,
+by design.
+
+Portability guidance for authors: kit content MUST NOT assume host
+filesystem paths. A runtime may give the sandbox no reachable host
+filesystem, and commands that reference host paths exit successfully having
+done nothing. Content that genuinely needs a host path belongs in a mixin
+applied only where that host exists.

--- a/spec/SPEC-v2.md
+++ b/spec/SPEC-v2.md
@@ -978,6 +978,11 @@ reading what the runtime sets.
   Running once at apply time was considered and rejected: the field's
   contract is start-time state, and a backend that does not yet re-run it
   tracks the gap per [§10](#10-runtime-support).
+  A start counts for this rule only when processes boot fresh. A runtime
+  whose stop and start is a memory resume, where the sandbox's processes
+  survive a snapshot and continue, MUST NOT re-run startup on that resume:
+  the started state the rule protects never went away, and a re-run into a
+  surviving process tree would duplicate it.
 - A long-running background process started by kit content MUST be started as
   a process group leader (for example with `setsid`), with stdio redirected
   away from the launching script, so it outlives its setup command and can be

--- a/spec/SPEC-v2.md
+++ b/spec/SPEC-v2.md
@@ -726,7 +726,7 @@ setup:
       description: "…"
   files:                                   # files written at startup via shell exec
     - path: /home/agent/.cfg/config.json   # REQUIRED, absolute
-      content: '{"workdir": "${WORKDIR}"}' # only ${WORKDIR} placeholder is allowed
+      content: '{"workdir": "${WORKDIR}"}' # ${WORKDIR} is substituted; other ${...} text passes through literally
       mode: "0644"                         # optional octal (default 0644)
       onlyIfMissing: true                  # optional; skip if the file exists
       description: "…"
@@ -736,7 +736,7 @@ setup:
 |---|---|---|
 | `install[].command` | **string** (REQUIRED) | `sh -c <string>`; shell metacharacters work. A list is an error. |
 | `startup[].command` | **list<string>** (REQUIRED, non-empty) | Exec-style argv, no shell processing. For a shell, use `["sh", "-c", "<cmd>"]`. |
-| `files[]` | file write | Shell exec as uid `1000` (agent); `path` absolute; `mode` octal; only `${WORKDIR}` placeholder allowed in `content`. |
+| `files[]` | file write | Shell exec as uid `1000` (agent). `path` absolute, `mode` octal. `${WORKDIR}` in `content` is substituted, and any other `${...}` text passes through literally (#200). |
 
 - `install` runs **once** at sandbox creation, for every kit (built-in or
   user-supplied). Guard with `command -v <binary>` or use `files` with
@@ -834,9 +834,10 @@ the per-field rules above:
   runtime guard, so a kit that validates here will not fail the interceptor
   later. Placeholder *correctness* inside `structure` is checked by the
   engine at render time, not here.
-- **setup**: `install[].command` non-empty; `startup[].command` non-empty;
-  `files[].path` absolute; `files[].mode` octal; only `${WORKDIR}` placeholder
-  in `files[].content`.
+- **setup**: `install[].command` and `startup[].command` non-empty,
+  `files[].path` absolute, `files[].mode` octal. `files[].content` is not
+  placeholder-checked. `${WORKDIR}` is substituted at write time, and any
+  other `${...}` text passes through literally (#200).
 - **locked**: each a well-formed dotted path; no duplicates.
 - **licenses**: each non-empty; no duplicates.
 - **args**: each name matches the argument-name pattern; exactly one of

--- a/spec/support.go
+++ b/spec/support.go
@@ -1,0 +1,146 @@
+package spec
+
+// Capability names one runtime ability a kit field needs beyond the core
+// contract every runtime provides. A runtime declares the set it implements
+// (CapabilitySet); EvaluateSupport reports the declared fields whose
+// capability the runtime lacks. SPEC-v2.md §10 is the normative home.
+type Capability string
+
+const (
+	// CapabilityHostKernel means sandboxes share the runtime host's kernel,
+	// which is what makes security.privileged meaningful.
+	CapabilityHostKernel Capability = "host-kernel"
+	// CapabilityGPUSelector means the runtime applies sandbox.resources.gpu.
+	CapabilityGPUSelector Capability = "gpu-selector"
+	// CapabilityKitVolumes means the runtime auto-provisions the volumes
+	// list with §5.7's identity: per (sandbox, kit, path), sized, reclaimed.
+	CapabilityKitVolumes Capability = "kit-volumes"
+	// CapabilityKitPorts means the runtime publishes the declared ports.
+	CapabilityKitPorts Capability = "kit-ports"
+	// CapabilityMixinAgentContext means the runtime delivers a mixin's
+	// agentInstructions content per §4.2.
+	CapabilityMixinAgentContext Capability = "mixin-agent-context"
+)
+
+// CapabilitySet declares the capabilities a runtime implements. A missing
+// key reads as not implemented, so a runtime that declares nothing gets the
+// full finding list for what a kit declares: the set fails closed.
+type CapabilitySet map[Capability]bool
+
+// SupportAction is what an applier MUST do with a declared field whose
+// capability its runtime lacks. There is no silent tier: a field is applied
+// with its specified semantics, refused, or visibly skipped.
+type SupportAction string
+
+const (
+	// ActionRefuse fails the whole application, naming the field.
+	ActionRefuse SupportAction = "refuse"
+	// ActionWarn applies the rest of the kit and surfaces the skipped
+	// field visibly (a warning, operation metadata) — never silently.
+	ActionWarn SupportAction = "warn"
+)
+
+// SupportFinding reports one declared field the runtime cannot honour.
+type SupportFinding struct {
+	// Field is the dotted v2 grammar path (e.g. "security.privileged").
+	Field string
+	// Capability the runtime would need to honour the field.
+	Capability Capability
+	// Action the applier MUST take.
+	Action SupportAction
+	// Reason states why the field cannot be honoured without the capability.
+	Reason string
+	// Alternative names the portable way to get the effect, empty when
+	// none exists.
+	Alternative string
+}
+
+type supportRule struct {
+	field       string
+	capability  Capability
+	declared    func(*Artifact) bool
+	action      SupportAction
+	reason      string
+	alternative string
+}
+
+// supportRules is the per-field support ledger. A field with no rule needs
+// no capability beyond the core contract and is honoured on every runtime;
+// TestSupportLedgerCompleteness forces every grammar field to be classified
+// one way or the other. The action encodes the field's failure severity:
+// running a privileged workload unprivileged is a security divergence and
+// refuses, while an undelivered convenience degrades with a visible skip.
+var supportRules = []supportRule{
+	{
+		field:      v2Field("Security", "Privileged"),
+		capability: CapabilityHostKernel,
+		declared: func(a *Artifact) bool {
+			return a.Manifest.Security != nil && a.Manifest.Security.Privileged
+		},
+		action: ActionRefuse,
+		reason: "sandboxes on this runtime do not share a host kernel, so privileged cannot be honoured",
+	},
+	{
+		field:      v2Field("Sandbox", "Resources", "GPU"),
+		capability: CapabilityGPUSelector,
+		declared: func(a *Artifact) bool {
+			return a.Manifest.Resources != nil && a.Manifest.Resources.GPU != ""
+		},
+		action: ActionRefuse,
+		reason: "this runtime does not apply the gpu selector, so declaring it would be silently inert",
+	},
+	{
+		field:      v2Field("Volumes"),
+		capability: CapabilityKitVolumes,
+		declared: func(a *Artifact) bool {
+			return len(a.Manifest.Volumes) > 0
+		},
+		action:      ActionWarn,
+		reason:      "this runtime does not auto-provision kit volumes, so state under the declared paths would not persist",
+		alternative: "attach a pre-created volume at create, or ship static content under files/",
+	},
+	{
+		field:      v2Field("PublishedPorts"),
+		capability: CapabilityKitPorts,
+		declared: func(a *Artifact) bool {
+			return len(a.PublishedPorts) > 0
+		},
+		action:      ActionWarn,
+		reason:      "this runtime does not publish the declared ports",
+		alternative: "publish the ports after create through the runtime's port controls",
+	},
+	{
+		field:      v2Field("AgentInstructions", "Content"),
+		capability: CapabilityMixinAgentContext,
+		declared: func(a *Artifact) bool {
+			return a.Manifest.Kind == KindMixin && a.AgentContext != ""
+		},
+		action:      ActionWarn,
+		reason:      "this runtime does not deliver a mixin's agentInstructions content",
+		alternative: "put shared instructions in the base kit's agentInstructions",
+	},
+}
+
+// EvaluateSupport returns every field the artifact declares whose capability
+// the runtime does not implement, in ledger order. An ActionRefuse finding
+// MUST fail the application naming the field; an ActionWarn finding MUST be
+// surfaced visibly. An empty result means the whole declaration is honoured.
+func EvaluateSupport(a *Artifact, caps CapabilitySet) []SupportFinding {
+	if a == nil {
+		return nil
+	}
+	var findings []SupportFinding
+	for _, rule := range supportRules {
+		if caps[rule.capability] || !rule.declared(a) {
+			continue
+		}
+		findings = append(findings, SupportFinding{
+			Field:       rule.field,
+			Capability:  rule.capability,
+			Action:      rule.action,
+			Reason:      rule.reason,
+			Alternative: rule.alternative,
+		})
+	}
+	return findings
+}

--- a/spec/support_test.go
+++ b/spec/support_test.go
@@ -1,0 +1,164 @@
+package spec
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestEvaluateSupport(t *testing.T) {
+	privileged := &Artifact{Manifest: Manifest{Kind: KindSandbox, Security: &Security{Privileged: true}}}
+	gpu := &Artifact{Manifest: Manifest{Kind: KindSandbox, Resources: &Resources{GPU: "all"}}}
+	volumes := &Artifact{Manifest: Manifest{Kind: KindSandbox, Volumes: []MountSpec{{Path: "/home/agent/.cache", Size: "2g"}}}}
+	ports := &Artifact{Manifest: Manifest{Kind: KindSandbox}, PublishedPorts: []PublishedPort{{Container: 8080}}}
+	mixinContext := &Artifact{Manifest: Manifest{Kind: KindMixin}, AgentContext: "use the tool"}
+	sandboxContext := &Artifact{Manifest: Manifest{Kind: KindSandbox}, AgentContext: "use the tool"}
+
+	none := CapabilitySet{}
+	full := CapabilitySet{
+		CapabilityHostKernel:        true,
+		CapabilityGPUSelector:       true,
+		CapabilityKitVolumes:        true,
+		CapabilityKitPorts:          true,
+		CapabilityMixinAgentContext: true,
+	}
+
+	cases := []struct {
+		name string
+		art  *Artifact
+		caps CapabilitySet
+		want []SupportFinding // Field+Action only; reasons asserted non-empty separately
+	}{
+		{name: "nil artifact yields nothing", art: nil, caps: none},
+		{name: "empty artifact needs no capabilities", art: &Artifact{}, caps: none},
+		{name: "privileged refused without host kernel", art: privileged, caps: none,
+			want: []SupportFinding{{Field: "security.privileged", Action: ActionRefuse}}},
+		{name: "privileged honoured with host kernel", art: privileged, caps: full},
+		{name: "gpu refused without the selector capability", art: gpu, caps: none,
+			want: []SupportFinding{{Field: "sandbox.resources.gpu", Action: ActionRefuse}}},
+		{name: "gpu honoured with the selector capability", art: gpu, caps: full},
+		{name: "volumes warn without auto-provisioning", art: volumes, caps: none,
+			want: []SupportFinding{{Field: "volumes", Action: ActionWarn}}},
+		{name: "volumes honoured with auto-provisioning", art: volumes, caps: full},
+		{name: "ports warn without publication", art: ports, caps: none,
+			want: []SupportFinding{{Field: "ports", Action: ActionWarn}}},
+		{name: "ports honoured with publication", art: ports, caps: full},
+		{name: "mixin agent context warns without delivery", art: mixinContext, caps: none,
+			want: []SupportFinding{{Field: "agentInstructions.content", Action: ActionWarn}}},
+		{name: "sandbox agent context needs no capability", art: sandboxContext, caps: none},
+		{name: "nil capability set fails closed", art: privileged, caps: nil,
+			want: []SupportFinding{{Field: "security.privileged", Action: ActionRefuse}}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := EvaluateSupport(tc.art, tc.caps)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d findings %+v, want %d", len(got), got, len(tc.want))
+			}
+			for i, w := range tc.want {
+				if got[i].Field != w.Field || got[i].Action != w.Action {
+					t.Errorf("finding %d = {%s %s}, want {%s %s}", i, got[i].Field, got[i].Action, w.Field, w.Action)
+				}
+				if got[i].Capability == "" {
+					t.Errorf("finding %d has an empty capability", i)
+				}
+				if got[i].Reason == "" {
+					t.Errorf("finding %d has an empty reason", i)
+				}
+			}
+		})
+	}
+}
+
+// TestSupportLedgerCompleteness forces every v2 grammar field to be
+// classified: either listed as needing no capability beyond the core
+// contract, or covered by a supportRules entry. Adding a grammar field
+// without classifying it fails here, which is the ledger's drift alarm
+// (same role TestFieldPaths plays for message paths).
+func TestSupportLedgerCompleteness(t *testing.T) {
+	core := map[string]bool{
+		"schemaVersion": true, "kind": true, "name": true, "version": true,
+		"displayName": true, "description": true, "sourceURL": true,
+		"extends": true, "mixins": true, "requires.agent": true,
+		"locked": true, "licenses": true, "args": true,
+		"sandbox.image":      true,
+		"sandbox.entrypoint": true, "sandbox.command": true,
+		"sandbox.resources.cpu": true, "sandbox.resources.memory": true,
+		"agentInstructions.filename": true,
+		"permissions.network.allow":  true, "permissions.network.deny": true,
+		"credentials": true, "environment.variables": true,
+		"environment.proxyManaged": true, // legacy input; normalize folds it into credentials
+		"setup.install":            true, "setup.startup": true, "setup.files": true,
+		// build is forward-compat: accepted at decode, rejected at load when
+		// image is absent, uniformly on every runtime (see Manifest.Build).
+		"sandbox.build.context": true, "sandbox.build.dockerfile": true,
+		"sandbox.build.args": true, "sandbox.build.target": true,
+		"sandbox.build.platforms": true,
+	}
+	ruled := map[string]bool{}
+	for _, r := range supportRules {
+		ruled[r.field] = true
+	}
+
+	var unclassified []string
+	for _, path := range grammarPaths(specFileV2Type, "") {
+		if !core[path] && !ruled[path] {
+			unclassified = append(unclassified, path)
+		}
+	}
+	sort.Strings(unclassified)
+	if len(unclassified) > 0 {
+		t.Fatalf("grammar fields missing a support classification (add to supportRules or to the core list): %v", unclassified)
+	}
+	for field := range ruled {
+		if core[field] {
+			t.Errorf("field %q is both ruled and listed as core", field)
+		}
+	}
+}
+
+// grammarPaths walks a grammar struct's yaml-tagged fields, recursing into
+// struct and pointer-to-struct fields and stopping at scalars, slices, and
+// maps, mirroring the granularity the support ledger classifies at.
+func grammarPaths(t reflect.Type, prefix string) []string {
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	var paths []string
+	for i := range t.NumField() {
+		f := t.Field(i)
+		if !f.IsExported() && f.Anonymous {
+			continue
+		}
+		tag, _, _ := strings.Cut(f.Tag.Get("yaml"), ",")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		path := tag
+		if prefix != "" {
+			path = prefix + "." + tag
+		}
+		ft := f.Type
+		for ft.Kind() == reflect.Pointer {
+			ft = ft.Elem()
+		}
+		if ft.Kind() == reflect.Struct && ft.NumField() > 0 && hasYAMLFields(ft) {
+			paths = append(paths, grammarPaths(ft, path)...)
+			continue
+		}
+		paths = append(paths, path)
+	}
+	return paths
+}
+
+func hasYAMLFields(t reflect.Type) bool {
+	for i := range t.NumField() {
+		tag, _, _ := strings.Cut(t.Field(i).Tag.Get("yaml"), ",")
+		if tag != "" && tag != "-" {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
A kit verified on one runtime can silently degrade on another: declared fields drop with exit 0 and no message. This adds SPEC-v2 section 10 (Runtime support): every declared field is honoured with one semantic, or refused/visibly skipped naming the field. Fields needing more than the core contract map to declared runtime capabilities (host kernel, gpu selector, kit volumes, kit ports, mixin agent context). EvaluateSupport in the spec package is the machine-readable ledger every applier consumes, and an undeclared capability fails closed. A reflection test forces every grammar field to be classified, so a new field cannot ship unclassified.

Rulings folded in: resource and entrypoint precedence, where an explicit caller request beats the kit and the kit beats the image. Startup re-runs on every start, tightening 9.6's MAY. Kit volume identity lands in 5.7, host-path portability guidance in section 10, and the 3.1 field set gains its missing security row.

Tests: spec package suite green, including the new evaluator table and completeness tests.