### PR TITLE
Add bun kit

### DIFF
--- a/bun/README.md
+++ b/bun/README.md
@@ -1,0 +1,70 @@
+# bun
+
+A mixin kit that installs [Bun](https://bun.sh/) **v1.4.0** from a
+pinned, SHA256-verified GitHub release so agents can use `bun` as a
+runtime, package manager, and test runner inside the sandbox.
+
+## Usage
+
+```console
+sbx run claude --kit "docker.io/sbx/bun-kit:latest" .
+```
+
+Or straight from this repository over git:
+
+```console
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=bun" claude
+```
+
+Or with a local clone of this repo:
+
+```console
+sbx run claude --kit ./bun/ .
+```
+
+Inside the sandbox:
+
+```console
+bun --version
+bun run ./index.ts
+bun test
+```
+
+`bun install` needs extra egress (npm, often GitHub). Add it per sandbox:
+
+```console
+sbx policy allow network --sandbox <name> "registry.npmjs.org,github.com,objects.githubusercontent.com"
+```
+
+## How it works
+
+### Why a pinned GitHub zip, not `curl | bash`
+
+The upstream installer (`curl -fsSL https://bun.sh/install | bash`) is
+unpinned and unsigned. This kit downloads
+`bun-linux-x64.zip` / `bun-linux-aarch64.zip` from
+`github.com/oven-sh/bun` at **v1.4.0**, checks the SHA256 from that
+release's `SHASUMS256.txt`, and extracts the `bun` binary with
+`python3` (zipfile) so we do not need `apt-get install unzip` or the
+Ubuntu/Docker apt hosts. To bump: change `BUN_VERSION` and both SHA256
+values in `spec.yaml`.
+
+### Why these domains
+
+`permissions.network.allow` is the kit's complete outbound contract — CI
+runs e2e under a `deny-all` policy.
+
+| Domain | Why |
+| --- | --- |
+| `github.com` | Release page entry point (302-redirects) |
+| `objects.githubusercontent.com` | Typical redirect target for this repo's assets |
+| `release-assets.githubusercontent.com` | Kept alongside it; redirect host is not guaranteed |
+
+Runtime package installs are **not** on the default allowlist. Keep the
+kit's footprint to the one-shot binary fetch; opt in to registries
+deliberately.
+
+## Cleanup
+
+`bun` under `/usr/local/bin` disappears with the sandbox
+(`sbx rm <name>`).

--- a/bun/spec.yaml
+++ b/bun/spec.yaml
@@ -1,0 +1,74 @@
+schemaVersion: "2"
+kind: mixin
+name: bun
+displayName: Bun
+description: Installs the Bun JavaScript runtime and package manager from a pinned GitHub release.
+agentInstructions:
+  content: |
+    ## Bun
+
+    The `bun` CLI v1.4.0 is on PATH. Use it as a runtime (`bun run`),
+    a package manager (`bun install`), and a test runner (`bun test`).
+    Run `bun --version` to confirm.
+
+    `bun install` reaches the npm registry and often GitHub; those
+    hosts are not in this kit's allowlist (install time only covers
+    the release tarball). Add them on the sandbox if the project
+    needs to fetch packages:
+
+        sbx policy allow network --sandbox <name> "registry.npmjs.org,github.com,objects.githubusercontent.com"
+permissions:
+  network:
+    allow:
+      # Release zip download (install time, one-shot).
+      # github.com 302-redirects to objects.githubusercontent.com for
+      # binary downloads; release-assets.githubusercontent.com kept
+      # alongside it since that isn't guaranteed for every asset.
+      - github.com
+      - objects.githubusercontent.com
+      - release-assets.githubusercontent.com
+setup:
+  install:
+    # Install Bun from a pinned, SHA256-verified GitHub release.
+    # Do NOT use `curl | bash` from bun.sh — that pattern is unsigned
+    # and unpinned. Do NOT query api.github.com for releases/latest
+    # (CI IPs hit the 60 req/hr limit). To bump: change BUN_VERSION
+    # plus the per-arch SHA256 below (from the release SHASUMS256.txt).
+    # Archives are zip files; python3's zipfile is used so we do not
+    # need an apt unzip and the extra Ubuntu/Docker apt hosts.
+    - command: |
+        set -euo pipefail
+        BUN_VERSION=1.4.0
+        ARCH=$(dpkg --print-architecture)
+        case "$ARCH" in
+          amd64)
+            ZIP="bun-linux-x64.zip"
+            SHA256="2d03fb5fb83ac8b567aca0a281b2ce1a1a19d488f56c2968d88c3f25e92fe452"
+            ;;
+          arm64)
+            ZIP="bun-linux-aarch64.zip"
+            SHA256="4b1a332ee861983eb93bcfe6f770fff94e3e31b2c388bdaea3c8ed35e58eed0e"
+            ;;
+          *)
+            echo "unsupported sandbox arch: $ARCH (expected amd64 or arm64)" >&2
+            exit 1
+            ;;
+        esac
+        curl --proto '=https' --tlsv1.2 -fsSL \
+          -o /tmp/bun.zip \
+          "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/${ZIP}"
+        echo "${SHA256}  /tmp/bun.zip" | sha256sum -c -
+        python3 -c "
+        import pathlib, stat, zipfile, sys
+        z = zipfile.ZipFile('/tmp/bun.zip')
+        name = next((n for n in z.namelist() if n.rstrip('/').endswith('/bun') or n == 'bun'), None)
+        if not name:
+            sys.exit('bun binary not found in zip')
+        dest = pathlib.Path('/usr/local/bin/bun')
+        dest.write_bytes(z.read(name))
+        dest.chmod(dest.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        "
+        rm /tmp/bun.zip
+        bun --version
+      user: "0"
+      description: Install Bun CLI v1.4.0, version+digest pinned


### PR DESCRIPTION
## Summary
- Add a `bun` mixin that installs Bun v1.4.0 from a SHA256-verified GitHub release zip (`bun-linux-x64` / `bun-linux-aarch64`).
- Extract the binary with Python's `zipfile` so the kit does not need `apt-get install unzip` or Ubuntu/Docker apt hosts.
- Keep the allowlist to the one-shot release download; `bun install` registries are opt-in per sandbox.

## Spec choices worth flagging for review
- **No `curl | bash` from bun.sh.** Version + per-arch SHA256 are pinned from the release `SHASUMS256.txt`.
- Runtime package installs (`registry.npmjs.org`, etc.) are intentionally *not* allowlisted — same posture as keeping Vale/Task install-only. Documented in the README.
- Python unzip instead of apt `unzip` keeps the network contract to three GitHub asset hosts.

## Origin
New runtime mixin, patterned on `vale/` / `task/` (pinned GitHub release).

## Test plan
- [ ] `./scripts/test-kit.sh bun` passes (the TCK)
- [ ] `./scripts/test-kit-e2e.sh bun` passes under deny-all
- [ ] Manual smoke: `sbx run --kit ./bun/ claude` then `bun --version`


Made with [Cursor](https://cursor.com)