### PR TITLE
Add kubeaid-cli sandbox kit

### DIFF
--- a/kubeaid-cli/README.md
+++ b/kubeaid-cli/README.md
@@ -1,0 +1,104 @@
+# kubeaid-cli
+
+A mixin kit that installs [`kubeaid-cli`](https://github.com/Obmondo/kubeaid-cli),
+the operator CLI for [KubeAid](https://github.com/Obmondo/KubeAid)-managed
+Kubernetes clusters. `kubeaid-cli` drives the full GitOps-native cluster
+lifecycle — bootstrap, upgrade, recover, test, and delete — across AWS
+(self-managed or EKS), Azure (self-managed or AKS), Hetzner, and generic
+bare metal.
+
+## Usage
+
+```console
+sbx run --kit "docker.io/sbx/kubeaid-cli-kit:latest" bash
+agent@sandbox:/workspace$ kubeaid-cli --help
+```
+
+Or from a git URL targeting this repo:
+
+```console
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=kubeaid-cli" bash
+```
+
+Or with a local clone of this repo:
+
+```console
+sbx run --kit ./kubeaid-cli/ bash
+```
+
+Verify inside the sandbox:
+
+```console
+kubeaid-cli version
+kubeaid-cli --help
+```
+
+## How it works
+
+- The kit installs a specific `kubeaid-cli` release tarball (pinned by tag)
+  from GitHub Releases and verifies its SHA256 against a checksum recorded
+  in this spec, rather than piping an install script to a shell — the same
+  pattern used by this repo's `trivy` and `glab` kits.
+- `permissions.network.allow` is limited to the GitHub hosts needed to
+  download the pinned release asset (`api.github.com`, `github.com`,
+  `objects.githubusercontent.com`, `release-assets.githubusercontent.com`).
+  No other egress is granted by this kit.
+- `kubeaid-cli` only has one hard host dependency: a Docker daemon, used to
+  run a short-lived local [K3D](https://k3d.io/) "management cluster" that
+  bootstraps the real target cluster via Cluster API. Inside an `sbx`
+  sandbox this is satisfied by the sandbox's own nested Docker daemon — no
+  host Docker socket access is requested or required by this kit.
+
+## What this kit does *not* provision
+
+`kubeaid-cli` needs two more things to actually run a `cluster bootstrap`,
+which are intentionally left out of this kit because they are
+credential-bearing and target-environment-specific:
+
+1. **Git SSH access** to the "KubeAid Config" repo that `kubeaid-cli`
+   renders manifests into and that ArgoCD reconciles from. Rather than
+   handing the sandbox a raw private key, `ssh-add` your deploy key into
+   your **host's** SSH agent before starting the sandbox — sandboxes
+   forward `SSH_AUTH_SOCK` automatically (see this repo's `git-ssh-sign`
+   kit for the same underlying mechanism), so the key never enters the
+   VM. Then set `git.useSSHAgent: true` in `general.yaml` instead of
+   `privateKeyFilePath`, so `kubeaid-cli` dials the forwarded agent for
+   signing. If the KubeAid Config repo is on GitHub, combine with this
+   repo's `github-ssh` kit to also pre-populate `known_hosts` for it:
+
+   ```console
+   ssh-add ~/.ssh/kubeaid_config_deploy_key
+   sbx run shell \
+     --kit ./kubeaid-cli/ \
+     --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=github-ssh"
+   ```
+
+2. **Cloud credentials** for whichever provider you're targeting
+   (AWS/Azure/Hetzner). Add the relevant credentials with `sbx secret
+   set-custom` and extend `permissions.network.allow` for that provider's
+   API hosts — this kit's network policy only covers installing the binary
+   itself. `cloud.local` in `general.yaml` needs neither cloud credentials
+   nor extra network access, and is the fastest way to smoke-test the CLI
+   end to end inside a sandbox.
+
+The kit's `agentInstructions` documents both of these gaps directly to the
+agent so it doesn't attempt cloud/git operations it has no way to complete.
+
+## Why the install is pinned
+
+The install hook downloads a specific `kubeaid-cli` release tarball and
+verifies its SHA256 against a checksum recorded in this spec (same pattern
+as the `trivy` and `glab` kits), instead of piping an install script to a
+shell. To bump the version, update `KUBEAID_CLI_VERSION` and both per-arch
+`SHA256` values from that release's `kubeaid-cli_<version>_checksums.txt`
+asset.
+
+## Testing notes
+
+- `sbx kit validate ./kubeaid-cli/` passes.
+- The TCK's `validation`, `network_policy`, and `commands_validation`
+  suites pass. The `container` suite (which actually boots the kit inside
+  a container and runs the install hook) requires a working
+  `/var/run/docker.sock` for `testcontainers-go`; on a snap-packaged
+  Docker install this can require `sudo chgrp docker /var/run/docker.sock`
+  first if the socket is owned `root:root` instead of `root:docker`.

--- a/kubeaid-cli/spec.yaml
+++ b/kubeaid-cli/spec.yaml
@@ -1,0 +1,122 @@
+schemaVersion: "2"
+kind: mixin
+name: kubeaid-cli
+displayName: KubeAid CLI
+description: Installs kubeaid-cli, the operator CLI for KubeAid-managed Kubernetes clusters (bootstrap/upgrade/recover/test/delete across AWS, Azure, Hetzner, and bare metal), pinned to a signed release with a checked binary hash.
+
+permissions:
+  network:
+    allow:
+      # Version lookup + release asset download (install time).
+      - api.github.com
+      - github.com
+      - objects.githubusercontent.com
+      - release-assets.githubusercontent.com
+
+agentInstructions:
+  content: |
+    ## KubeAid CLI
+
+    `kubeaid-cli` is installed and on PATH (`kubeaid-cli version` to check;
+    `kubeaid-cli --help` for the full command tree).
+
+    ### What it is
+
+    `kubeaid-cli` is Obmondo's operator CLI for the KubeAid platform: it
+    owns the full GitOps-native lifecycle of a Kubernetes cluster —
+    bootstrap, upgrade, recover, test, and delete — across AWS (self-managed
+    or EKS), Azure (self-managed or AKS), Hetzner (cloud or bare metal
+    Robot), and generic bare metal. It's the CLI half of a repo trio:
+    `kubeaid-cli` (this binary) drives `KubeAid` (a curated, version-pinned
+    fork of upstream Helm charts) into a per-customer "KubeAid Config" git
+    repo, which ArgoCD then reconciles continuously.
+
+    ### The bootstrap flow, concretely (`kubeaid-cli cluster bootstrap`)
+
+    1. **Config**: reads `general.yaml`/`secrets.yaml` (produced by
+       `kubeaid-cli config generate`, an interactive prompt) — cluster name,
+       k8s version, cloud provider block, fork URLs, git auth.
+    2. **Local K3D "management cluster"**: spins up a short-lived K3D cluster
+       in the sandbox's own nested Docker daemon (`devenv create`). This is
+       the only host dependency — no cloud account is needed just to reach
+       this stage.
+    3. **Cluster API provisioning**: Cluster API + the matching provider
+       (CAPA/CAPZ/hcloud, or KubeOne for bare metal) create the real target
+       cluster from the management cluster.
+    4. **Pivot**: `clusterctl move` transfers Cluster API CRDs from the
+       throwaway management cluster onto the real cluster, which becomes
+       self-managing.
+    5. **Render + push + sync**: renders manifests from `general.yaml` into
+       the KubeAid Config repo, pushes over git SSH, and ArgoCD reconciles a
+       strict dependency order: cloud-controller-manager → traefik →
+       cert-manager → cloudnative-pg → keycloakx → netbird — each step
+       gated on real readiness (not just "Synced").
+    6. **Host-firewall lockdown**: applies a live Cilium `CiliumClusterwideNetworkPolicy`
+       immediately via server-side apply, then opens a *separate* PR to
+       persist it in git. If that PR is left unmerged before the next
+       ArgoCD sync, the lockdown silently reverts (fail-open) — flag this to
+       a human if a bootstrap run left one open.
+    7. **NetBird operator gate**: `cluster bootstrap` pauses interactively
+       until a NetBird API-key Secret exists; the NetBird operator's webhook
+       has `failurePolicy: Fail`, so pods cluster-wide can't schedule
+       without it — this is intentional, not a bug.
+
+    ### What this kit provisions vs. what it doesn't
+
+    This kit installs the binary only, with network access limited to
+    GitHub (for the pinned-checksum install). It does **not** provision:
+    - **Git SSH access** to the KubeAid Config repo — `cluster bootstrap`
+      needs to push there. Don't hand it a raw private key. Instead:
+      `ssh-add` the deploy key into your **host's** SSH agent before
+      starting the sandbox — sandboxes forward `SSH_AUTH_SOCK`
+      automatically, so the key material never enters the VM. Set
+      `git.useSSHAgent: true` in `general.yaml` (instead of
+      `privateKeyFilePath`) so `kubeaid-cli` dials the forwarded agent for
+      signing instead of expecting a key file on disk. Combine with the
+      `github-ssh` mixin from this repo if the KubeAid Config repo lives on
+      GitHub, to also pre-populate `known_hosts` for it.
+    - **Cloud credentials** (AWS/Azure/Hetzner) — add via `sbx secret
+      set-custom` (proxy-injected, HTTP-header based) plus the matching
+      cloud API host in `permissions.network.allow`. Note: `cloud.local`
+      in `general.yaml` needs neither — it targets the K3D management
+      cluster directly and is the fastest way to smoke-test the CLI.
+
+    ### Guardrails already enforced by the CLI itself (don't route around them)
+
+    - `cluster upgrade` and `cluster recover` refuse to run against EKS/AKS
+      clusters — those are GitOps-only there by design.
+    - K8s version is checked against a live EOL table; an EOL version fails
+      config validation outright (this is a real, current check — not a
+      lint warning).
+    - `kube-prometheus` version selection is also version-gated; an
+      unsupported k8s/kube-prometheus pairing fails validation the same way.
+
+setup:
+  install:
+    - command: |
+        set -euo pipefail
+        KUBEAID_CLI_VERSION=v0.31.7
+        ARCH=$(dpkg --print-architecture)
+        case "$ARCH" in
+          amd64)
+            TARBALL="kubeaid-cli_Linux_x86_64.tar.gz"
+            SHA256="dc4f633907e8abd7da393549b5311b23cf3c1f07296f9608573e99b452380eb7"
+            ;;
+          arm64)
+            TARBALL="kubeaid-cli_Linux_arm64.tar.gz"
+            SHA256="60a84f85e78dffc4b75c284e90481a25e43cb821d05006ef22ffbf70b19e87ea"
+            ;;
+          *)
+            echo "unsupported sandbox arch: $ARCH (expected amd64 or arm64)" >&2
+            exit 1
+            ;;
+        esac
+        URL="https://github.com/Obmondo/kubeaid-cli/releases/download/${KUBEAID_CLI_VERSION}/${TARBALL}"
+        curl --proto '=https' --tlsv1.2 -fsSL -o /tmp/kubeaid-cli.tgz "$URL"
+        echo "${SHA256}  /tmp/kubeaid-cli.tgz" | sha256sum -c -
+        tar -C /tmp -xzf /tmp/kubeaid-cli.tgz kubeaid-cli
+        install -m 0755 /tmp/kubeaid-cli /usr/local/bin/kubeaid-cli
+        rm -rf /tmp/kubeaid-cli.tgz /tmp/kubeaid-cli
+        kubeaid-cli version
+      user: "0"
+      description: "Install kubeaid-cli v0.31.7, version+digest pinned"


### PR DESCRIPTION
## Summary

Adds a mixin kit for `kubeaid-cli`, Obmondo's GitOps-native Kubernetes cluster lifecycle CLI. any agent's sandbox so the agent can drive cluster bootstrap, GitOps sync, and day-2 operations for real Kubernetes clusters (Hetzner, AWS, Azure, bare metal) from inside the sandbox.

