### PR TITLE
Add stylelint kit

### DIFF
--- a/stylelint/README.md
+++ b/stylelint/README.md
@@ -1,0 +1,72 @@
+# stylelint
+
+A mixin kit that installs [Stylelint](https://stylelint.io/) **v16.26.1**
+and [stylelint-config-standard](https://github.com/stylelint/stylelint-config-standard)
+**v39.0.0** from npm so an agent can lint CSS in the workspace.
+
+## Usage
+
+```console
+sbx run claude --kit "docker.io/sbx/stylelint-kit:latest" .
+```
+
+Or straight from this repository over git:
+
+```console
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=stylelint" claude
+```
+
+Or with a local clone of this repo:
+
+```console
+sbx run claude --kit ./stylelint/ .
+```
+
+Prerequisites:
+
+- A base image with Node.js ≥ 18.12 and npm — all standard agent
+  templates ship Node ≥ 18. The install fails loudly if npm is missing.
+
+Inside the sandbox:
+
+```console
+stylelint --version
+stylelint "**/*.css"
+stylelint "**/*.css" --fix
+```
+
+## How it works
+
+### Why a wrapper and a fallback config
+
+Stylelint refuses to run without a configuration file. Projects that
+already ship `stylelint.config.*` or `.stylelintrc*` are left alone.
+When none is present, the wrapper at `/usr/local/bin/stylelint` passes
+`--config /usr/local/share/stylelint/config.mjs`, which extends
+`stylelint-config-standard`. Passing `--config` yourself always wins.
+
+### Why Stylelint 16.26.1, not 17.x
+
+Stylelint 17.x requires Node ≥ 20.19. Standard agent templates only
+guarantee Node ≥ 18. 16.26.1 is the last 16.x release and accepts Node ≥
+18.12; `stylelint-config-standard@39.0.0` is the last config that peers
+`stylelint@^16`. npm verifies tarballs against registry `sha512`
+integrity values, so pinning the versions pins the content. To bump:
+change both versions in `spec.yaml` and the references in
+`agentInstructions` and this README. Do not jump to 17.x until the
+templates ship Node 20.19.
+
+### Why these domains
+
+`permissions.network.allow` is the kit's complete outbound contract — CI
+runs e2e under a `deny-all` policy.
+
+| Domain | Why |
+| --- | --- |
+| `registry.npmjs.org` | npm tarballs for `stylelint` + `stylelint-config-standard` (install time) |
+
+No browser, no apt. Runtime linting is local to the workspace.
+
+## Cleanup
+
+The global npm packages disappear with the sandbox (`sbx rm <name>`).

--- a/stylelint/spec.yaml
+++ b/stylelint/spec.yaml
@@ -1,0 +1,77 @@
+schemaVersion: "2"
+kind: mixin
+name: stylelint
+displayName: Stylelint
+description: Stylelint CSS linter with stylelint-config-standard — agents can lint CSS, SCSS-adjacent, and CSS-in-JS files in the workspace.
+agentInstructions:
+  content: |
+    ## Stylelint
+
+    `stylelint` v16.26.1 is on PATH, with stylelint-config-standard
+    39.0.0 as the fallback config. If the workspace already has a
+    Stylelint config (stylelint.config.* or .stylelintrc*), that
+    file wins. Otherwise the wrapper passes
+    --config /usr/local/share/stylelint/config.mjs.
+
+    - Lint CSS: `stylelint "**/*.css"`
+    - Autofix: `stylelint "**/*.css" --fix`
+    - Confirm: `stylelint --version`
+
+    Stylelint 17.x needs Node >= 20.19; standard agent templates
+    only guarantee Node >= 18. This kit stays on the last 16.x line
+    (Node >= 18.12). Do not pass a Stylelint 17-only config.
+permissions:
+  network:
+    allow:
+      # npm packages (install time): stylelint + stylelint-config-standard
+      # and their dependency trees.
+      - registry.npmjs.org:443
+environment:
+  variables:
+    NODE_PATH: /usr/local/share/npm-global/lib/node_modules
+setup:
+  install:
+    # Stylelint 17.x requires Node >= 20.19. 16.26.1 is the last 16.x
+    # and accepts Node >= 18.12. Pair with stylelint-config-standard
+    # 39.0.0 (peer stylelint ^16.23). npm verifies tarballs against
+    # registry sha512 integrity. To bump: change both versions here
+    # and in agentInstructions / README. Do not jump to 17.x until
+    # templates ship Node 20.19.
+    - command: |
+        set -euo pipefail
+        command -v npm >/dev/null || { echo "npm not found: this mixin needs a base image with Node.js >= 18 (all standard agent templates ship it)" >&2; exit 1; }
+        if [ -n "${HTTP_PROXY:-}" ]; then
+          npm config set proxy "$HTTP_PROXY"
+          npm config set https-proxy "$HTTP_PROXY"
+        fi
+        STYLELINT_VERSION=16.26.1
+        CONFIG_VERSION=39.0.0
+        npm install -g "stylelint@${STYLELINT_VERSION}" "stylelint-config-standard@${CONFIG_VERSION}"
+        PREFIX="$(npm prefix -g)"
+        SL_JS="${PREFIX}/lib/node_modules/stylelint/bin/stylelint.mjs"
+        test -f "$SL_JS" || { echo "stylelint CLI entry not found at $SL_JS" >&2; exit 1; }
+        mkdir -p /usr/local/share/stylelint
+        printf '%s\n' 'export default { extends: ["stylelint-config-standard"] };' > /usr/local/share/stylelint/config.mjs
+        {
+          printf '%s\n' '#!/bin/sh' 'set -eu' 'has_config=0'
+          printf '%s\n' 'for arg in "$@"; do'
+          printf '%s\n' '  case "$arg" in' '    --config|--config=*) has_config=1 ;;' '  esac'
+          printf '%s\n' 'done'
+          printf '%s\n' 'if [ "$has_config" -eq 0 ]; then'
+          printf '%s\n' '  for f in stylelint.config.js stylelint.config.mjs stylelint.config.cjs stylelint.config.ts .stylelintrc .stylelintrc.json .stylelintrc.yaml .stylelintrc.yml .stylelintrc.js; do'
+          printf '%s\n' '    [ -e "$f" ] && has_config=1 && break'
+          printf '%s\n' '  done'
+          printf '%s\n' 'fi'
+          printf '%s\n' 'if [ "$has_config" -eq 0 ]; then'
+          printf '%s\n' '  set -- --config /usr/local/share/stylelint/config.mjs "$@"'
+          printf '%s\n' 'fi'
+          printf '%s\n' "exec node \"${SL_JS}\" \"\$@\""
+        } > /usr/local/bin/stylelint
+        chmod 0755 /usr/local/bin/stylelint
+        NPM_SL="${PREFIX}/bin/stylelint"
+        if [ -e "$NPM_SL" ] && [ "$NPM_SL" != /usr/local/bin/stylelint ]; then
+          ln -sfn /usr/local/bin/stylelint "$NPM_SL"
+        fi
+        stylelint --version
+      user: "0"
+      description: Install stylelint v16.26.1 + stylelint-config-standard v39.0.0, version pinned, with a default-config wrapper


### PR DESCRIPTION
## Summary
- Add a `stylelint` mixin that installs Stylelint v16.26.1 and stylelint-config-standard v39.0.0 from npm (version-pinned).
- Wrapper uses the project's Stylelint config when present; otherwise `--config /usr/local/share/stylelint/config.mjs` (extends `stylelint-config-standard`).
- Install-time allowlist is only `registry.npmjs.org` — no browser, no apt.

## Spec choices worth flagging for review
- **Stylelint 16.26.1, not 17.x.** 17.x requires Node ≥ 20.19; templates only guarantee Node ≥ 18. 16.26.1 is the last 16.x (Node ≥ 18.12); config-standard 39.0.0 is the last config that peers `stylelint@^16`.
- Fallback config only applies when the workspace has no `stylelint.config.*` / `.stylelintrc*` and the caller did not pass `--config`.

## Origin
New frontend-tool mixin, patterned on `vale/` (one-concern CLI) and `lighthouse/` (npm pin).

## Test plan
- [ ] `./scripts/test-kit.sh stylelint` passes (the TCK)
- [ ] `./scripts/test-kit-e2e.sh stylelint` passes under deny-all
- [ ] Manual smoke: `sbx run --kit ./stylelint/ claude` then `stylelint --version` and `stylelint "**/*.css"`


Made with [Cursor](https://cursor.com)