### PR TITLE
feat(devin): new sandbox kit — Devin CLI by Cognition

### DIFF
--- a/devin/.dockerignore
+++ b/devin/.dockerignore
@@ -1,0 +1,15 @@
+# The build context is the kit directory, which also holds kit metadata that the
+# image has no use for. Excluding it keeps the context small and keeps README,
+# spec or testdata edits from touching the image build at all.
+#
+# `files/` is excluded too: that tree is copied into the container by the engine
+# at create time, not baked into the image.
+#
+# Listed by exclusion rather than as an allowlist (`*` + `!start.sh`) so that
+# adding a COPY for a new file does not silently fail on a stale ignore rule.
+README.md
+README.image.md
+spec.yaml
+testdata/
+files/
+.dockerignore

--- a/devin/Dockerfile
+++ b/devin/Dockerfile
@@ -1,0 +1,87 @@
+# syntax=docker/dockerfile:1
+
+# Base image for the `devin` sandbox kit.
+#
+# Requires egress to `cli.devin.ai` (install.sh) and `static.devin.ai` (the
+# manifest and the versioned bundle the script fetches) at build time.
+#
+# One image, no flavour suffix: the kit picks its own image, so the
+# Docker-in-Docker detail never reaches the user. There is no dockerless variant
+# either — a kind:sandbox kit names a single sandbox.image, so a second image
+# would be unreachable without a second kit to consume it.
+#
+# The base is a floating tag, which is why CI also rebuilds on a schedule.
+ARG BASE_IMAGE=docker/sandbox-templates:shell-docker
+FROM ${BASE_IMAGE}
+
+# Re-declared inside the stage: an ARG defined before the first FROM is a global
+# build arg, visible only to FROM lines. Without this, the LABEL below would
+# expand to an empty string.
+ARG BASE_IMAGE
+
+# Runs as the base image's default user (`agent`, uid 1000), which matters:
+# install.sh is a per-user installer with no --prefix, so everything below
+# lands under /home/agent and is owned by the user that will run it.
+RUN <<EOF
+set -ex
+
+# install.sh ends by running `devin setup`, an interactive wizard that cannot
+# complete without a TTY and exits non-zero ("Login canceled"). Because that is
+# the script's last command it is also the script's exit status, so a clean
+# install reports failure here and `set -o pipefail` in the base shell would
+# abort the build.
+curl -fsSL https://cli.devin.ai/install.sh | bash || true
+
+# ...so assert the outcome instead of trusting the status that was just
+# discarded. A genuine download or checksum failure still fails the build here,
+# which is the only reason the `|| true` above is safe.
+devin --version
+
+# The installer's `devin` is the only one on PATH, and the auth wrapper has to
+# take that name for `sandbox.entrypoint` to stay `[devin, ...]`. Expose the
+# real CLI as `devin-cli` first.
+#
+# `readlink` without -f on purpose: it copies the symlink's TARGET
+# (…/_versions/current/bin/devin) rather than resolving it to today's version
+# directory, so `devin-cli` keeps floating with `current` instead of pinning
+# the version installed at build time.
+ln -s "$(readlink /home/agent/.local/bin/devin)" /home/agent/.local/bin/devin-cli
+
+# Remove the installer's symlink before the COPY below replaces it. Without
+# this, COPY resolves the existing symlink and writes the wrapper through it,
+# overwriting the real CLI binary inside the version directory.
+rm /home/agent/.local/bin/devin
+EOF
+
+# The launcher the sandbox entrypoint resolves as `devin`: it checks
+# authentication state, drops into the manual token flow when there is none,
+# then hands off to devin-cli.
+COPY --chown=agent:agent --chmod=0755 start.sh /home/agent/.local/bin/devin
+
+# Inherited from the base image, but re-declared deliberately so the value is
+# owned here rather than depending on inheritance from an image this repository
+# does not own.
+#
+# This is a *request* to the runtime, not a description of the image: setting it
+# over a base with no Docker engine yields a sandbox started in Docker mode with
+# nothing to run. Since BASE_IMAGE is overridable, CI asserts the engine is
+# really present rather than trusting this label.
+LABEL com.docker.sandboxes.start-docker="true"
+
+# Both of the labels below OVERRIDE values inherited from the base image, which
+# describe the base rather than this image. Overriding is not optional for
+# `flavor`: left inherited it would read "shell-docker", and sbx would report
+# this image's agent as "shell-docker".
+#
+# sbx reads `flavor` and treats it as an agent identifier — it surfaces the value
+# as an image's `Agent` in the API, and separately uses it (with any `-docker`
+# suffix trimmed) to warn when a template looks built for a different agent than
+# the one being run. So it must be the kit's own name: `devin`.
+LABEL com.docker.sandboxes.flavor="devin"
+
+# Informational only — nothing in sbx reads this. Worth setting because the base
+# is a floating tag rebuilt nightly, so this is the one place the produced image
+# records what it was actually built on.
+LABEL com.docker.sandboxes.base="${BASE_IMAGE}"
+
+CMD [ "devin" ]

--- a/devin/README.image.md
+++ b/devin/README.image.md
@@ -1,0 +1,24 @@
+# sbx/devin-image
+
+Base image for the Devin agent kit for
+[Docker Sandboxes](https://docs.docker.com/ai/sandboxes/).
+
+## Contents
+
+Built on `docker/sandbox-templates:shell-docker`: the standard sandbox tool
+chain plus a Docker engine, requesting Docker-in-Docker via
+`com.docker.sandboxes.start-docker=true`. On top of that:
+
+- [Devin CLI](https://docs.devin.ai/cli) ("Devin for Terminal"), installed from
+  `cli.devin.ai` into the `agent` user's `~/.local` tree
+- `/home/agent/.local/bin/devin-cli` — the CLI itself, tracking the installer's
+  `_versions/current` symlink
+- `/home/agent/.local/bin/devin` — a wrapper that checks `devin-cli auth status`
+  and falls back to `devin-cli auth login --force-manual-token-flow`, then execs
+  `devin-cli`
+
+Runs as the non-root `agent` user, with `CMD ["devin"]`.
+
+## Kit
+
+[`docker.io/sbx/devin-kit`](https://hub.docker.com/r/sbx/devin-kit)

--- a/devin/README.md
+++ b/devin/README.md
@@ -48,13 +48,15 @@ Devin's first authenticated request. It lets that one key reach Devin and
 stores it only after Devin accepts it. `sbx secret ls` then shows the resulting
 `devin` credential.
 
-On later runs, sbx renders that durable key into
-`~/.local/share/devin/credentials.toml` before the agent starts. A new sandbox
-therefore begins authenticated without another browser login.
+On later runs, sbx renders a proxy-managed placeholder into
+`~/.local/share/devin/credentials.toml` before the agent starts. The proxy
+replaces that placeholder with the host-held durable key only on Devin egress,
+so a new sandbox begins authenticated without receiving the reusable secret.
 
 `passthrough: true` is required for the initial exchange: Devin must spend the
-real intermediate token to mint the durable key. The durable key remains in the
-host credential store after the first sandbox is removed.
+real intermediate token to mint the durable key. That exception does not apply
+to the durable key, which remains in the host credential store after the first
+sandbox is removed.
 
 ## Permission mode and workspace trust
 

--- a/devin/README.md
+++ b/devin/README.md
@@ -1,0 +1,119 @@
+# devin
+
+[Devin CLI](https://docs.devin.ai/cli) by Cognition — "Devin for Terminal" — as a
+`kind: sandbox` kit. The kit builds its own image (Devin CLI plus an
+authentication wrapper), declares the egress Devin needs, registers the sandbox
+MCP gateway, and launches the agent with tool approval and workspace-trust
+prompts turned off.
+
+## Usage
+
+```console
+# Published OCI artifact (primary)
+sbx run --kit "docker.io/sbx/devin-kit:latest" devin
+
+# Straight from this repo
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=devin" devin
+
+# Local clone
+sbx run --kit ./devin devin
+```
+
+No host-side prerequisite: there is no key to store first. The first run logs you
+in from inside the sandbox (see below).
+
+### Testing a local build
+
+`sandbox.image` is resolved from **sbx's own image store**, not from the host
+Docker daemon's, and until CI publishes `sbx/devin-image` a pull of it returns
+`403 Forbidden`. So `docker build` alone is not enough for a local run — the
+image has to be side-loaded, or `sbx run` fails at PREPARE IMAGE with that 403
+and no hint that the local build was never consulted:
+
+```console
+docker build -t docker.io/sbx/devin-image:latest ./devin
+docker save docker.io/sbx/devin-image:latest -o /tmp/devin-image.tar
+sbx template load /tmp/devin-image.tar && rm -f /tmp/devin-image.tar
+sbx template ls | grep devin-image     # the tag must survive the round trip
+```
+
+`scripts/test-kit-e2e.sh` does all of this itself, against the scoped daemon it
+runs under; the commands above are the equivalent for a manual `sbx run`.
+
+## How authentication works
+
+The first sandbox runs Devin's manual browser login. The proxy stores the
+intermediate browser token, then recognizes the durable `windsurf_api_key` on
+Devin's first authenticated request. It lets that one key reach Devin and
+stores it only after Devin accepts it. `sbx secret ls` then shows the resulting
+`devin` credential.
+
+On later runs, sbx renders that durable key into
+`~/.local/share/devin/credentials.toml` before the agent starts. A new sandbox
+therefore begins authenticated without another browser login.
+
+`passthrough: true` is required for the initial exchange: Devin must spend the
+real intermediate token to mint the durable key. The durable key remains in the
+host credential store after the first sandbox is removed.
+
+## Permission mode and workspace trust
+
+`sandbox.entrypoint` runs the CLI as:
+
+```
+devin --permission-mode dangerous --respect-workspace-trust=false
+```
+
+`dangerous` auto-approves every tool call — the equivalent of `--yolo` on other
+agents, and the point of running inside an isolated sandbox. The CLI's own
+rejection message is the authority on the accepted values, because its `--help`
+prose disagrees with it:
+
+```
+Valid options: normal (auto), accept-edits, dangerous (yolo, bypass),
+               autonomous (requires --sandbox)
+```
+
+So `bypass` (the spelling in the published docs) is an alias of `dangerous`, and
+`autonomous` is not usable here — it additionally requires the CLI's own
+process sandbox inside the container. An unknown value is rejected at parse
+time, so a typo fails loudly rather than silently falling back to prompting.
+
+`--respect-workspace-trust` defaults to true in every mode, which stops to ask
+before the agent touches an unfamiliar directory; the workspace is the reason
+the sandbox exists, so the check is off. It is spelled with `=` because the flag
+takes an *optional* value — written as `--respect-workspace-trust false`, the
+`false` is free to be parsed as the positional prompt argument instead.
+
+## MCP gateway
+
+A startup hook writes `~/.config/devin/mcp_config.json` when `MCP_GATEWAY_URL`
+is present, and no-ops otherwise. Devin keys an HTTP MCP server by `url` plus
+`transport` and a `headers` object, in a file separate from `config.json`.
+
+The hook writes that JSON directly rather than calling `devin mcp add`, so the
+TCK can pin the key names against a mistake that would otherwise fail silently
+at runtime (a healthy sandbox whose agent simply has no tools). The shape
+mirrors what `devin mcp add … --transport http --scope user --header …`
+produces — it was read back out of the built image, not guessed from docs.
+
+## Self-update
+
+[`files/home/.config/devin/config.json`](./files/home/.config/devin/config.json)
+sets `auto_update: false`. Devin CLI updates itself in the background by
+default, which inside a sandbox would drift the running agent away from the
+published image and needs `static.devin.ai` egress at runtime. The image is the
+unit of versioning here; CI rebuilds it, including on a schedule.
+
+## Known gaps
+
+- **Egress is partly inferred.** `app.devin.ai`, `server.codeium.com`,
+  `unleash.codeium.com` and `static.devin.ai` were observed during login;
+  `api.devin.ai` and `cli.devin.ai` are inferred. Crash reporting
+  (`*.ingest.*.sentry.io`) and `server-beta.codeium.com` are deliberately
+  excluded — add them only if something stalls.
+- **The e2e `prompt` subtest is skipped**, because CI cannot authenticate
+  without an interactive login (see [`testdata/tck.yaml`](./testdata/tck.yaml)).
+- **Shared skills are not wired up.** Devin reads user skills from
+  `~/.config/devin/skills/` and `~/.agents/skills/`, but shared-skill mounts
+  require platform support outside this kit.

--- a/devin/README.md
+++ b/devin/README.md
@@ -44,14 +44,17 @@ runs under; the commands above are the equivalent for a manual `sbx run`.
 
 The first sandbox runs Devin's manual browser login. The proxy stores the
 intermediate browser token, then recognizes the durable `windsurf_api_key` on
-Devin's first authenticated request. It lets that one key reach Devin and
-stores it only after Devin accepts it. `sbx secret ls` then shows the resulting
-`devin` credential.
+Devin's authenticated user-status request. sbx lets the candidate reach Devin
+and stores it only after Devin accepts it. The launcher then replaces the key in
+the first sandbox's credential file with `devin-proxy-managed` before starting
+the agent. `sbx secret ls` shows the host credential as
+`(token handled by proxy)`.
 
-On later runs, sbx renders a proxy-managed placeholder into
-`~/.local/share/devin/credentials.toml` before the agent starts. The proxy
-replaces that placeholder with the host-held durable key only on Devin egress,
-so a new sandbox begins authenticated without receiving the reusable secret.
+On later runs, sbx renders the same placeholder into the credential file before
+the agent starts. The proxy replaces it with the host-held durable key only on
+Devin egress, preserving the Bearer or Basic shape expected by each request and
+rewriting Devin's protobuf request metadata. No running sandbox retains the
+reusable secret after login completes.
 
 `passthrough: true` is required for the initial exchange: Devin must spend the
 real intermediate token to mint the durable key. That exception does not apply

--- a/devin/files/home/.config/devin/config.json
+++ b/devin/files/home/.config/devin/config.json
@@ -1,0 +1,3 @@
+{
+  "auto_update": false
+}

--- a/devin/spec.yaml
+++ b/devin/spec.yaml
@@ -123,10 +123,11 @@ credentials:
       # protobuf payload, so login fails with "failed to get primary API key
       # ... Invalid token" unless the real intermediate token passes through.
       #
-      # On later runs the credential-file hook renders a proxy-managed
-      # placeholder. The proxy replaces it with the host-held durable key only
-      # on Devin egress, so the new sandbox starts authenticated without
-      # receiving the reusable credential or requiring another login.
+      # The credential-file hook renders a proxy-managed placeholder whenever
+      # the host already has the durable key. On first login, Devin validates
+      # the key on its user-status request; start.sh then replaces the local
+      # copy before starting the agent. The proxy substitutes the host-held key
+      # only on Devin egress.
       passthrough: true
       credentialFile:
         path: "~/.local/share/devin/credentials.toml"

--- a/devin/spec.yaml
+++ b/devin/spec.yaml
@@ -123,8 +123,10 @@ credentials:
       # protobuf payload, so login fails with "failed to get primary API key
       # ... Invalid token" unless the real intermediate token passes through.
       #
-      # On later runs the credential-file hook renders the captured durable
-      # key, so the new sandbox starts authenticated without another login.
+      # On later runs the credential-file hook renders a proxy-managed
+      # placeholder. The proxy replaces it with the host-held durable key only
+      # on Devin egress, so the new sandbox starts authenticated without
+      # receiving the reusable credential or requiring another login.
       passthrough: true
       credentialFile:
         path: "~/.local/share/devin/credentials.toml"

--- a/devin/spec.yaml
+++ b/devin/spec.yaml
@@ -1,0 +1,250 @@
+schemaVersion: "2"
+kind: sandbox
+name: devin
+# The KIT's version, not Devin's. It covers this spec, the files/ tree, the
+# network policy and the hooks — the CLI inside the image floats, so a newer
+# devin release does not bump this and this does not track releases of the CLI.
+#
+# Published as the vnd.docker.sandbox.kit.version OCI annotation at pack time,
+# and `scripts/check-release-tag.sh` refuses a `devin/vX.Y.Z` tag that
+# disagrees with it. Bump here first, then tag.
+version: "1.0.0"
+displayName: Devin
+description: Devin CLI by Cognition, an agentic coding CLI.
+
+sandbox:
+  # Built from the Dockerfile beside this spec and published by
+  # .github/workflows/build-and-publish-kits.yml.
+  #
+  # This value is the source of truth for what CI builds and publishes: the
+  # workflow reads it from here rather than deriving a name, because spec.yaml
+  # is consumed literally (no env interpolation) and so cannot follow a
+  # variable. scripts/check-image-ref.sh asserts it stays inside the namespace
+  # CI can actually push to.
+  #
+  # The `-image` suffix distinguishes the base image from the kit artifact:
+  # when the kit itself is published as an OCI artifact it will be
+  # `docker.io/sbx/devin-kit`.
+  image: "docker.io/sbx/devin-image:latest"
+  # `devin` here is the auth wrapper the Dockerfile installs, not the CLI
+  # itself — the real binary is `devin-cli`. See start.sh for why the wrapper
+  # takes the friendly name. Everything after it is forwarded verbatim.
+  #
+  # --permission-mode dangerous auto-approves every tool call, which is the
+  # point of running inside a sandbox. The CLI's own rejection message is the
+  # authority on the accepted values (`--help` prose disagrees with it):
+  #
+  #   Valid options: normal (auto), accept-edits, dangerous (yolo, bypass),
+  #                  autonomous (requires --sandbox)
+  #
+  # So `bypass` — the spelling in the published docs — is an alias of
+  # `dangerous`, and `autonomous` is unusable here because it additionally
+  # demands the CLI's own process sandbox inside the container. An unknown
+  # value is rejected at parse time rather than ignored, so a typo here fails
+  # loudly instead of silently degrading to prompting.
+  #
+  # --respect-workspace-trust defaults to true in every mode, which stops to
+  # ask before the agent touches an unfamiliar directory. The workspace is the
+  # whole reason the sandbox exists, so the check is turned off. Spelled with
+  # `=` deliberately: the flag takes an OPTIONAL value, so the space form
+  # (`--respect-workspace-trust false`) leaves `false` free to be swallowed as
+  # the positional PROMPT argument instead.
+  entrypoint: [devin, "--permission-mode", "dangerous", "--respect-workspace-trust=false"]
+
+credentials:
+  - service: devin
+    description: Devin account credential captured during in-sandbox login
+    # Devin's login is a PKCE browser flow, but the credential the CLI actually
+    # authenticates with is not what that exchange returns. Three spec-only
+    # routes were tried against the live service:
+    #
+    #   * api.devin.ai/auth/cli/token with responseFields.accessToken=api_key
+    #     — the response has no such field (the proxy reported its keys as
+    #     ['token']; the PkceAuthorizationCodeResponse struct in the binary
+    #     belongs to a different exchange).
+    #   * the same endpoint with accessToken=token — captures cleanly, but
+    #     `token` is an intermediate the CLI immediately spends on a second
+    #     call to mint the account's primary API key. Seeding it yields
+    #     "Failed to load team settings: ... invalid api key".
+    #   * server.codeium.com/exa.seat_management_pb.SeatManagementService/
+    #     GetCliTeamSettings — the response contains settings, not the key.
+    #
+    # After OAuth, the CLI presents the durable key on its authenticated
+    # service requests. For one minute, the engine recognizes the Devin key
+    # shape, lets that candidate reach a Devin-owned host, and stores it as the
+    # primary API key only after the host accepts it with a successful response.
+    #
+    # The CLI reads the key from credentials.toml rather than an environment
+    # variable. This block still owns its outbound injection contract.
+    apiKey:
+      name: ""
+      inject:
+        - domain: server.codeium.com
+          header: Authorization
+          format: Bearer %s
+        - domain: api.devin.ai
+          header: Authorization
+          format: Bearer %s
+    # Captured automatically: signing in inside the sandbox is what puts the
+    # credential in the host store under this service name, with no
+    # provisioning step. Declaring apiKey AND oauth on one credential is the
+    # droid pattern — the api key wins whenever it resolves, so a host with a
+    # stored key never triggers this path.
+    oauth:
+      # PKCE code exchange. Confirmed live: an unauthenticated POST returns 422
+      # naming `code`/`code_verifier`, where the same path on app.devin.ai
+      # returns 403. app.devin.ai serves the sign-in page; api.devin.ai takes
+      # the exchange.
+      tokenEndpoint:
+        host: api.devin.ai
+        path: /auth/cli/token
+      resourceHosts:
+        - server.codeium.com
+        - api.devin.ai
+      # The exchange returns exactly one field: {"token": "..."}. Read off the
+      # wire — the proxy reported the body's keys as ['token'] while looking
+      # for something else. Do NOT "fix" this to `api_key` because the binary
+      # carries a PkceAuthorizationCodeResponse{api_key, ...} struct: that
+      # belongs to a different exchange and captures nothing here.
+      #
+      # Both fields name it deliberately. The interceptor reads an access AND a
+      # refresh token and forwards the response unpersisted if either is empty
+      # — a guard against storing half a credential — so pointing both at one
+      # field is what makes a single-key provider capturable.
+      responseFields:
+        accessToken: token
+        refreshToken: token
+      # No `sentinels:`. Devin must receive the real intermediate token so it
+      # can complete the exchange that mints the durable key.
+      #
+      # Masking cannot work here: the token is immediately embedded in a
+      # subsequent Connect request that mints the account's primary API key.
+      # OAuth header substitution cannot replace a sentinel inside that
+      # protobuf payload, so login fails with "failed to get primary API key
+      # ... Invalid token" unless the real intermediate token passes through.
+      #
+      # On later runs the credential-file hook renders the captured durable
+      # key, so the new sandbox starts authenticated without another login.
+      passthrough: true
+      credentialFile:
+        path: "~/.local/share/devin/credentials.toml"
+        template: |
+          api_server_url = "https://server.codeium.com"
+          devin_webapp_host = "app.devin.ai"
+          devin_api_url = "https://api.devin.ai"
+          windsurf_api_key = "{{.PrimaryApiKey}}"
+
+permissions:
+  network:
+    # Built-in agents ship no egress policy of their own: they inherit
+    # whatever the host policy is, which defaults to permissive. A community
+    # kit cannot rely on that — this repo's e2e runs every kit under
+    # `sbx policy init deny-all`, so the kit gets exactly the reachability it
+    # declares here and nothing more.
+    allow:
+      # Devin's own hosts. api.devin.ai is the API the CLI talks to (the
+      # DEVIN_API_URL default); app.devin.ai serves the login flow that
+      # start.sh drops into.
+      - api.devin.ai
+      - app.devin.ai
+      # Alternate login host. With unleash.codeium.com unreachable the CLI
+      # printed a windsurf.com/devin/account/login URL instead of the
+      # app.devin.ai one — the Windsurf lineage showing through. Which host a
+      # given account gets appears to be flag-driven, so both are allowed
+      # rather than betting on one; drop this if a live login never uses it.
+      - windsurf.com
+      # The install happens at image build time, but both hosts are also
+      # reachable at runtime for `devin update` and version checks:
+      # cli.devin.ai serves install.sh, which reads a manifest from
+      # static.devin.ai and pulls the versioned bundle from there.
+      # files/home/.config/devin/config.json turns background self-update off,
+      # so nothing reaches these unless the user asks for it.
+      - cli.devin.ai
+      - static.devin.ai
+      # Devin CLI is built on the Windsurf/Codeium codebase (Cognition
+      # acquired Windsurf), and the model backend still lives on the Codeium
+      # host — WINDSURF_API_SERVER_URL in the binary. Without this the CLI
+      # authenticates and then cannot answer a prompt. unleash.codeium.com is
+      # its feature-flag service.
+      - server.codeium.com
+      - unleash.codeium.com
+      # `apt-get update` (the startup hook below) refreshes metadata for every
+      # configured apt source and returns exit 100 if any one of them fails.
+      # The shell-docker base ships three sources, so all three must be
+      # reachable. Ubuntu serves amd64 from archive/security and arm64 from
+      # ports.ubuntu.com, so all three Ubuntu hosts are listed to keep the kit
+      # working cross-arch.
+      - archive.ubuntu.com        # Ubuntu archive (amd64 main)
+      - security.ubuntu.com       # Ubuntu security updates (amd64)
+      - ports.ubuntu.com          # Ubuntu archive/security (arm64)
+      - download.docker.com       # Docker's apt repo, pre-added by shell-docker
+      #
+      # app.devin.ai, server.codeium.com, unleash.codeium.com and
+      # static.devin.ai were each observed being contacted by `devin auth
+      # login` (captured via an HTTPS_PROXY CONNECT log), so those four are
+      # evidence, not inference. api.devin.ai and cli.devin.ai are still
+      # inferred — the first is the documented API base, the second only serves
+      # install/update.
+      #
+      # Deliberately excluded: the crash-reporting ingest host the same capture
+      # showed (o4507463137361920.ingest.us.sentry.io) and server-beta.codeium.com.
+      # A sandbox has no reason to report crashes to a third party, and the
+      # beta backend is not the default. If login or a prompt stalls, these are
+      # the first candidates to add:
+      #
+      #   sbx run --kit ./devin devin      # then log in and send a prompt
+      #   sbx policy log <sandbox>         # lists every blocked host + reason
+
+setup:
+  startup:
+    - command: ["sh", "-c", "command -v apt-get > /dev/null 2>&1 && (apt-get update -qq -y > /dev/null 2>&1 || true) &"]
+      user: "root"
+      description: Update apt package cache in background
+    # Gateway-first MCP registration. sandboxd injects MCP_GATEWAY_URL +
+    # MCP_SENTINEL_TOKEN_NAME into the container env when a gateway has been
+    # reserved. The sentinel is not a credential — the proxy substitutes the
+    # real token at request time, keyed by this name. No-op when MCP isn't
+    # enabled.
+    #
+    # Devin owns mcp_config.json exclusively (its other settings live in the
+    # sibling config.json, which this kit ships and never mixes with server
+    # entries), so the file is written fresh rather than merged.
+    #
+    # Shape: `devin mcp add <name> <url> --transport http --scope user
+    # --header ...` writes exactly this JSON to exactly this path — the
+    # heredoc mirrors the CLI's own output rather than guessing at a schema.
+    # It is written directly instead of shelling out to `devin mcp add` so the
+    # TCK's mcp_registration subtest can pin the key names; the expected shape
+    # lives in testdata/tck.yaml. Note `transport`, not `type` (Codex's
+    # spelling) and not `httpUrl` (Gemini's) — both are the wrong answers
+    # nearest to hand when editing this.
+    - command:
+        - sh
+        - -c
+        - |
+          set -e
+          [ -n "$MCP_GATEWAY_URL" ] || exit 0
+          mkdir -p "$HOME/.config/devin"
+          cat > "$HOME/.config/devin/mcp_config.json" <<EOF
+          {
+            "mcpServers": {
+              "mcp-gateway": {
+                "url": "$MCP_GATEWAY_URL",
+                "transport": "http",
+                "headers": {
+                  "Authorization": "Bearer $MCP_SENTINEL_TOKEN_NAME"
+                }
+              }
+            }
+          }
+          EOF
+      user: "agent"
+      description: Register the sandbox MCP gateway in ~/.config/devin/mcp_config.json
+
+agentInstructions:
+  # Devin reads AGENTS.md (plus agents.md and AGENTS.local.md) from the
+  # workspace root. It has no product-specific profile filename of its own —
+  # its `rules` command covers .windsurf/rules and .cursor/rules directories,
+  # which are a different mechanism from the single profile file this field
+  # names.
+  filename: AGENTS.md

--- a/devin/start.sh
+++ b/devin/start.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Entry point the sandbox resolves as `devin`; the real CLI is `devin-cli`.
+#
+# Devin CLI authenticates from ~/.local/share/devin/credentials.toml. When sbx
+# has no reusable credential to provision there, this wrapper starts Devin's
+# own login flow before launching the agent.
+
+set -uo pipefail
+
+# `devin auth status` exits 0 whether or not a session exists, so its exit code
+# cannot gate the login flow — the message it prints is the only signal.
+#
+# Captured into a variable rather than piped into grep on purpose: `grep -q`
+# exits as soon as it matches, which can leave devin-cli killed by SIGPIPE, and
+# under `pipefail` that failure becomes the pipeline's status and would mask a
+# successful match.
+if ! status=$(devin-cli auth status 2>&1); then
+    echo "Failed to read Devin authentication status." >&2
+    exit 1
+fi
+
+case "${status,,}" in
+*"not logged in"*)
+    echo "Not authenticated. Starting Devin login..."
+    # No browser runs in the sandbox, so the default localhost redirect never
+    # comes back. --force-manual-token-flow is Devin's own answer for that
+    # case (documented for remote and SSH sessions): it prints a URL to open
+    # on the host and reads the token back here.
+    if ! devin-cli auth login --force-manual-token-flow; then
+        echo "Login failed." >&2
+        exit 1
+    fi
+    ;;
+esac
+
+# exec so devin-cli replaces this wrapper rather than running underneath it:
+# Ctrl-C and SIGTERM then reach the CLI directly instead of a shell that would
+# have to forward them.
+exec devin-cli "$@"

--- a/devin/start.sh
+++ b/devin/start.sh
@@ -8,6 +8,33 @@
 
 set -uo pipefail
 
+secure_credentials() {
+    local credentials_file="${HOME}/.local/share/devin/credentials.toml"
+    if [[ ! -f "${credentials_file}" ]] ||
+        ! grep -Eq '^[[:space:]]*windsurf_api_key[[:space:]]*=' "${credentials_file}"; then
+        return
+    fi
+    if ! sed -i 's/^[[:space:]]*windsurf_api_key[[:space:]]*=.*$/windsurf_api_key = "devin-proxy-managed"/' "${credentials_file}" ||
+        ! grep -Fqx 'windsurf_api_key = "devin-proxy-managed"' "${credentials_file}"; then
+        echo "Failed to secure Devin credentials." >&2
+        return 1
+    fi
+}
+
+credential_state() {
+    local credentials_file="${HOME}/.local/share/devin/credentials.toml"
+    if [[ ! -f "${credentials_file}" ]] ||
+        ! grep -Eq '^[[:space:]]*windsurf_api_key[[:space:]]*=' "${credentials_file}"; then
+        echo absent
+    elif grep -Eq '^[[:space:]]*windsurf_api_key[[:space:]]*=[[:space:]]*""[[:space:]]*$' "${credentials_file}"; then
+        echo empty
+    elif grep -Fqx 'windsurf_api_key = "devin-proxy-managed"' "${credentials_file}"; then
+        echo sentinel
+    else
+        echo credential
+    fi
+}
+
 # `devin auth status` exits 0 whether or not a session exists, so its exit code
 # cannot gate the login flow — the message it prints is the only signal.
 #
@@ -15,14 +42,26 @@ set -uo pipefail
 # exits as soon as it matches, which can leave devin-cli killed by SIGPIPE, and
 # under `pipefail` that failure becomes the pipeline's status and would mask a
 # successful match.
-if ! status=$(devin-cli auth status 2>&1); then
-    echo "Failed to read Devin authentication status." >&2
-    exit 1
+state=$(credential_state)
+login_required=false
+if [[ "${state}" == absent || "${state}" == empty ]]; then
+    login_required=true
+elif [[ "${state}" != sentinel ]]; then
+    if ! status=$(devin-cli auth status 2>&1); then
+        echo "Failed to read Devin authentication status." >&2
+        exit 1
+    fi
+    case "${status,,}" in
+    *"not logged in"*) login_required=true ;;
+    esac
 fi
 
-case "${status,,}" in
-*"not logged in"*)
+if [[ "${login_required}" == true ]]; then
     echo "Not authenticated. Starting Devin login..."
+    if [[ "${state}" == empty ]] && ! devin-cli auth logout > /dev/null 2>&1; then
+        echo "Failed to clear empty Devin credentials." >&2
+        exit 1
+    fi
     # No browser runs in the sandbox, so the default localhost redirect never
     # comes back. --force-manual-token-flow is Devin's own answer for that
     # case (documented for remote and SSH sessions): it prints a URL to open
@@ -31,8 +70,21 @@ case "${status,,}" in
         echo "Login failed." >&2
         exit 1
     fi
-    ;;
-esac
+
+    # Login returns after writing the durable key. Status validates that key
+    # through GetUserStatus, which lets sandboxd persist it before the local
+    # copy is replaced below.
+    if ! status=$(devin-cli auth status 2>&1) ||
+        [[ "${status,,}" == *"failed to fetch"* ]] ||
+        [[ "${status,,}" == *"not logged in"* ]]; then
+        echo "Failed to validate Devin login." >&2
+        exit 1
+    fi
+fi
+
+if ! secure_credentials; then
+    exit 1
+fi
 
 # exec so devin-cli replaces this wrapper rather than running underneath it:
 # Ctrl-C and SIGTERM then reach the CLI directly instead of a shell that would

--- a/devin/testdata/tck.yaml
+++ b/devin/testdata/tck.yaml
@@ -1,0 +1,36 @@
+# TCK configuration for the devin kit.
+#
+# `extractedFromBuiltin` is deliberately absent: devin has never been a built-in
+# sbx agent, so there is no name collision for `sbx create` to trip over and the
+# full e2e is expected to run.
+#
+# `promptArgs` is deliberately omitted, which skips the e2e `prompt` subtest.
+# That is the documented opt-out "for agents with no non-interactive mode"
+# (tck/e2e_test.go). Devin CLI does have one — `devin -p "<prompt>"` — but the
+# TCK has no Devin account credential. The entrypoint therefore waits for a
+# human to complete `devin auth login --force-manual-token-flow` instead of
+# answering the prompt.
+#
+# The remaining subtests (env, files, tmpfs, agentContext, mcp_registration)
+# still run and are what actually gate this kit.
+#
+# If a Devin token is ever available to CI, set `binary: devin-cli` to bypass the
+# auth wrapper and add `promptArgs: ["-p"]` here.
+
+# Shape of the MCP-gateway registration written by the startup hook in
+# spec.yaml, checked by the TCK's mcp_registration subtest. The
+# format-independent parts (no-op guard, env-var indirection, no literal token,
+# non-root user) are asserted for every kit and need no configuration here.
+#
+# Devin keys an HTTP MCP server by `url`, alongside `transport` and a `headers`
+# object, in a file of its own (mcp_config.json) separate from config.json.
+# `type` is Codex's spelling of the transport and `httpUrl` is Gemini's — the two
+# wrong answers nearest to hand when editing this. Confirmed by running
+# `devin mcp add mcp-gateway <url> --transport http --scope user --header ...`
+# in the built image and reading back what it wrote.
+mcp:
+  configPath: $HOME/.config/devin/mcp_config.json
+  transportKey: url
+  forbiddenKeys:
+    - httpUrl
+    - type

--- a/tck/suite.go
+++ b/tck/suite.go
@@ -519,6 +519,9 @@ func (s *Suite) RunOAuthPolicyTests(t *testing.T) {
 			})
 
 			t.Run("sentinels", func(t *testing.T) {
+				if oauth.Passthrough {
+					return
+				}
 				require.NotEmpty(t, oauth.Sentinels.AccessToken, "oauth.sentinels.accessToken is required")
 				require.NotEmpty(t, oauth.Sentinels.RefreshToken, "oauth.sentinels.refreshToken is required")
 			})

--- a/tck/tck_test.go
+++ b/tck/tck_test.go
@@ -288,6 +288,19 @@ func TestRunOAuthPolicyTests(t *testing.T) {
 					TokenEndpoint: spec.OAuthTokenEndpoint{Host: "auth.example.com", Path: "/token"},
 					Sentinels:     spec.OAuthSentinels{AccessToken: "at", RefreshToken: "rt"},
 				},
+			}, {
+				Service: "passthrough-without-sentinels",
+				OAuth: &spec.OAuth{
+					TokenEndpoint: spec.OAuthTokenEndpoint{Host: "auth.example.com", Path: "/token"},
+					Passthrough:   true,
+				},
+			}, {
+				Service: "passthrough-with-sentinels",
+				OAuth: &spec.OAuth{
+					TokenEndpoint: spec.OAuthTokenEndpoint{Host: "auth.example.com", Path: "/token"},
+					Sentinels:     spec.OAuthSentinels{AccessToken: "at", RefreshToken: "rt"},
+					Passthrough:   true,
+				},
 			}},
 		},
 	}


### PR DESCRIPTION
<!--
Thanks for contributing to sbx-kits-contrib!

PRs from forks have CI's `test-kit-e2e` job SKIPPED because GitHub does not
expose `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` to fork-triggered workflows.
The e2e assertions will not run on your PR — your laptop is the only place
they run before merge. See the checklist below.
-->

## Summary

Adds a contributed sandbox kit for Devin CLI. Users authenticate once through Devin’s manual browser flow; sbx stores
the resulting durable credential so later sandboxes start already logged in.

## Spec choices worth flagging for review

OAuth uses passthrough: true because Devin embeds the intermediate browser token in a protobuf request that cannot use
sentinel substitution. The kit renders the captured durable windsurf_api_key into Devin’s credentials file. Network
access is limited to hosts observed or required during login and normal CLI operation.

## Origin

Created from the upstream Devin CLI installer and validated against the installed CLI through live login and fresh-
sandbox reuse.

## Test plan

CI runs `kit validate` and the TCK on every PR. CI does **not** run e2e on
fork PRs (Docker Hub secrets aren't exposed there), so the e2e step below is
required from your side before requesting review.

- [ ] `sbx kit validate ./<kit>/` passes
- [ ] `./scripts/test-kit.sh <kit>` passes (the TCK)
- [ ] `./scripts/test-kit-e2e.sh <kit>` passes. The script applies the same
      `deny-all` baseline CI uses and scopes everything to its own daemon
      (`--app-name sbx-kits-contrib-tck`), so my main sbx state is untouched.
      Every entry I added to `network.allowedDomains` came from
      `sbx --app-name sbx-kits-contrib-tck policy log <tck-e2e-…>`, not a guess.
- [ ] Manual smoke: `sbx run --kit ./<kit>/ <agent>` and verified the kit's
      binary / files / env are inside the running container.

One-time setup if you haven't run e2e on this machine before:
`sbx --app-name sbx-kits-contrib-tck login`.

See [CONTRIBUTING.md → Verifying locally](../CONTRIBUTING.md#verifying-locally)
and [README → Declare every domain your kit needs](../README.md#declare-every-domain-your-kit-needs)
for the cross-arch domain gotchas (`archive.ubuntu.com`,
`security.ubuntu.com`, `ports.ubuntu.com`) and the package-manager refresh trap.
