### PR TITLE
feat(qemu): new mixin — register QEMU emulators via binfmt for multi-arch

### DIFF
--- a/qemu/README.md
+++ b/qemu/README.md
@@ -1,0 +1,70 @@
+# qemu
+
+A mixin kit that registers **QEMU user-mode emulators** with the kernel's `binfmt_misc` using Docker ([`tonistiigi/binfmt`](https://github.com/tonistiigi/binfmt)) — the same mechanism `docker buildx` uses for cross-platform builds. Once composed onto a Docker-in-Docker agent, the sandbox can **run and build container images for non-native CPU architectures** (for example `linux/arm64` on an amd64 host, and vice versa).
+
+## Usage
+
+```console
+sbx run claude --kit "docker.io/sbx/qemu-kit:latest" .
+```
+
+Or straight from this repository over git:
+
+```console
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=qemu" claude
+```
+
+Or with a local clone of this repo:
+
+```console
+sbx run claude --kit ./qemu/ .
+```
+
+Prerequisites:
+
+- **A Docker-in-Docker base.** This kit shells out to `docker` at startup, so compose it onto a `*-docker` sandbox template (for example `docker/sandbox-templates:shell-docker`). The startup hook fails loudly with a clear message if `docker` isn't on `PATH`.
+
+Inside the sandbox:
+
+```console
+docker run --rm --platform linux/arm64 alpine uname -m   # -> aarch64
+docker buildx build --platform linux/amd64,linux/arm64 -t demo .
+ls /proc/sys/fs/binfmt_misc/qemu-*                        # registered emulators
+```
+
+## How it works
+
+### Why registration happens at startup, not install time
+
+`tonistiigi/binfmt --install` talks to the in-sandbox Docker daemon (DinD), which is only up once the container is running — it is **not** available during `install` hooks, which run before the entrypoint. So the actual registration is a `startup` hook. `startup` always runs after `install`, which is why the `mount` prerequisite (below) can be handled at install time and is guaranteed to be present when the startup hook runs.
+
+### Why `mount` is installed, then used to mount `binfmt_misc`
+
+Emulator registrations live in the `binfmt_misc` pseudo-filesystem, which must be mounted at `/proc/sys/fs/binfmt_misc` before handlers can be registered or inspected. That needs the `mount` tool, so the install hook ensures it's present (`apt-get install mount` only if the base image lacks it). The startup hook then mounts the filesystem, guarding on the `register` control file — which exists only once `binfmt_misc` is mounted — so a re-mount is skipped when it's already there.
+
+### Why it's safe to run on every start
+
+`startup` hooks run on **every** container start (create, stop/start, daemon restart, host reboot), so the body is idempotent. `binfmt_misc` registrations are kernel-global and survive sandbox restarts, so before pulling and running `tonistiigi/binfmt` the hook checks for existing `qemu-*` handlers and skips the network-heavy install when they're already registered. When it does need to install, it waits (up to 60s) for the Docker daemon to accept connections first.
+
+### Why these domains
+
+`permissions.network.allow` is the kit's complete outbound contract — CI runs e2e under a `deny-all` policy.
+
+| Domain | Why |
+| --- | --- |
+| `registry-1.docker.io` | Docker Hub registry — serves the `tonistiigi/binfmt` manifest |
+| `auth.docker.io` | Docker Hub token endpoint for the pull |
+| `production.cloudflare.docker.com` | Docker Hub layer-blob CDN |
+| `index.docker.io` | Legacy Docker Hub index some client flows still touch |
+| `archive.ubuntu.com` | Ubuntu apt archive, amd64 — `apt-get install mount` |
+| `security.ubuntu.com` | Ubuntu security pocket, amd64 — refreshed by the same `apt-get update` |
+| `ports.ubuntu.com` | Ubuntu archive/security for arm64 (Apple Silicon sandboxes) |
+| `download.docker.com` | Docker's apt repo, pre-added by the `*-docker` templates — `apt-get update` refreshes every configured source and fails if any is blocked |
+
+## Cleanup
+
+The apt-installed `mount` package and the `binfmt_misc` mount are sandbox-local and disappear with the sandbox (`sbx rm <name>`). The **emulator registrations are not** — `binfmt_misc` is global to the Docker VM's kernel, so they persist for other sandboxes and for the host's Docker until the VM restarts. To remove them explicitly without restarting the VM:
+
+```console
+docker run --privileged --rm tonistiigi/binfmt --uninstall 'qemu-*'
+```

--- a/qemu/spec.yaml
+++ b/qemu/spec.yaml
@@ -1,0 +1,105 @@
+schemaVersion: "2"
+kind: mixin
+name: qemu
+displayName: QEMU (multi-arch binfmt)
+description: >-
+  Registers QEMU user-mode emulators with the kernel's binfmt_misc via Docker
+  (tonistiigi/binfmt) so the sandbox can run and build container images for
+  other CPU architectures. Requires a Docker-in-Docker base template.
+
+permissions:
+  network:
+    allow:
+      # Docker Hub: the in-sandbox docker daemon pulls tonistiigi/binfmt for the
+      # startup step. registry-1.docker.io serves the manifest, auth.docker.io
+      # issues the pull token, and layer blobs come from Cloudflare. index.docker.io
+      # is the legacy index some client flows still touch.
+      - registry-1.docker.io:443
+      - auth.docker.io:443
+      - production.cloudflare.docker.com:443
+      - index.docker.io:443
+      # apt: install the `mount` prerequisite if the base image lacks it.
+      # `apt-get update` refreshes every configured source, so all of the
+      # *-docker template's Ubuntu + Docker apt hosts must be reachable. Ubuntu
+      # serves amd64 from archive/security and arm64 from ports.ubuntu.com.
+      - archive.ubuntu.com:80
+      - security.ubuntu.com:80
+      - ports.ubuntu.com:80
+      - download.docker.com:443
+setup:
+  # `mount` is required to mount the binfmt_misc filesystem in the startup step.
+  # install hooks run once, as root, before the entrypoint — the right place for
+  # apt (the in-sandbox docker daemon is not up yet). command is a string,
+  # executed via `sh -c`.
+  install:
+    - command: |
+        set -eu
+        if ! command -v mount >/dev/null 2>&1; then
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update
+          apt-get install -y --no-install-recommends mount
+          rm -rf /var/lib/apt/lists/*
+        fi
+      user: "0"
+      description: Ensure `mount` is installed (prerequisite for binfmt_misc)
+  # Registering QEMU emulators needs the in-sandbox docker daemon (DinD), which
+  # only comes up once the container is running — so this is a startup hook, and
+  # startup always runs after install, so the `mount` prerequisite is present.
+  # startup runs on EVERY start, so the body is idempotent: it mounts
+  # binfmt_misc only if needed and skips the docker install when the emulators
+  # are already registered. startup commands are exec-style argv, so wrap the
+  # script in ["sh", "-c", …].
+  startup:
+    - command:
+        - sh
+        - -c
+        - |
+          set -eu
+          # This kit needs a Docker-in-Docker base. Fail loudly (like the
+          # playwright kit does for npm) if it was composed onto a template
+          # without docker.
+          if ! command -v docker >/dev/null 2>&1; then
+            echo "docker not found: the qemu kit needs a Docker-in-Docker base (compose it onto a *-docker template, e.g. docker/sandbox-templates:shell-docker)" >&2
+            exit 1
+          fi
+          # Mount binfmt_misc so emulator registrations are visible and writable.
+          # The `register` control file only exists once binfmt_misc is mounted,
+          # so use it as the idempotency guard. This hook runs as root, so no
+          # sudo is needed.
+          if [ ! -e /proc/sys/fs/binfmt_misc/register ]; then
+            mount -t binfmt_misc binfmt_misc /proc/sys/fs/binfmt_misc
+          fi
+          # binfmt_misc registrations are kernel-global and survive sandbox
+          # restarts, so skip the network-heavy docker install when the QEMU
+          # emulators are already registered.
+          if ls /proc/sys/fs/binfmt_misc/qemu-* >/dev/null 2>&1; then
+            echo "QEMU binfmt emulators already registered; skipping install."
+            exit 0
+          fi
+          # Wait for the in-sandbox docker daemon (DinD) to accept connections.
+          i=0
+          while [ "$i" -lt 60 ]; do
+            if docker info >/dev/null 2>&1; then
+              break
+            fi
+            i=$((i + 1))
+            sleep 1
+          done
+          docker run --privileged --rm tonistiigi/binfmt --install all
+      user: "0"
+      description: Mount binfmt_misc and install QEMU emulators via Docker
+
+agentInstructions:
+  content: |
+    ## Multi-architecture emulation (QEMU / binfmt)
+
+    QEMU user-mode emulators are registered with the kernel's binfmt_misc, so
+    this sandbox can run and build container images for non-native CPU
+    architectures (e.g. linux/arm64 on an amd64 host and vice versa).
+
+    - Run a foreign-arch image directly:
+      `docker run --rm --platform linux/arm64 alpine uname -m`
+    - Build multi-arch images with buildx:
+      `docker buildx build --platform linux/amd64,linux/arm64 .`
+    - Inspect the registered emulators under
+      `/proc/sys/fs/binfmt_misc` (`ls /proc/sys/fs/binfmt_misc/qemu-*`).


### PR DESCRIPTION
## Summary

- New **`qemu` mixin** kit: registers QEMU user-mode emulators with the kernel's `binfmt_misc` via Docker ([`tonistiigi/binfmt`](https://github.com/tonistiigi/binfmt)), so a Docker-in-Docker sandbox can **run and build container images for non-native CPU architectures** (e.g. `linux/arm64` on an amd64 host and vice versa).
- **`install` hook** ensures `mount` is present (apt, as root, once) — the prerequisite for mounting `binfmt_misc`.
- **Idempotent `startup` hook**: mounts `binfmt_misc`, then registers emulators via `docker run --privileged tonistiigi/binfmt`; it fails loudly if `docker` isn't on `PATH`, waits for the in-sandbox daemon, and skips the network-heavy install when `qemu-*` handlers are already registered (registrations are kernel-global and survive restarts).
- **Scoped egress allowlist** (Docker Hub registry/auth/CDN + Ubuntu/Docker apt hosts) — the kit's complete outbound contract under the e2e `deny-all` policy.
- Requires a **privileged Docker-in-Docker base** (e.g. `docker/sandbox-templates:shell-docker`).

## Test plan

- [ ] Compose onto a `*-docker` template and confirm `ls /proc/sys/fs/binfmt_misc/qemu-*` lists emulators.
- [ ] `docker run --rm --platform linux/arm64 alpine uname -m` prints `aarch64` on an amd64 host.
- [ ] `docker buildx build --platform linux/amd64,linux/arm64 .` succeeds.
- [ ] Restart the sandbox and confirm the startup hook is idempotent (skips reinstall when emulators are already registered).
- [ ] e2e passes under `deny-all` with the declared allowlist.
