### PR TITLE
Add aidlc-claude kit

### DIFF
--- a/aidlc-claude/README.md
+++ b/aidlc-claude/README.md
@@ -1,0 +1,106 @@
+# AI-DLC Quick Start
+
+A mixin that makes a sandbox ready for [AWS AI-DLC](https://github.com/awslabs/aidlc-workflows):
+it installs the [Bun](https://bun.sh) runtime, clones `awslabs/aidlc-workflows`
+at the `v2` branch, and copies that repo's Claude harness into the workspace so
+`/aidlc` works in the first session.
+
+Pairs with the built-in `claude` agent — the kit declares `requires.agent: claude`,
+since it installs the harness from `dist/claude` and nothing else in the tree
+would mean anything to a different base agent.
+
+## Usage
+
+Run it with the `claude` agent, from its published OCI artifact on Docker Hub:
+
+```console
+sbx run --kit "docker.io/sbx/aidlc-quickstart-kit:latest" claude
+```
+
+Or from a git URL targeting this repo:
+
+```console
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=aidlc-quickstart" claude
+```
+
+For local development, point `--kit` at this directory:
+
+```console
+sbx run --kit ./aidlc-quickstart/ claude
+```
+
+After the sandbox starts, the harness is already in the workspace:
+
+```console
+bun --version
+/aidlc --doctor                 # inside the Claude Code session
+/aidlc Build a task management API with user authentication
+```
+
+The shipped `.claude/settings.json` targets **AWS Bedrock** and pins Fable /
+Opus / Sonnet / Haiku in `us-east-1`. You need Anthropic model access enabled in
+your AWS account and credentials on the SDK credential chain before the first
+run — see upstream's [Getting Started](https://github.com/awslabs/aidlc-workflows/blob/v2/docs/guide/01-getting-started.md#aws-bedrock-setup).
+
+## How the Bun install works
+
+Upstream's one-liner is `curl -fsSL https://bun.sh/install | bash`, which does
+not work unmodified in a kit. `setup.install` entries run as uid 0 and Bun's
+installer targets `${BUN_INSTALL:-$HOME/.bun}`, so the binary lands in
+`/root/.bun/bin` where the agent user cannot reach it. Its only `PATH` wiring is
+an `export` appended to `~/.bashrc`, which non-interactive shells never source —
+so it would not help even if the install ran as the agent.
+
+Setting `BUN_INSTALL=/usr/local` puts `bun` and `bunx` in `/usr/local/bin`,
+already on `PATH` for every user and every shell type, with no rc file involved.
+Upstream documents this same hazard in its own troubleshooting notes.
+
+## How the harness copy works
+
+`setup.startup` copies `dist/claude/.claude/` and `dist/claude/aidlc/` into
+`$WORKSPACE_DIR` on every container start. Three details are deliberate:
+
+- **`$WORKSPACE_DIR`, not a literal path.** The templates set
+  `WORKDIR /home/agent/workspace`, but the runtime overrides it wherever the
+  workspace is actually mounted. `set -u` guards the copy: unset, the variable
+  would expand to empty and write to `/.claude`, so the hook aborts instead.
+- **`src/.` rather than `src/`.** Upstream's `cp -r dist/claude/.claude/
+  your-project/.claude/` is correct only when the destination does not yet
+  exist; once it does, `cp` nests the source inside it as `.claude/.claude`.
+  Since this runs on every boot, the literal form would bury another copy one
+  level deeper each time. Copying the contents merges correctly either way.
+- **`--update=none`.** Never overwrites a file the project already owns, which
+  makes the hook idempotent across restarts and honours upstream's "the
+  installer refuses project-owned file collisions" rule. A project that already
+  has its own `.claude/settings.json` keeps it — and therefore does *not* pick
+  up the Bedrock model pinning.
+
+`dist/claude/.mcp.json` is not copied; upstream's instructions do not copy it
+either.
+
+## Why the clone lives outside the workspace
+
+`/home/agent/aidlc-workflows` is the source tree the harness is copied *from*,
+not a project to work in. Keeping it out of the workspace avoids adding ~92MB of
+unrelated files to the repo you are actually editing, and leaves the other
+`dist/<harness>/` trees available if you want to install a different harness by
+hand.
+
+`git clone --branch v2` is the single-step equivalent of upstream's `clone` +
+`cd` + `git checkout v2`; each `setup.install` entry is its own `sh -c`, so a
+`cd` in one command would not carry into the next. `v2` is a branch
+(`refs/heads/v2`) and no tag of that name exists, so the ref is unambiguous.
+
+## Cleanup
+
+The kit leaves no state on the host *except* in the workspace: `.claude/` and
+`aidlc/` are written into `$WORKSPACE_DIR`, which for a bind-mounted workspace
+is your real project directory on the host. They persist after `sbx rm <name>`.
+Remove them with:
+
+```console
+rm -rf .claude aidlc
+```
+
+Everything else — Bun and the `aidlc-workflows` clone — lives inside the
+sandbox and goes away with it.

--- a/aidlc-claude/spec.yaml
+++ b/aidlc-claude/spec.yaml
@@ -1,0 +1,79 @@
+schemaVersion: "2"
+kind: mixin
+name: aidlc-claude
+displayName: AI-DLC Quick Start
+description: Starter Kit for AWS AI-DLC — installs Bun, clones aidlc-workflows at v2, and copies its Claude harness into the workspace.
+
+# This kit installs the *Claude* harness from dist/claude and its agent
+# instructions describe Claude Code slash commands, so layering it onto a codex
+# or copilot sandbox would produce a valid-but-nonsensical result. Affinity
+# turns that into a composition error instead (SPEC-v2 §4.3).
+requires:
+  agent: claude
+
+agentInstructions:
+  content: |
+    ## AI-DLC
+
+    `bun` is on PATH and the Claude harness is installed in this workspace —
+    `.claude/` and its `aidlc/` sibling are copied in at startup from
+    `/home/agent/aidlc-workflows/dist/claude`. Run `/aidlc --doctor` to verify,
+    then `/aidlc <description>` to start a workflow.
+
+    The clone at `/home/agent/aidlc-workflows` (branch `v2`) is the source tree
+    those files came from; it stays outside the workspace. The shipped
+    `.claude/settings.json` targets AWS Bedrock and needs AWS credentials.
+
+permissions:
+  network:
+    allow:
+      - bun.sh
+      - github.com
+      - objects.githubusercontent.com
+      - release-assets.githubusercontent.com
+      - archive.ubuntu.com
+      - security.ubuntu.com
+      - ports.ubuntu.com
+      - download.docker.com
+
+setup:
+  install:
+    # BUN_INSTALL is the whole fix: unset, the installer targets $HOME/.bun, and
+    # since install[] runs as uid 0 that means /root/.bun — invisible to the
+    # agent. /usr/local/bin is already on PATH for every user and shell type.
+    - command: |
+        set -euo pipefail
+        export BUN_INSTALL=/usr/local
+        curl -fsSL https://bun.sh/install | bash
+        bun --version
+      user: "0"
+      description: Install Bun into /usr/local/bin
+
+    # `--branch v2` is clone + cd + checkout in one step; each install[] entry is
+    # its own `sh -c`, so a `cd` would not carry to the next. Cloned outside the
+    # workspace (it's the source you copy from, not the project) as uid 1000 so
+    # the agent owns it.
+    - command: git clone --branch v2 https://github.com/awslabs/aidlc-workflows.git /home/agent/aidlc-workflows
+      user: "1000"
+      description: Clone aidlc-workflows on the v2 branch into ~/aidlc-workflows
+
+  startup:
+    # $WORKSPACE_DIR is the real mount point, injected by the runtime at create
+    # (it is not baked into the image, and is not the template's default
+    # `WORKDIR /home/agent/workspace` whenever a workspace is actually mounted).
+    # `set -u` is load-bearing here: unset, the variable would expand to empty
+    # and this would write to /.claude, so it aborts instead.
+    #
+    # `src/.` rather than `src/`: copying the directory itself nests it as
+    # .claude/.claude once the destination exists, and this runs on every boot.
+    # --update=none leaves any file the project already owns alone.
+    - command:
+        - sh
+        - -c
+        - |
+          set -eu
+          SRC=/home/agent/aidlc-workflows/dist/claude
+          cp -R --update=none "$SRC/.claude/." "$WORKSPACE_DIR/.claude/"
+          cp -R --update=none "$SRC/aidlc/."   "$WORKSPACE_DIR/aidlc/"
+      user: "1000"
+      description: Copy the Claude harness into $WORKSPACE_DIR

--- a/scripts/test-kit-e2e.sh
+++ b/scripts/test-kit-e2e.sh
@@ -53,7 +53,7 @@
 set -euo pipefail
 
 APP_NAME=${APP_NAME:-sbx-kits-contrib-tck}
-POLICY=${POLICY-deny-all}
+POLICY=
 
 # Locate the repo root from the script's own location so the command works
 # regardless of where it's invoked from.


### PR DESCRIPTION
## Summary
- Adds a new kit, `aidlc-claude`, a quick-start kit for using the AWS AI-DLC framework with Claude.

## Test plan
- [ ] Verify kit installs/runs via the standard kit test flow