### PR TITLE
fix(claude-sbx-statusline): ensure statusline.sh is executable

### DIFF
--- a/claude-sbx-statusline/spec.yaml
+++ b/claude-sbx-statusline/spec.yaml
@@ -28,6 +28,8 @@ setup:
         tmp=$(mktemp -p /home/agent/.claude)
         jq '.statusLine = {type: "command", command: "~/.claude/statusline.sh"}' "$f" > "$tmp"
         mv "$tmp" "$f"
+        # Shipped files arrive 0644; unexecutable, it renders nothing and no error.
+        chmod +x /home/agent/.claude/statusline.sh
         chown -R agent:agent /home/agent/.claude
       user: "0"
-      description: Set the statusLine key in ~/.claude/settings.json to ~/.claude/statusline.sh (jq merge, so all other keys are preserved; any existing statusLine is replaced by design)
+      description: Set the statusLine key in ~/.claude/settings.json to ~/.claude/statusline.sh (jq merge, so all other keys are preserved; any existing statusLine is replaced by design) and make the script executable


### PR DESCRIPTION
## Symptom

The status line does not render, and nothing looks wrong. The script is installed and the `statusLine` key points at it:

```console
$ jq .statusLine ~/.claude/settings.json
{ "type": "command", "command": "~/.claude/statusline.sh" }

$ ls -l ~/.claude/statusline.sh
-rw-r--r-- 1 agent agent 3318 ... /home/agent/.claude/statusline.sh
```

Mode **0644**, though `files/home/.claude/statusline.sh` is committed **0755**. Claude Code cannot execute the command, and renders no status line *and no error* — so the failure is invisible from the config alone.

`chmod +x ~/.claude/statusline.sh` on the running sandbox makes it appear immediately, which confirms the diagnosis. It does not survive a recreate, since install re-copies the file.

## Change

`chmod +x` in `setup.install`, which runs after the shipped files are placed. `openclaw` already does the same for its own shipped scripts, so this is the established pattern in this repo for a kit that needs an executable.

Observed on sbx `v0.39.0-rc1-441-gfeb4c3cc9`.
