### PR TITLE
Start code-server by automatically trusting the workspace folder

### DIFF
--- a/code-server/files/home/.local/share/code-server/User/settings.json
+++ b/code-server/files/home/.local/share/code-server/User/settings.json
@@ -3,5 +3,6 @@
   "chat.commandCenter.enabled": false,
   "workbench.tips.enabled": false,
   "telemetry.telemetryLevel": "off",
-  "claudeCode.preferredLocation": "sidebar"
+  "claudeCode.preferredLocation": "sidebar",
+  "security.workspace.trust.enabled": false
 }


### PR DESCRIPTION
## Summary

When starting code-server, it opens the workspace as expected. But, it's not trusted. Since we're running in a sandbox, it makes sense to trust it by default.

This PR configures the code server to trust the workspace.

## Test plan

CI runs `kit validate` and the TCK on every PR. CI does **not** run e2e on
fork PRs (Docker Hub secrets aren't exposed there), so the e2e step below is
required from your side before requesting review.

- [x] `sbx kit validate ./<kit>/` passes
- [x] `./scripts/test-kit.sh <kit>` passes (the TCK)
- [x] `./scripts/test-kit-e2e.sh <kit>` passes. The script applies the same
      `deny-all` baseline CI uses and scopes everything to its own daemon
      (`--app-name sbx-kits-contrib-tck`), so my main sbx state is untouched.
      Every entry I added to `network.allowedDomains` came from
      `sbx --app-name sbx-kits-contrib-tck policy log <tck-e2e-…>`, not a guess.
- [x] Manual smoke: `sbx run --kit ./<kit>/ <agent>` and verified the kit's
      binary / files / env are inside the running container.

One-time setup if you haven't run e2e on this machine before:
`sbx --app-name sbx-kits-contrib-tck login`.

See [CONTRIBUTING.md → Verifying locally](../CONTRIBUTING.md#verifying-locally)
and [README → Declare every domain your kit needs](../README.md#declare-every-domain-your-kit-needs)
for the cross-arch domain gotchas (`archive.ubuntu.com`,
`security.ubuntu.com`, `ports.ubuntu.com`) and the package-manager refresh trap.
