### PR TITLE
Add lighthouse kit

### DIFF
--- a/lighthouse/README.md
+++ b/lighthouse/README.md
@@ -1,0 +1,111 @@
+# lighthouse
+
+A mixin kit that installs the [Lighthouse](https://github.com/GoogleChrome/lighthouse)
+CLI **v12.6.1** from npm, plus **Chromium** (via the same Playwright browser
+channel as the `playwright` kit) so an agent can audit performance,
+accessibility, SEO, and best practices against pages served inside the
+sandbox — headless, sandbox-local.
+
+## Usage
+
+```console
+sbx run claude --kit "docker.io/sbx/lighthouse-kit:latest" .
+```
+
+Or straight from this repository over git:
+
+```console
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=lighthouse" claude
+```
+
+Or with a local clone of this repo:
+
+```console
+sbx run claude --kit ./lighthouse/ .
+```
+
+Prerequisites:
+
+- A base image with Node.js ≥ 18.20 and npm — all standard agent templates
+  ship Node ≥ 18. The install fails loudly if npm is missing.
+
+Inside the sandbox:
+
+```console
+lighthouse --version
+chromium --version
+lighthouse http://localhost:3000 --output html --output-path ./lh-report.html --quiet
+lighthouse http://localhost:3000 --output json --output-path ./lh-report.json --quiet
+```
+
+Compose with `playwright` when the agent also needs to drive the browser:
+
+```console
+sbx run claude --kit "docker.io/sbx/playwright-kit:latest" --kit "docker.io/sbx/lighthouse-kit:latest" .
+```
+
+Both kits set `PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright`, so Chromium is
+downloaded once and reused.
+
+## How it works
+
+### Why Chromium comes from Playwright, not apt
+
+Lighthouse needs a real Chrome/Chromium binary (`chrome-launcher` reads
+`CHROME_PATH`). Ubuntu's `chromium` / `chromium-browser` packages are often
+snap stubs that do not run in the sandbox. This kit installs Chromium with
+`npx playwright@1.61.1 install --with-deps chromium` into
+`/opt/ms-playwright` — the same channel and path the `playwright` kit uses —
+then symlinks the `chrome` binary to `/usr/local/bin/chromium` so the path
+in `CHROME_PATH` stays stable when the Playwright revision changes.
+
+If Chromium is already present under `/opt/ms-playwright` (for example
+because the sandbox also loaded the `playwright` kit), the install hook
+skips the download and only refreshes the symlink.
+
+### Why a wrapper around the npm bin
+
+Chrome inside the sandbox needs `--no-sandbox`, `--disable-dev-shm-usage`,
+and `--disable-gpu`. The wrapper at `/usr/local/bin/lighthouse` appends
+those via `--chrome-flags` unless the caller already passed that flag, and
+always passes `--no-enable-error-reporting` so a failed run does not try
+to reach Sentry (not on the allowlist). Headless is Lighthouse's own
+default; the sandbox has no display server.
+
+### Why Lighthouse 12.6.1, not 13.x
+
+Lighthouse 13.x requires Node ≥ 22.19. Standard agent templates only
+guarantee Node ≥ 18. 12.6.1 is the last 12.x release and accepts Node ≥
+18.20. npm verifies tarballs against the registry `sha512` integrity
+values, so pinning the version pins the content. To bump: change
+`LIGHTHOUSE_VERSION` in `spec.yaml` and the version references in
+`agentInstructions` and this README. Do not jump to 13.x until the
+templates ship Node 22.19.
+
+### Why these domains
+
+`permissions.network.allow` is the kit's complete outbound contract — CI
+runs e2e under a `deny-all` policy.
+
+| Domain | Why |
+| --- | --- |
+| `registry.npmjs.org` | npm tarballs for `lighthouse` and its dependencies (install time) |
+| `cdn.playwright.dev` | Playwright's primary browser-binary CDN (install time) |
+| `playwright.download.prss.microsoft.com` | Documented fallback CDN Playwright rotates to on primary failure |
+| `storage.googleapis.com` | Chrome-for-Testing zip on amd64 after the CDN 302 |
+| `archive.ubuntu.com` | Ubuntu apt archive, amd64 — `--with-deps` installs Chromium system libraries |
+| `security.ubuntu.com` | Ubuntu security pocket, amd64 — refreshed by the same `apt-get update` |
+| `ports.ubuntu.com` | Ubuntu archive/security for arm64 (Apple Silicon sandboxes) |
+| `download.docker.com` | Docker's apt repo, pre-added by the `*-docker` templates — `apt-get update` refreshes every configured source and fails if any is blocked |
+
+**Runtime reminder:** the allowlist covers installing Lighthouse and
+Chromium, not the sites an audit visits. Servers on `localhost` inside the
+sandbox always work; navigating to external sites fails with a proxy error
+unless the user's sandbox policy allows those domains.
+
+## Cleanup
+
+Everything is sandbox-local: the global `lighthouse` npm package, Chromium
+under `/opt/ms-playwright`, and apt-installed libraries all disappear with
+the sandbox (`sbx rm <name>`). Nothing touches the host's browsers or
+displays.

--- a/lighthouse/spec.yaml
+++ b/lighthouse/spec.yaml
@@ -1,0 +1,133 @@
+schemaVersion: "2"
+kind: mixin
+name: lighthouse
+displayName: Lighthouse
+description: Google Lighthouse CLI for auditing performance, accessibility, SEO, and best practices — headless Chromium included so agents can score pages served inside the sandbox.
+agentInstructions:
+  content: |
+    ## Lighthouse
+
+    `lighthouse` v12.6.1 is on PATH. Chromium lives under
+    /opt/ms-playwright; CHROME_PATH points at a stable
+    /usr/local/bin/chromium symlink. Don't unset CHROME_PATH or
+    PLAYWRIGHT_BROWSERS_PATH, or chrome-launcher will look for a
+    host Chrome that is not in this sandbox.
+
+    The `lighthouse` wrapper always passes
+    `--no-enable-error-reporting` (Sentry is not on the allowlist)
+    and, unless you already passed `--chrome-flags`, appends
+    `--no-sandbox --disable-dev-shm-usage --disable-gpu`. Headless
+    is Lighthouse's default; the sandbox has no display, so headed
+    Chrome will not work.
+
+    - Audit a local server: `lighthouse http://localhost:3000 --output html --output-path ./lh-report.html --quiet`
+    - JSON for an agent to read: `lighthouse http://localhost:3000 --output json --output-path ./lh-report.json --quiet`
+    - Desktop form factor: `lighthouse http://localhost:3000 --preset=desktop --output json --output-path ./lh-report.json --quiet`
+    - Confirm the toolchain: `lighthouse --version` and `chromium --version`
+
+    Only Chromium is installed. External sites fail with a proxy
+    error unless their hosts are in the sandbox network policy;
+    localhost inside the sandbox always works. Do not enable
+    Lighthouse error reporting — that phones home to Sentry and is
+    not on the allowlist.
+permissions:
+  network:
+    allow:
+      # npm package (install time): lighthouse and its dependency tree
+      # (chrome-launcher, puppeteer-core, axe-core, …). puppeteer-core
+      # does not download a browser; Chromium comes from the second hook.
+      - registry.npmjs.org:443
+      # Chromium via `npx playwright install --with-deps chromium` — the
+      # same channel the playwright kit uses. cdn.playwright.dev is the
+      # primary CDN; prss.microsoft.com is the documented fallback.
+      - cdn.playwright.dev:443
+      - playwright.download.prss.microsoft.com:443
+      # On amd64, Playwright's Chromium is a Chrome-for-Testing build:
+      # cdn.playwright.dev 302s to this bucket. arm64 builds come from
+      # prss.microsoft.com instead.
+      - storage.googleapis.com:443
+      # `--with-deps` apt-installs Chromium's system libraries.
+      # `apt-get update` refreshes every configured source, so all
+      # template sources must be reachable: Ubuntu hosts amd64 on
+      # archive/security and arm64 on ports.ubuntu.com, and the
+      # *-docker templates pre-add Docker's apt repo.
+      - archive.ubuntu.com:80
+      - security.ubuntu.com:80
+      - ports.ubuntu.com:80
+      - download.docker.com:443
+environment:
+  variables:
+    # chrome-launcher reads CHROME_PATH (LIGHTHOUSE_CHROMIUM_PATH is
+    # deprecated). The install hook points this symlink at Playwright's
+    # chrome binary so the path stays stable across Chromium builds.
+    CHROME_PATH: /usr/local/bin/chromium
+    # Same system path as the playwright kit, so composing both kits
+    # shares one browser tree instead of downloading Chromium twice.
+    PLAYWRIGHT_BROWSERS_PATH: /opt/ms-playwright
+    # Lets `require('lighthouse')` / `import('lighthouse')` resolve
+    # from the global npm install in a workspace with no package.json.
+    # Projects with their own node_modules are unaffected.
+    NODE_PATH: /usr/local/share/npm-global/lib/node_modules
+setup:
+  install:
+    # Lighthouse 13.x requires Node >= 22.19; standard agent templates
+    # only guarantee Node >= 18. 12.6.1 is the last 12.x line and
+    # accepts Node >= 18.20. npm verifies tarballs against registry
+    # sha512 integrity, so pinning the version pins the content.
+    # To bump: change LIGHTHOUSE_VERSION here and in agentInstructions
+    # / README. Do not jump to 13.x until templates ship Node 22.19.
+    - command: |
+        set -euo pipefail
+        command -v npm >/dev/null || { echo "npm not found: this mixin needs a base image with Node.js >= 18 (all standard agent templates ship it)" >&2; exit 1; }
+        if [ -n "${HTTP_PROXY:-}" ]; then
+          npm config set proxy "$HTTP_PROXY"
+          npm config set https-proxy "$HTTP_PROXY"
+        fi
+        LIGHTHOUSE_VERSION=12.6.1
+        npm install -g "lighthouse@${LIGHTHOUSE_VERSION}"
+        LH_JS="$(npm prefix -g)/lib/node_modules/lighthouse/cli/index.js"
+        test -f "$LH_JS" || { echo "lighthouse CLI entry not found at $LH_JS" >&2; exit 1; }
+        # printf (not a YAML-indented heredoc) so the shebang stays in column 0.
+        {
+          printf '%s\n' '#!/bin/sh' 'set -eu' 'has_flags=0'
+          printf '%s\n' 'for arg in "$@"; do'
+          printf '%s\n' '  case "$arg" in' '    --chrome-flags|--chrome-flags=*) has_flags=1 ;;' '  esac'
+          printf '%s\n' 'done'
+          printf '%s\n' 'if [ "$has_flags" -eq 0 ]; then'
+          printf '%s\n' '  set -- "$@" --chrome-flags="--no-sandbox --disable-dev-shm-usage --disable-gpu"'
+          printf '%s\n' 'fi'
+          printf '%s\n' "exec node \"${LH_JS}\" --no-enable-error-reporting \"\$@\""
+        } > /usr/local/bin/lighthouse
+        chmod 0755 /usr/local/bin/lighthouse
+        NPM_LH="$(npm prefix -g)/bin/lighthouse"
+        if [ -e "$NPM_LH" ] && [ "$NPM_LH" != /usr/local/bin/lighthouse ]; then
+          ln -sfn /usr/local/bin/lighthouse "$NPM_LH"
+        fi
+        lighthouse --version
+      user: "0"
+      description: Install lighthouse v12.6.1 from registry.npmjs.org, version pinned, with a container-safe CLI wrapper
+    - command: |
+        set -euo pipefail
+        export PLAYWRIGHT_BROWSERS_PATH="${PLAYWRIGHT_BROWSERS_PATH:-/opt/ms-playwright}"
+        mkdir -p "$PLAYWRIGHT_BROWSERS_PATH"
+        find_chrome() {
+          find "$PLAYWRIGHT_BROWSERS_PATH" -type f -name chrome ! -path '*headless*' 2>/dev/null | head -1
+        }
+        CHROME_BIN="$(find_chrome || true)"
+        if [ -z "$CHROME_BIN" ]; then
+          # Reuse the playwright kit's browser channel so composing both
+          # kits shares one Chromium tree. Ubuntu apt chromium is often a
+          # snap stub that does not run in the sandbox.
+          npx -y playwright@1.61.1 install --with-deps chromium
+          rm -rf /var/lib/apt/lists/*
+          CHROME_BIN="$(find_chrome || true)"
+        fi
+        if [ -z "$CHROME_BIN" ] || [ ! -x "$CHROME_BIN" ]; then
+          echo "failed to locate Chromium chrome binary under $PLAYWRIGHT_BROWSERS_PATH" >&2
+          exit 1
+        fi
+        ln -sfn "$CHROME_BIN" /usr/local/bin/chromium
+        chmod -R a+rX "$PLAYWRIGHT_BROWSERS_PATH"
+        chromium --version
+      user: "0"
+      description: Install Playwright Chromium into /opt/ms-playwright and symlink /usr/local/bin/chromium


### PR DESCRIPTION
## Summary
- Add a `lighthouse` mixin that installs Google Lighthouse CLI v12.6.1 (pinned; last 12.x that runs on Node ≥ 18.20, which standard agent templates guarantee) and a container-safe wrapper.
- Install Chromium via the same Playwright browser channel as the `playwright` kit (`/opt/ms-playwright` + `CHROME_PATH=/usr/local/bin/chromium`) so Ubuntu's snap Chromium stub is avoided and composing both kits shares one browser tree.
- Document usage (OCI / git / local), the deny-all allowlist, and why error reporting is disabled.

## Spec choices worth flagging for review
- **Lighthouse 12.6.1, not 13.x.** 13.x requires Node ≥ 22.19; templates only guarantee Node ≥ 18. Easy to bump once templates catch up.
- **Chromium via `npx playwright@1.61.1 install --with-deps chromium`**, not apt. Same hosts and path as `playwright/`. The second hook skips the download if Chromium is already present.
- **Wrapper** at `/usr/local/bin/lighthouse` always passes `--no-enable-error-reporting` (Sentry is not allowlisted) and default Chrome flags (`--no-sandbox --disable-dev-shm-usage --disable-gpu`) unless the caller set `--chrome-flags`.
- Allowlist matches the playwright kit's browser/apt hosts plus `registry.npmjs.org`. Runtime audits of external sites are intentionally *not* allowlisted — localhost works; anything else needs a per-sandbox rule.

## Origin
New frontend-tool mixin, patterned on `playwright/` (npm pin + Chromium) and `vale/` (one-concern CLI).

## Test plan
CI runs `kit validate` and the TCK on every PR.

- [ ] `sbx kit validate ./lighthouse/` passes (needs sbx that understands schemaVersion 2)
- [ ] `./scripts/test-kit.sh lighthouse` passes (the TCK)
- [ ] `./scripts/test-kit-e2e.sh lighthouse` passes under deny-all on a scoped daemon
- [ ] Manual smoke: `sbx run --kit ./lighthouse/ claude` then `lighthouse --version` and `chromium --version`


Made with [Cursor](https://cursor.com)