### PR TITLE
fix(copilot): auto-wire the MCP gateway into Copilot

### DIFF
--- a/copilot/README.md
+++ b/copilot/README.md
@@ -99,6 +99,16 @@ configured source is unreachable).
 >
 > then add the reported hosts to `permissions.network.allow` in `spec.yaml`.
 
+## MCP
+
+When a gateway is reserved, sandboxd injects `MCP_GATEWAY_URL` and
+`MCP_SENTINEL_TOKEN_NAME`, and the kit's startup hook writes
+`~/.copilot/mcp-config.json` pointing at the gateway, so servers registered
+with `sbx mcp add` / `sbx mcp load` show up in `copilot mcp list` (and under
+`/mcp`) with no manual configuration. The sentinel is not a credential — the
+proxy substitutes the real token per request, keyed by name. The hook is a
+no-op when MCP is not enabled.
+
 ## Base image
 
 Unlike most kits here — which are `kind: mixin` or `kind: agent` and layer onto

--- a/copilot/spec.yaml
+++ b/copilot/spec.yaml
@@ -94,6 +94,34 @@ setup:
     - command: ["sh", "-c", "command -v apt-get > /dev/null 2>&1 && (apt-get update -qq -y > /dev/null 2>&1 || true) &"]
       user: "root"
       description: Update apt package cache in background
+    # Gateway-first MCP registration. sandboxd injects MCP_GATEWAY_URL +
+    # MCP_SENTINEL_TOKEN_NAME into the container env when a gateway has been
+    # reserved. The sentinel name is not a credential — the proxy substitutes
+    # the real token at request time keyed by this name. No-op when MCP isn't
+    # enabled, which is what the guard is for.
+    - command:
+        - sh
+        - -c
+        - |
+          set -e
+          [ -n "$MCP_GATEWAY_URL" ] || exit 0
+          mkdir -p "$HOME/.copilot"
+          cat > "$HOME/.copilot/mcp-config.json" <<EOF
+          {
+            "mcpServers": {
+              "mcp-gateway": {
+                "type": "http",
+                "url": "$MCP_GATEWAY_URL",
+                "headers": {
+                  "Authorization": "Bearer $MCP_SENTINEL_TOKEN_NAME"
+                },
+                "tools": ["*"]
+              }
+            }
+          }
+          EOF
+      user: "agent"
+      description: Register the sandbox MCP gateway in ~/.copilot/mcp-config.json
   files:
     - path: /home/agent/.copilot/config.json
       content: '{"trusted_folders": ["${WORKDIR}"]}'

--- a/copilot/testdata/tck.yaml
+++ b/copilot/testdata/tck.yaml
@@ -23,5 +23,22 @@ extractedFromBuiltin: true
 # The remaining subtests (env, files, tmpfs, agentContext) still run and are
 # what actually gate this kit.
 
-# Copilot's startup hook does no MCP-gateway registration (unlike kiro's), so
-# no `mcp:` block is needed here.
+# Shape of the MCP-gateway registration written by the startup hook in
+# spec.yaml, checked by the TCK's mcp_registration subtest. The
+# format-independent parts (no-op guard, env-var indirection, no literal token,
+# non-root user) are asserted for every kit and need no configuration here.
+#
+# Copilot keys an HTTP MCP server by `url`, alongside `type: "http"`, a
+# `headers` object and `tools: ["*"]` — the shape
+# `copilot mcp add --transport http` writes and the one documented at
+# https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers
+#
+# The forbidden keys are the two wrong answers nearest to hand: `httpUrl` is
+# Gemini's spelling of `url`, and `transport` is the name of the `copilot mcp
+# add` flag rather than a key in the config file (the file spells it `type`).
+mcp:
+  configPath: $HOME/.copilot/mcp-config.json
+  transportKey: url
+  forbiddenKeys:
+    - httpUrl
+    - transport


### PR DESCRIPTION
<!--
Thanks for contributing to sbx-kits-contrib!

PRs from forks have CI's `test-kit-e2e` job SKIPPED because GitHub does not
expose `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` to fork-triggered workflows.
The e2e assertions will not run on your PR — your laptop is the only place
they run before merge. See the checklist below.
-->

## Summary

Wires up sbx MCP servers in copilot.

Fixes docker/sbx-releases#468

<!-- What changed and why. -->

## Spec choices worth flagging for review

<!-- Decisions a reviewer should sanity-check: unusual image, deliberately narrow
allowedDomains, workaround for a known bug, etc. -->

## Origin

<!-- Where did the kit come from? One sentence is enough. -->

## Test plan

CI runs `kit validate` and the TCK on every PR. CI does **not** run e2e on
fork PRs (Docker Hub secrets aren't exposed there), so the e2e step below is
required from your side before requesting review.

- [x] `sbx kit validate ./<kit>/` passes
- [x] `./scripts/test-kit.sh <kit>` passes (the TCK)
- [ ] `./scripts/test-kit-e2e.sh <kit>` passes. The script applies the same
      `deny-all` baseline CI uses and scopes everything to its own daemon
      (`--app-name sbx-kits-contrib-tck`), so my main sbx state is untouched.
      Every entry I added to `network.allowedDomains` came from
      `sbx --app-name sbx-kits-contrib-tck policy log <tck-e2e-…>`, not a guess.
- [x] Manual smoke: `sbx run --kit ./<kit>/ <agent>` and verified the kit's
      binary / files / env are inside the running container.

One-time setup if you haven't run e2e on this machine before:
`sbx --app-name sbx-kits-contrib-tck login`.

See [CONTRIBUTING.md → Verifying locally](../CONTRIBUTING.md#verifying-locally)
and [README → Declare every domain your kit needs](../README.md#declare-every-domain-your-kit-needs)
for the cross-arch domain gotchas (`archive.ubuntu.com`,
`security.ubuntu.com`, `ports.ubuntu.com`) and the package-manager refresh trap.
