### PR TITLE
fix(git-ssh-sign): cross-check GitHub signing keys before picking one

### DIFF
--- a/git-ssh-sign/README.md
+++ b/git-ssh-sign/README.md
@@ -70,14 +70,44 @@ sandbox infrastructure, so the config is always present when
 
 `gpg.ssh.defaultKeyCommand` points to
 `/home/agent/.config/git/ssh-signing-key-command`. When Git needs a
-signing key, it runs that command. The command reads the first public key
-from `ssh-add -L`, writes `/home/agent/.config/git/allowed_signers` for
-signature verification, and prints the key in Git's inline `key::...`
+signing key, it runs that command, writes
+`/home/agent/.config/git/allowed_signers` for local signature
+verification, and prints the chosen key in Git's inline `key::...`
 format.
 
 This avoids writing key material at install or startup time, when the
 forwarded SSH agent may not be connected yet. It also avoids relying on
 Git hooks for signing.
+
+**Picking which forwarded key to sign with**
+
+A host's SSH agent often forwards more than one key — e.g. a password
+manager's own key alongside the key you actually use with GitHub — and
+nothing about `ssh-add -L`'s ordering says which one is registered
+anywhere. Signing with the wrong one still produces a valid signature,
+but it shows **Unverified** on GitHub because that key was never added
+to the committer's account.
+
+When the repo's remote is on `github.com` and the `gh` CLI is
+authenticated (`gh auth status`), the command instead:
+
+1. Resolves the committer's GitHub login (`gh api user`).
+2. Fetches their registered signing keys from the public,
+   unauthenticated `GET /users/{username}/ssh_signing_keys` endpoint —
+   deliberately not `github.com/{username}.keys`, which only lists
+   **authentication** keys and can diverge from the signing-key list.
+3. Uses whichever of the agent's keys matches one of those, falling back
+   to the first agent key (with a stderr warning) if none do.
+
+The GitHub response is cached for 5 minutes in
+`/home/agent/.config/git/github-signing-keys.cache`, since this command
+runs on every single commit and signature and unauthenticated GitHub API
+requests are capped at 60/hour per source IP.
+
+On any other remote host, or without `gh`, this step is skipped
+entirely — no network call is made, and behavior is unchanged from
+before: the first key the agent offers. GitHub Enterprise Server and
+other forges aren't cross-checked yet.
 
 **Composing with repo-local hooks**
 

--- a/git-ssh-sign/spec.yaml
+++ b/git-ssh-sign/spec.yaml
@@ -10,6 +10,17 @@ agentInstructions:
     This sandbox is configured to sign git commits with your host's SSH key.
     Commits and tags are signed automatically. Use `git log --show-signature`
     to verify signatures on existing commits.
+
+    If a repo's remote is on github.com and the `gh` CLI is authenticated,
+    the signing key is cross-checked against the keys registered on the
+    committer's GitHub account (https://github.com/settings/keys), so the
+    commit also shows as Verified there — not just locally. On any other
+    host, or without `gh`, the first key the SSH agent offers is used, same
+    as before.
+permissions:
+  network:
+    allow:
+      - api.github.com
 setup:
   install:
     - command: |
@@ -35,8 +46,8 @@ setup:
             exit 1
         fi
 
-        key=$(ssh-add -L 2>/dev/null | head -n 1)
-        if [ -z "$key" ]; then
+        agent_keys=$(ssh-add -L 2>/dev/null)
+        if [ -z "$agent_keys" ]; then
             echo "[git-ssh-sign] no keys in SSH agent - cannot sign commits" >&2
             exit 1
         fi
@@ -46,6 +57,67 @@ setup:
             config_dir="/home/agent/.config/git"
         fi
         mkdir -p "$config_dir"
+
+        # Default: the first key the agent offers, same as always. Refined
+        # below when the repo's remote is GitHub and one of the agent's keys
+        # is confirmed to be registered there for signing - otherwise the
+        # signature only ever verifies locally and shows Unverified once
+        # pushed, because the agent may forward keys (e.g. a host password
+        # manager's own key) that were never added to the committer's GitHub
+        # account at all.
+        key=$(printf '%s\n' "$agent_keys" | head -n 1)
+
+        is_github=0
+        for remote_url in $(git config --get-regexp '^remote\..*\.url$' 2>/dev/null | cut -d' ' -f2- || true); do
+            case "$remote_url" in
+                *github.com*) is_github=1 ;;
+            esac
+        done
+
+        if [ "$is_github" = "1" ] && command -v gh >/dev/null 2>&1; then
+            # GitHub's SSH signing keys are a separate list from the
+            # authentication keys behind github.com/<user>.keys, and there is
+            # no bulk unauthenticated lookup by key - only by username. This
+            # cache keeps a commit-signing hook from making a network call
+            # (and burning unauthenticated rate limit) on every single commit.
+            cache_file="$config_dir/github-signing-keys.cache"
+            cache_ttl=300
+            now=$(date +%s 2>/dev/null || echo 0)
+            cache_age=$cache_ttl
+            if [ -f "$cache_file" ]; then
+                cache_ts=$(head -n 1 "$cache_file" 2>/dev/null || echo 0)
+                case "$cache_ts" in
+                    ''|*[!0-9]*) cache_ts=0 ;;
+                esac
+                cache_age=$((now - cache_ts))
+            fi
+
+            if [ -f "$cache_file" ] && [ "$cache_age" -lt "$cache_ttl" ]; then
+                github_keys=$(tail -n +2 "$cache_file")
+            else
+                login=$(gh api user --jq .login 2>/dev/null) || login=""
+                github_keys=""
+                if [ -n "$login" ]; then
+                    github_keys=$(gh api "users/$login/ssh_signing_keys" --jq '.[].key' 2>/dev/null) || github_keys=""
+                fi
+                {
+                    printf '%s\n' "$now"
+                    printf '%s\n' "$github_keys"
+                } > "$cache_file"
+            fi
+
+            if [ -n "$github_keys" ]; then
+                matched=$(printf '%s\n' "$agent_keys" | awk -v gh="$github_keys" '
+                    BEGIN { n = split(gh, ghlines, "\n"); for (i = 1; i <= n; i++) seen[ghlines[i]] = 1 }
+                    { fp = $1 " " $2; if (fp in seen) { print; exit } }
+                ')
+                if [ -n "$matched" ]; then
+                    key="$matched"
+                else
+                    echo "[git-ssh-sign] none of the SSH agent's keys are registered on GitHub as a signing key - commits will sign but show Unverified there. Add one at https://github.com/settings/ssh/new?type=signing" >&2
+                fi
+            fi
+        fi
 
         email=$(git config user.email 2>/dev/null || printf '%s' "agent@sandbox.local")
         printf '%s %s\n' "$email" "$key" > "$config_dir/allowed_signers"


### PR DESCRIPTION
## Summary

- `ssh-signing-key-command` always signed with whichever key `ssh-add -L` listed first. A host agent forwarding more than one key (e.g. a password manager's own key alongside the one actually registered on GitHub) can make that the wrong one — the commit signs fine and verifies locally against `allowed_signers` (which the script itself writes from the same pick), but shows **Unverified** on GitHub because that key was never added to the committer's account.
- When the repo's remote is on `github.com` and `gh` is authenticated, the command now cross-checks the agent's keys against `GET /users/{username}/ssh_signing_keys` — the public, unauthenticated signing-keys endpoint — and prefers whichever agent key actually matches, falling back to the first key (with a stderr warning) if none do.
- Deliberately not `github.com/{username}.keys`: that only lists **authentication** keys and can diverge from the signing-key list.
- The GitHub response is cached for 5 minutes in `github-signing-keys.cache` next to `allowed_signers`, since this command runs on every commit/tag signature and unauthenticated GitHub API calls are capped at 60/hour per source IP.
- On any other remote host, or without `gh`, this is skipped entirely — no network call, same first-key behavior as before.

## Spec choices worth flagging for review

- Added `permissions.network.allow: [api.github.com]` — required for the cross-check to run under `deny-all`. It's a permission grant, not a mandate; non-GitHub repos never trigger a request to it.
- GitHub Enterprise Server and other forges aren't cross-checked — only literal `github.com` remotes trigger the lookup. Scoped narrowly on purpose rather than guessing at enterprise hostnames.
- Username resolution goes through `gh api user`, so it depends on `gh` being installed and authenticated (`gh auth status`). Sandboxes without `gh` silently fall back to prior behavior.

## Test plan

- `go run ./scripts/verify-kit-spec git-ssh-sign` — valid, no warnings.
- `../scripts/test-kit.sh git-ssh-sign` — TCK suite passes (validation, network policy, and a real container run of the install hook).
- Manually extracted the script and ran it against a scratch repo with a `github.com` remote and one with a `gitlab.com` remote — the GitLab repo produces byte-identical output to the old script (no cache file, no network call). Unit-tested the key-matching `awk` against synthetic agent/GitHub key lists for both the match and no-match (fallback + warning) branches, and manually backdated the cache file to confirm it's refetched after the 5-minute TTL and reused within it (verified via a stubbed `gh`).
- Not run: `../scripts/test-kit-e2e.sh` (needs `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN`, per CONTRIBUTING.md) and `sbx run --kit .` (no `sbx` binary available in this environment).

## Origin

Found while debugging why a Docker Learn sandbox's commits showed Unverified on GitHub — the agent's forwarded SSH agent had two keys, and this kit picked the one that isn't registered on GitHub at all.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>