### PR TITLE
fix(git-ssh-sign): scope signing to repos with a remote, and diagnose a dead agent

### DIFF
--- a/git-ssh-sign/README.md
+++ b/git-ssh-sign/README.md
@@ -68,7 +68,7 @@ Inside the sandbox, confirm which state you are in:
 ```console
 echo "$SSH_AUTH_SOCK"      # always set in a sandbox — proves nothing on its own
 test -S "$SSH_AUTH_SOCK"   # the real check: is the relay socket present?
-ssh-add -l                 # 0 = keys loaded; 1 = reachable but no usable key; 2 = no agent
+ssh-add -l                 # 0 = keys loaded; 1 = connected but no usable key; 2 = no connection
 ```
 
 `SSH_AUTH_SOCK` is exported into every sandbox whether or not agent
@@ -84,23 +84,31 @@ Recovery happens **on the host**:
    sbx settings set ssh.agentForwardingEnabled true
    ```
 
-   Check this before anything else. While it is `false` the daemon never
-   records a socket for the sandbox, so the relay closes every connection
-   without writing a byte — which surfaces in the sandbox as a broken
-   agent rather than a disabled feature, and survives any number of key
-   reloads and sandbox restarts. It defaults to `true`, so `false` means
-   something turned it off, e.g. declining agent forwarding in `sbx setup`.
+   Check this before anything else. While it is `false` the forwarded
+   agent is never wired up, so `ssh-add` in the sandbox reports a broken
+   agent (exit 1 or 2, depending on how far the connection gets) rather
+   than a disabled feature, and it survives any number of key reloads and
+   sandbox restarts. It defaults to `true`, so `false` means something
+   turned it off, e.g. declining agent forwarding in `sbx setup`.
 2. Check the host agent holds the key: `ssh-add -l`, then
    `ssh-add ~/.ssh/id_ed25519` if it does not.
-3. From that same shell, restart the sandbox: `sbx start <sandbox-name>`.
-   The daemon adopts the requesting client's `SSH_AUTH_SOCK`, and the
-   sandbox restart relaunches the in-container relay. `<sandbox-name>` is
-   `$SANDBOX_NAME` inside the sandbox.
-4. If the socket still does not appear, restart the daemon:
-   `sbx daemon restart`. The gateway listener is created when the daemon
-   builds the sandbox's runtime, and changes to `ssh.agentForwardingEnabled`
-   or `ssh.agentSocketPath` only reach existing forwarders after a daemon
-   restart.
+3. If step 1 changed the setting, restart the daemon:
+   `sbx daemon restart`. Changes to `ssh.agentForwardingEnabled` and
+   `ssh.agentSocketPath` only reach sandboxes that already exist once the
+   daemon has restarted.
+4. From that same shell — the daemon adopts the requesting client's
+   `SSH_AUTH_SOCK` — restart the sandbox's container so the in-container
+   relay is relaunched:
+
+   ```console
+   sbx stop <sandbox-name>
+   sbx run --name <sandbox-name>
+   ```
+
+   Stop-then-run is the supported restart cycle; there is no `sbx start`.
+   Substitute the sandbox's own name — `hostname` prints it *inside* the
+   sandbox, but `$SANDBOX_NAME` is not set in a host shell, so type the
+   literal name there.
 
 To get one commit through unsigned while you sort that out:
 

--- a/git-ssh-sign/README.md
+++ b/git-ssh-sign/README.md
@@ -153,8 +153,10 @@ sandbox depend on a live SSH agent — including throwaway repositories that
 test suites create with `git init` and that have nothing to do with your
 commits. When the forwarded agent goes away, those all start failing too,
 with an error that points at `user.signingKey`. Scoping by "has a remote"
-keeps automatic signing on everywhere a commit can actually leave the
-machine, and off in local scratch repositories.
+keeps automatic signing on in the repositories you push from, and off in
+local scratch repositories. It is a proxy, not a guarantee: commits made
+in a fresh `git init` *before* the first `git remote add` stay unsigned
+and are pushed that way.
 
 Two things this deliberately does *not* do:
 

--- a/git-ssh-sign/README.md
+++ b/git-ssh-sign/README.md
@@ -166,12 +166,21 @@ fails closed (signs too much) rather than open (signs nothing).
 
 **Key material — resolved at signing time**
 
-`gpg.ssh.defaultKeyCommand` points to
-`/home/agent/.config/git/ssh-signing-key-command`. When Git needs a
-signing key, it runs that command. The command reads the first public key
-from `ssh-add -L`, writes `/home/agent/.config/git/allowed_signers` for
-signature verification, and prints the key in Git's inline `key::...`
-format.
+`gpg.ssh.defaultKeyCommand` runs
+`/home/agent/.config/git/ssh-signing-key-command`, a static script shipped
+under the kit's
+[`files/home/`](files/home/.config/git/ssh-signing-key-command) tree. It is
+configured as `/bin/sh <path>`, not as a bare path: files delivered from a
+kit's OCI artifact land mode `0644` (per-file executable bits are not
+representable in a v2 layer, see [`spec/OCI-v2.md`](../spec/OCI-v2.md)) and
+Git execs the key command itself, so a bare path would fail with `cannot
+exec: Permission denied` before any of the script's own diagnostics could
+run.
+
+When Git needs a signing key, it runs that command. The command reads the
+first public key from `ssh-add -L`, writes
+`/home/agent/.config/git/allowed_signers` for signature verification, and
+prints the key in Git's inline `key::...` format.
 
 This avoids writing key material at install or startup time, when the
 forwarded SSH agent may not be connected yet. It also avoids relying on

--- a/git-ssh-sign/README.md
+++ b/git-ssh-sign/README.md
@@ -37,8 +37,9 @@ ssh-ed25519 AAAA... you@example.com
 ```
 
 If it returns nothing, the key isn't loaded on the host yet — re-run
-`ssh-add` there and try again. Git signing will fail with a clear error
-if no key is available.
+`ssh-add` there and try again. Git signing fails loudly, with a message
+naming the exact state and its recovery; see
+[When signing fails](#when-signing-fails).
 
 ## Verifying
 
@@ -48,7 +49,66 @@ commit abc1234...
 Good "git" signature for you@example.com with ED25519 key SHA256:...
 ```
 
-If signing fails, see Docker's
+## When signing fails
+
+Git surfaces a failed signature as two lines:
+
+```
+warning: gpg.ssh.defaultKeyCommand failed: [git-ssh-sign] ...
+error: user.signingKey needs to be set for ssh signing
+```
+
+The second line is git's, not this kit's, and it is misleading — the kit
+leaves `user.signingKey` unset on purpose. Git prints the key command's
+stderr verbatim in the `warning:` line above it, so the `[git-ssh-sign]`
+lines are the ones that name the real state and its fix.
+
+Inside the sandbox, confirm which state you are in:
+
+```console
+echo "$SSH_AUTH_SOCK"      # always set in a sandbox — proves nothing on its own
+test -S "$SSH_AUTH_SOCK"   # the real check: is the relay socket present?
+ssh-add -l                 # 0 = keys loaded; 1 = reachable but no usable key; 2 = no agent
+```
+
+`SSH_AUTH_SOCK` is exported into every sandbox whether or not agent
+forwarding was actually wired, so a set variable and a missing socket are
+the common failure — the in-sandbox relay is not running.
+
+Recovery happens **on the host**:
+
+1. Check that forwarding is enabled at all:
+
+   ```console
+   sbx settings get ssh.agentForwardingEnabled   # must be true
+   sbx settings set ssh.agentForwardingEnabled true
+   ```
+
+   Check this before anything else. While it is `false` the daemon never
+   records a socket for the sandbox, so the relay closes every connection
+   without writing a byte — which surfaces in the sandbox as a broken
+   agent rather than a disabled feature, and survives any number of key
+   reloads and sandbox restarts. It defaults to `true`, so `false` means
+   something turned it off, e.g. declining agent forwarding in `sbx setup`.
+2. Check the host agent holds the key: `ssh-add -l`, then
+   `ssh-add ~/.ssh/id_ed25519` if it does not.
+3. From that same shell, restart the sandbox: `sbx start <sandbox-name>`.
+   The daemon adopts the requesting client's `SSH_AUTH_SOCK`, and the
+   sandbox restart relaunches the in-container relay. `<sandbox-name>` is
+   `$SANDBOX_NAME` inside the sandbox.
+4. If the socket still does not appear, restart the daemon:
+   `sbx daemon restart`. The gateway listener is created when the daemon
+   builds the sandbox's runtime, and changes to `ssh.agentForwardingEnabled`
+   or `ssh.agentSocketPath` only reach existing forwarders after a daemon
+   restart.
+
+To get one commit through unsigned while you sort that out:
+
+```console
+git -c commit.gpgsign=false commit -m "..."
+```
+
+See also Docker's
 [troubleshooting guide](https://docs.docker.com/ai/sandboxes/troubleshooting/#sandbox-commits-arent-signed).
 
 ## How it works
@@ -57,14 +117,52 @@ Git signing requires two things to be available when Git signs the
 commit: signing *config* (what format to use and how to resolve a key)
 and the actual *key material* from the forwarded SSH agent.
 
-**Signing config — written at install time to `/etc/gitconfig`**
+**Signing machinery — written at install time to `/etc/gitconfig`**
 
-The install command writes `gpg.format`, `commit.gpgSign`,
-`tag.gpgSign`, `gpg.ssh.defaultKeyCommand`, and
-`gpg.ssh.allowedSignersFile` to the system-level git config. This file
-is read by git at process startup and is never overwritten by the
-sandbox infrastructure, so the config is always present when
-`git commit` begins.
+The install command writes `gpg.format`, `gpg.ssh.defaultKeyCommand`, and
+`gpg.ssh.allowedSignersFile` to the system-level git config, and makes
+sure `user.signingKey` stays *unset*. This file is read by git at process
+startup and is never overwritten by the sandbox infrastructure, so the
+config is always present when `git commit` begins.
+
+`user.signingKey` has to stay empty: git consults
+`gpg.ssh.defaultKeyCommand` only when it is unset. Setting it to any
+value — even a placeholder meant to produce a nicer error — disables
+dynamic key resolution outright and breaks the working case.
+
+**Signing policy — scoped to repositories that have a remote**
+
+`commit.gpgSign` and `tag.gpgSign` are *not* in `/etc/gitconfig`. They live
+in `/etc/git/signing-enabled.inc`, pulled in conditionally:
+
+```ini
+[includeIf "hasconfig:remote.*.url:**"]
+	path = /etc/git/signing-enabled.inc
+```
+
+A machine-wide `commit.gpgSign = true` makes **every** `git commit` in the
+sandbox depend on a live SSH agent — including throwaway repositories that
+test suites create with `git init` and that have nothing to do with your
+commits. When the forwarded agent goes away, those all start failing too,
+with an error that points at `user.signingKey`. Scoping by "has a remote"
+keeps automatic signing on everywhere a commit can actually leave the
+machine, and off in local scratch repositories.
+
+Two things this deliberately does *not* do:
+
+- It does not scope by `gitdir:` to the workspace path. A sandbox can mount
+  more than one host directory, and repositories cloned inside the sandbox
+  would fall outside any single workspace prefix.
+- It does not make signing failures soft. Inside the scope, a missing agent
+  still fails the commit rather than quietly producing an unsigned one.
+
+`git commit -S` still signs in any repository, scope or no scope, because
+the machinery above is machine-wide.
+
+`includeIf "hasconfig:…"` needs git ≥ 2.36. The install command probes for
+it against a throwaway repository rather than parsing a version string; on
+an older git it falls back to machine-wide `commit.gpgSign` so the kit
+fails closed (signs too much) rather than open (signs nothing).
 
 **Key material — resolved at signing time**
 

--- a/git-ssh-sign/files/home/.config/git/ssh-signing-key-command
+++ b/git-ssh-sign/files/home/.config/git/ssh-signing-key-command
@@ -1,0 +1,71 @@
+#!/bin/sh
+# Resolve a signing key from the forwarded SSH agent.
+#
+# Git runs this only when user.signingKey is unset, and echoes whatever
+# this script writes to stderr verbatim as
+#     warning: gpg.ssh.defaultKeyCommand failed: <stderr>
+# immediately before its own, misleading
+#     error: user.signingKey needs to be set for ssh signing
+# Git's line cannot be suppressed, so the message below has to carry the
+# whole diagnosis and explicitly pre-empt it.
+
+fail() {
+    # A leading newline keeps the body off git's "warning: ...failed: "
+    # prefix line, which would otherwise swallow the first sentence.
+    {
+        printf '\n'
+        printf '[git-ssh-sign] cannot sign: %s\n' "$1"
+        printf '[git-ssh-sign] %s\n' "$2"
+        printf '[git-ssh-sign] The "user.signingKey needs to be set" error below is a red herring:\n'
+        printf '[git-ssh-sign] this kit resolves the key from the forwarded SSH agent, and the agent is what is unavailable.\n'
+        printf '[git-ssh-sign] To make this one commit unsigned: git -c commit.gpgsign=false commit ...\n'
+    } >&2
+    exit 1
+}
+
+sock=${SSH_AUTH_SOCK:-}
+
+if [ -z "$sock" ]; then
+    fail "SSH_AUTH_SOCK is not set" \
+         "Sandboxes export it unconditionally, so something in this shell unset it."
+fi
+
+# SSH_AUTH_SOCK is baked into every sandbox whether or not forwarding
+# was wired, so its presence proves nothing. The socket's existence is
+# the real check, and it distinguishes "relay is down" from "agent is
+# reachable but has no key" -- two states with different recoveries.
+if [ ! -S "$sock" ]; then
+    fail "the forwarded agent socket $sock does not exist" \
+         "The in-sandbox relay is not running. On the HOST, from a shell where 'ssh-add -l' lists your key: 'sbx start \$SANDBOX_NAME'; if the socket still does not appear, 'sbx daemon restart'."
+fi
+
+out=$(ssh-add -L 2>&1)
+case $? in
+    0) ;;
+    2) fail "nothing answered on $sock (ssh-add: $out)" \
+            "The relay socket is stale. On the HOST: 'sbx start \$SANDBOX_NAME'." ;;
+    *) fail "the agent returned no usable key (ssh-add: $out)" \
+            "'no identities' means the HOST agent is empty: run 'ssh-add ~/.ssh/id_ed25519' there. 'communication with agent failed' means the relay reached the host but the host's agent is gone: restore it, then 'sbx daemon restart'." ;;
+esac
+
+key=$(printf '%s\n' "$out" | head -n 1)
+if [ -z "$key" ]; then
+    fail "ssh-add -L succeeded but printed nothing" \
+         "Unexpected state; please report it against the git-ssh-sign kit."
+fi
+
+config_dir=${GIT_SSH_SIGN_CONFIG_DIR:-/home/agent/.config/git}
+
+# Guarded explicitly rather than with "set -e": this script reads ssh-add's
+# exit status by hand, and errexit would abort at the "out=$(ssh-add -L)"
+# assignment before the diagnosis below ever runs. Without these guards a
+# failed write leaves a stale allowed_signers while the commit still signs,
+# so verification later fails with git's opaque "No principal matched".
+mkdir -p "$config_dir" || fail "cannot create $config_dir" \
+    "Check the ownership and permissions of that directory inside the sandbox."
+
+email=$(git config user.email 2>/dev/null || printf '%s' "agent@sandbox.local")
+printf '%s %s\n' "$email" "$key" > "$config_dir/allowed_signers" || \
+    fail "cannot write $config_dir/allowed_signers" \
+         "Signing would succeed but 'git log --show-signature' would report 'No principal matched'."
+printf 'key::%s\n' "$key"

--- a/git-ssh-sign/files/home/.config/git/ssh-signing-key-command
+++ b/git-ssh-sign/files/home/.config/git/ssh-signing-key-command
@@ -17,7 +17,7 @@ fail() {
         printf '[git-ssh-sign] cannot sign: %s\n' "$1"
         printf '[git-ssh-sign] %s\n' "$2"
         printf '[git-ssh-sign] The "user.signingKey needs to be set" error below is a red herring:\n'
-        printf '[git-ssh-sign] this kit resolves the key from the forwarded SSH agent, and the agent is what is unavailable.\n'
+        printf '[git-ssh-sign] this kit resolves the key from the forwarded SSH agent, so the two lines above are the ones that name what is actually wrong.\n'
         printf '[git-ssh-sign] To make this one commit unsigned: git -c commit.gpgsign=false commit ...\n'
     } >&2
     exit 1

--- a/git-ssh-sign/files/home/.config/git/ssh-signing-key-command
+++ b/git-ssh-sign/files/home/.config/git/ssh-signing-key-command
@@ -23,6 +23,17 @@ fail() {
     exit 1
 }
 
+# The recovery steps below run on the HOST, where $SANDBOX_NAME does not
+# exist -- it is a sandbox-only variable. Resolve the name here and print its
+# value, so the user can paste the command instead of substituting by hand.
+name=${SANDBOX_NAME:-$(hostname 2>/dev/null || true)}
+[ -n "$name" ] || name="<sandbox-name>"
+
+# Same recovery preamble for every "the agent is not answering" state: the
+# forwarding setting first (it is the one cause that survives every restart),
+# then the host agent's keys, then the container restart.
+recover="On the HOST: 1) 'sbx settings get ssh.agentForwardingEnabled' must print true -- if it does not, 'sbx settings set ssh.agentForwardingEnabled true' and then 'sbx daemon restart', because a changed setting only reaches sandboxes that already exist once the daemon has restarted; 2) 'ssh-add -l' must list your key, else 'ssh-add ~/.ssh/id_ed25519'; 3) from that same shell, restart this sandbox: 'sbx stop $name' then 'sbx run --name $name'."
+
 sock=${SSH_AUTH_SOCK:-}
 
 if [ -z "$sock" ]; then
@@ -30,22 +41,37 @@ if [ -z "$sock" ]; then
          "Sandboxes export it unconditionally, so something in this shell unset it."
 fi
 
-# SSH_AUTH_SOCK is baked into every sandbox whether or not forwarding
-# was wired, so its presence proves nothing. The socket's existence is
-# the real check, and it distinguishes "relay is down" from "agent is
-# reachable but has no key" -- two states with different recoveries.
+# SSH_AUTH_SOCK is baked into every sandbox whether or not forwarding was
+# wired, so its presence proves nothing. The socket's existence is the real
+# check, and it separates "no relay at all" from "something is listening but
+# not answering" -- states that read very differently in the error message.
 if [ ! -S "$sock" ]; then
     fail "the forwarded agent socket $sock does not exist" \
-         "The in-sandbox relay is not running. On the HOST, from a shell where 'ssh-add -l' lists your key: 'sbx start \$SANDBOX_NAME'; if the socket still does not appear, 'sbx daemon restart'."
+         "The in-sandbox relay is not running. $recover"
 fi
 
 out=$(ssh-add -L 2>&1)
-case $? in
+rc=$?
+
+# ssh-add exit 2 is "could not connect at all"; exit 1 is "connected, but
+# the exchange failed or the agent is empty". Forwarding being switched off
+# can land in either one depending on how far the connection gets, so only
+# the genuinely-empty agent gets a recovery of its own -- every other state
+# runs the same host-side checks, the forwarding setting first.
+case $rc in
     0) ;;
-    2) fail "nothing answered on $sock (ssh-add: $out)" \
-            "The relay socket is stale. On the HOST: 'sbx start \$SANDBOX_NAME'." ;;
-    *) fail "the agent returned no usable key (ssh-add: $out)" \
-            "'no identities' means the HOST agent is empty: run 'ssh-add ~/.ssh/id_ed25519' there. 'communication with agent failed' means the relay reached the host but the host's agent is gone: restore it, then 'sbx daemon restart'." ;;
+    1)
+        case "$out" in
+            *"no identities"*)
+                fail "the forwarded agent holds no keys (ssh-add: $out)" \
+                     "The HOST agent is empty: run 'ssh-add ~/.ssh/id_ed25519' there, then 'sbx stop $name' and 'sbx run --name $name' from that same shell." ;;
+            *)
+                fail "the agent did not answer usably (ssh-add: $out)" \
+                     "Something accepted the connection but the exchange failed. $recover" ;;
+        esac ;;
+    *)
+        fail "nothing is accepting connections on $sock (ssh-add: $out, exit $rc)" \
+             "The socket is there but no forwarder is answering on it. $recover" ;;
 esac
 
 key=$(printf '%s\n' "$out" | head -n 1)

--- a/git-ssh-sign/spec.yaml
+++ b/git-ssh-sign/spec.yaml
@@ -154,6 +154,19 @@ setup:
         #     error: user.signingKey needs to be set for ssh signing
         # Git's line cannot be suppressed, so the message below has to carry the
         # whole diagnosis and explicitly pre-empt it.
+        #
+        # Braced parameter expansion is banned throughout this file. Released
+        # engines validate initFiles content against a placeholder allowlist
+        # holding WORKDIR alone, and reject every other brace-delimited dollar
+        # form -- it cannot tell shell syntax from a kit-spec placeholder, so
+        # a plain default-value expansion fails the kit at "sbx create" time.
+        # Unbraced "$VAR" is the portable spelling; "set +u" below makes it
+        # behave exactly like the default-value forms it replaces, expanding an
+        # unset variable to the empty string instead of aborting, whatever
+        # options the caller's shell had set. Every variable read here is
+        # either assigned first or explicitly tested for emptiness, so nounset
+        # buys this script nothing.
+        set +u
 
         fail() {
             # A leading newline keeps the body off git's "warning: ...failed: "
@@ -169,7 +182,7 @@ setup:
             exit 1
         }
 
-        sock="${SSH_AUTH_SOCK:-}"
+        sock=$SSH_AUTH_SOCK
 
         if [ -z "$sock" ]; then
             fail "SSH_AUTH_SOCK is not set" \
@@ -200,7 +213,10 @@ setup:
                  "Unexpected state; please report it against the git-ssh-sign kit."
         fi
 
-        config_dir="${GIT_SSH_SIGN_CONFIG_DIR:-/home/agent/.config/git}"
+        config_dir=$GIT_SSH_SIGN_CONFIG_DIR
+        if [ -z "$config_dir" ]; then
+            config_dir=/home/agent/.config/git
+        fi
         mkdir -p "$config_dir"
 
         email=$(git config user.email 2>/dev/null || printf '%s' "agent@sandbox.local")

--- a/git-ssh-sign/spec.yaml
+++ b/git-ssh-sign/spec.yaml
@@ -80,7 +80,14 @@ setup:
         # asks for a signature, and keeping it here means `git commit -S` works
         # in any repository in the sandbox.
         git config --system gpg.format ssh
-        git config --system gpg.ssh.defaultKeyCommand /home/agent/.config/git/ssh-signing-key-command
+        # The key command is invoked through /bin/sh rather than executed
+        # directly. Files shipped under a kit's files/home/ tree land mode
+        # 0644 when the kit is installed from its OCI artifact -- per-file
+        # executable bits are not representable in a v2 layer (spec/OCI-v2.md)
+        # -- and git execs this value itself, so a bare path would die with
+        # "cannot exec: Permission denied" before a single one of the script's
+        # own diagnostics could run.
+        git config --system gpg.ssh.defaultKeyCommand '/bin/sh /home/agent/.config/git/ssh-signing-key-command'
         git config --system gpg.ssh.allowedSignersFile /home/agent/.config/git/allowed_signers
 
         # user.signingKey MUST stay unset: git only runs
@@ -141,86 +148,3 @@ setup:
         fi
       user: "0"
       description: Configure SSH commit signing, scoped to repositories with a remote
-  files:
-    - path: /home/agent/.config/git/ssh-signing-key-command
-      content: |
-        #!/bin/sh
-        # Resolve a signing key from the forwarded SSH agent.
-        #
-        # Git runs this only when user.signingKey is unset, and echoes whatever
-        # this script writes to stderr verbatim as
-        #     warning: gpg.ssh.defaultKeyCommand failed: <stderr>
-        # immediately before its own, misleading
-        #     error: user.signingKey needs to be set for ssh signing
-        # Git's line cannot be suppressed, so the message below has to carry the
-        # whole diagnosis and explicitly pre-empt it.
-        #
-        # Braced parameter expansion is banned throughout this file. Released
-        # engines validate initFiles content against a placeholder allowlist
-        # holding WORKDIR alone, and reject every other brace-delimited dollar
-        # form -- it cannot tell shell syntax from a kit-spec placeholder, so
-        # a plain default-value expansion fails the kit at "sbx create" time.
-        # Unbraced "$VAR" is the portable spelling; "set +u" below makes it
-        # behave exactly like the default-value forms it replaces, expanding an
-        # unset variable to the empty string instead of aborting, whatever
-        # options the caller's shell had set. Every variable read here is
-        # either assigned first or explicitly tested for emptiness, so nounset
-        # buys this script nothing.
-        set +u
-
-        fail() {
-            # A leading newline keeps the body off git's "warning: ...failed: "
-            # prefix line, which would otherwise swallow the first sentence.
-            {
-                printf '\n'
-                printf '[git-ssh-sign] cannot sign: %s\n' "$1"
-                printf '[git-ssh-sign] %s\n' "$2"
-                printf '[git-ssh-sign] The "user.signingKey needs to be set" error below is a red herring:\n'
-                printf '[git-ssh-sign] this kit resolves the key from the forwarded SSH agent, and the agent is what is unavailable.\n'
-                printf '[git-ssh-sign] To make this one commit unsigned: git -c commit.gpgsign=false commit ...\n'
-            } >&2
-            exit 1
-        }
-
-        sock=$SSH_AUTH_SOCK
-
-        if [ -z "$sock" ]; then
-            fail "SSH_AUTH_SOCK is not set" \
-                 "Sandboxes export it unconditionally, so something in this shell unset it."
-        fi
-
-        # SSH_AUTH_SOCK is baked into every sandbox whether or not forwarding
-        # was wired, so its presence proves nothing. The socket's existence is
-        # the real check, and it distinguishes "relay is down" from "agent is
-        # reachable but has no key" -- two states with different recoveries.
-        if [ ! -S "$sock" ]; then
-            fail "the forwarded agent socket $sock does not exist" \
-                 "The in-sandbox relay is not running. On the HOST, from a shell where 'ssh-add -l' lists your key: 'sbx start \$SANDBOX_NAME'; if the socket still does not appear, 'sbx daemon restart'."
-        fi
-
-        out=$(ssh-add -L 2>&1)
-        case $? in
-            0) ;;
-            2) fail "nothing answered on $sock (ssh-add: $out)" \
-                    "The relay socket is stale. On the HOST: 'sbx start \$SANDBOX_NAME'." ;;
-            *) fail "the agent returned no usable key (ssh-add: $out)" \
-                    "'no identities' means the HOST agent is empty: run 'ssh-add ~/.ssh/id_ed25519' there. 'communication with agent failed' means the relay reached the host but the host's agent is gone: restore it, then 'sbx daemon restart'." ;;
-        esac
-
-        key=$(printf '%s\n' "$out" | head -n 1)
-        if [ -z "$key" ]; then
-            fail "ssh-add -L succeeded but printed nothing" \
-                 "Unexpected state; please report it against the git-ssh-sign kit."
-        fi
-
-        config_dir=$GIT_SSH_SIGN_CONFIG_DIR
-        if [ -z "$config_dir" ]; then
-            config_dir=/home/agent/.config/git
-        fi
-        mkdir -p "$config_dir"
-
-        email=$(git config user.email 2>/dev/null || printf '%s' "agent@sandbox.local")
-        printf '%s %s\n' "$email" "$key" > "$config_dir/allowed_signers"
-        printf 'key::%s\n' "$key"
-      mode: "0755"
-      description: Resolve the forwarded SSH agent key for Git SSH signing

--- a/git-ssh-sign/spec.yaml
+++ b/git-ssh-sign/spec.yaml
@@ -7,44 +7,200 @@ agentInstructions:
   content: |
     ## Git commit signing
 
-    This sandbox is configured to sign git commits with your host's SSH key.
-    Commits and tags are signed automatically. Use `git log --show-signature`
-    to verify signatures on existing commits.
+    This sandbox signs git commits with your host's SSH key, forwarded over
+    the sandbox's SSH agent relay. Use `git log --show-signature` to verify
+    signatures on existing commits.
+
+    Automatic signing is scoped to repositories that **have at least one
+    remote**. A throwaway repository created by a test fixture
+    (`git init` with no remote) commits unsigned, so an unrelated test
+    suite is never blocked by signing. `git commit -S` still signs
+    anywhere.
+
+    ### When signing fails
+
+    The key is resolved at signing time from the forwarded agent, so a
+    signing failure almost always means the agent is unreachable, not that
+    a config value is missing. Git reports it as:
+
+        warning: gpg.ssh.defaultKeyCommand failed: [git-ssh-sign] ...
+        error: user.signingKey needs to be set for ssh signing
+
+    **Ignore the `user.signingKey` line** — this kit deliberately leaves
+    `user.signingKey` unset. Read the `[git-ssh-sign]` lines above it; they
+    name the actual state and the recovery.
+
+    Diagnose in this order:
+
+    ```console
+    echo "$SSH_AUTH_SOCK"      # always set inside a sandbox; proves nothing
+    test -S "$SSH_AUTH_SOCK"   # the real check — is the relay socket there?
+    ssh-add -l                 # 0 = keys; 1 = reachable, no usable key; 2 = no agent
+    ```
+
+    Recovery, all of it **on the host**, not in the sandbox:
+
+    1. Check that forwarding is switched on at all:
+
+       ```console
+       sbx settings get ssh.agentForwardingEnabled   # must be true
+       sbx settings set ssh.agentForwardingEnabled true
+       ```
+
+       Do this first. When it is `false` the daemon never records a socket
+       for the sandbox and the relay closes every connection without
+       writing a byte, so `ssh-add` in the sandbox reports a broken agent
+       rather than a disabled feature — and no amount of reloading keys or
+       restarting the sandbox changes it. The setting defaults to `true`,
+       so a `false` means it was turned off explicitly, e.g. by declining
+       agent forwarding during `sbx setup`.
+
+    2. Make sure the host agent actually holds the key:
+       `ssh-add -l`, and `ssh-add ~/.ssh/id_ed25519` if it does not.
+    3. From that same shell (the daemon adopts the client's
+       `SSH_AUTH_SOCK`), restart the sandbox: `sbx start <sandbox-name>`.
+       Inside the sandbox `<sandbox-name>` is `$SANDBOX_NAME`.
+    4. If the socket still does not come back, restart the daemon:
+       `sbx daemon restart`. The gateway listener is created when the
+       daemon builds the sandbox's runtime, and `ssh.agentForwardingEnabled`
+       / `ssh.agentSocketPath` changes only take effect for existing
+       forwarders after a daemon restart.
+
+    To make one commit without a signature while you sort that out:
+
+    ```console
+    git -c commit.gpgsign=false commit -m "..."
+    ```
 setup:
   install:
     - command: |
+        set -e
+
+        # Signing *machinery* stays machine-wide: it is inert unless something
+        # asks for a signature, and keeping it here means `git commit -S` works
+        # in any repository in the sandbox.
         git config --system gpg.format ssh
-        git config --system --unset-all user.signingKey || true
-        git config --system commit.gpgSign true
-        git config --system tag.gpgSign true
         git config --system gpg.ssh.defaultKeyCommand /home/agent/.config/git/ssh-signing-key-command
         git config --system gpg.ssh.allowedSignersFile /home/agent/.config/git/allowed_signers
+
+        # user.signingKey MUST stay unset: git only runs
+        # gpg.ssh.defaultKeyCommand when it is empty. Setting it to any value
+        # (even a placeholder) disables dynamic key resolution entirely.
+        git config --system --unset-all user.signingKey || true
+
+        # Signing *policy* is scoped, not machine-wide. Setting
+        # commit.gpgSign=true in /etc/gitconfig makes every `git commit` in the
+        # sandbox depend on a live SSH agent — including throwaway repositories
+        # created by test suites that have nothing to do with the user's work.
+        # When the forwarded agent goes away, those all fail too.
+        mkdir -p /etc/git
+        cat > /etc/git/signing-enabled.inc <<'INC'
+        # Included by /etc/gitconfig for repositories with a remote.
+        # See the git-ssh-sign kit.
+        [commit]
+        	gpgSign = true
+        [tag]
+        	gpgSign = true
+        INC
+        chmod 0644 /etc/git/signing-enabled.inc
+
+        # Clear anything an older version of this kit left machine-wide, so a
+        # re-install converges rather than layering.
+        git config --system --unset-all commit.gpgSign || true
+        git config --system --unset-all tag.gpgSign || true
+        git config --system --unset-all 'includeIf.hasconfig:remote.*.url:**.path' || true
+
+        # `includeIf "hasconfig:remote.*.url:**"` needs git >= 2.36. Probe for
+        # it rather than parsing a version string: build a throwaway repo with
+        # a remote and see whether the include actually fires. Note that `**`
+        # is only a cross-slash wildcard when it is a whole path component --
+        # `git@github.com:**` does NOT match `git@github.com:org/repo.git`, so
+        # a bare `**` ("has any remote at all") is the pattern to use here.
+        probe=$(mktemp -d)
+        git init -q "$probe"
+        git -C "$probe" remote add origin https://example.invalid/probe.git
+        printf '[commit]\n\tgpgSign = true\n' > "$probe/inc"
+        printf '[includeIf "hasconfig:remote.*.url:**"]\n\tpath = %s/inc\n' "$probe" > "$probe/sys"
+        supported=$(GIT_CONFIG_SYSTEM="$probe/sys" GIT_CONFIG_GLOBAL=/dev/null \
+            git -C "$probe" config --get commit.gpgSign 2>/dev/null || true)
+        rm -rf "$probe"
+
+        if [ "$supported" = "true" ]; then
+            git config --system 'includeIf.hasconfig:remote.*.url:**.path' /etc/git/signing-enabled.inc
+        else
+            # Old git: an unrecognised includeIf keyword evaluates false, which
+            # would silently disable signing. Fail closed (sign everywhere)
+            # rather than fail open (sign nothing).
+            echo "[git-ssh-sign] git $(git --version | awk '{print $3}') lacks includeIf hasconfig; enabling signing machine-wide" >&2
+            git config --system commit.gpgSign true
+            git config --system tag.gpgSign true
+        fi
+
         if [ "$(git config --system --get core.hooksPath || true)" = "/home/agent/.config/git/hooks" ]; then
             git config --system --unset-all core.hooksPath
         fi
       user: "0"
-      description: Configure SSH commit signing with a dynamic key command
+      description: Configure SSH commit signing, scoped to repositories with a remote
   files:
     - path: /home/agent/.config/git/ssh-signing-key-command
       content: |
         #!/bin/sh
-        set -e
+        # Resolve a signing key from the forwarded SSH agent.
+        #
+        # Git runs this only when user.signingKey is unset, and echoes whatever
+        # this script writes to stderr verbatim as
+        #     warning: gpg.ssh.defaultKeyCommand failed: <stderr>
+        # immediately before its own, misleading
+        #     error: user.signingKey needs to be set for ssh signing
+        # Git's line cannot be suppressed, so the message below has to carry the
+        # whole diagnosis and explicitly pre-empt it.
 
-        if [ -z "$SSH_AUTH_SOCK" ]; then
-            echo "[git-ssh-sign] no SSH agent - cannot sign commits" >&2
+        fail() {
+            # A leading newline keeps the body off git's "warning: ...failed: "
+            # prefix line, which would otherwise swallow the first sentence.
+            {
+                printf '\n'
+                printf '[git-ssh-sign] cannot sign: %s\n' "$1"
+                printf '[git-ssh-sign] %s\n' "$2"
+                printf '[git-ssh-sign] The "user.signingKey needs to be set" error below is a red herring:\n'
+                printf '[git-ssh-sign] this kit resolves the key from the forwarded SSH agent, and the agent is what is unavailable.\n'
+                printf '[git-ssh-sign] To make this one commit unsigned: git -c commit.gpgsign=false commit ...\n'
+            } >&2
             exit 1
+        }
+
+        sock="${SSH_AUTH_SOCK:-}"
+
+        if [ -z "$sock" ]; then
+            fail "SSH_AUTH_SOCK is not set" \
+                 "Sandboxes export it unconditionally, so something in this shell unset it."
         fi
 
-        key=$(ssh-add -L 2>/dev/null | head -n 1)
+        # SSH_AUTH_SOCK is baked into every sandbox whether or not forwarding
+        # was wired, so its presence proves nothing. The socket's existence is
+        # the real check, and it distinguishes "relay is down" from "agent is
+        # reachable but has no key" -- two states with different recoveries.
+        if [ ! -S "$sock" ]; then
+            fail "the forwarded agent socket $sock does not exist" \
+                 "The in-sandbox relay is not running. On the HOST, from a shell where 'ssh-add -l' lists your key: 'sbx start \$SANDBOX_NAME'; if the socket still does not appear, 'sbx daemon restart'."
+        fi
+
+        out=$(ssh-add -L 2>&1)
+        case $? in
+            0) ;;
+            2) fail "nothing answered on $sock (ssh-add: $out)" \
+                    "The relay socket is stale. On the HOST: 'sbx start \$SANDBOX_NAME'." ;;
+            *) fail "the agent returned no usable key (ssh-add: $out)" \
+                    "'no identities' means the HOST agent is empty: run 'ssh-add ~/.ssh/id_ed25519' there. 'communication with agent failed' means the relay reached the host but the host's agent is gone: restore it, then 'sbx daemon restart'." ;;
+        esac
+
+        key=$(printf '%s\n' "$out" | head -n 1)
         if [ -z "$key" ]; then
-            echo "[git-ssh-sign] no keys in SSH agent - cannot sign commits" >&2
-            exit 1
+            fail "ssh-add -L succeeded but printed nothing" \
+                 "Unexpected state; please report it against the git-ssh-sign kit."
         fi
 
-        config_dir="$GIT_SSH_SIGN_CONFIG_DIR"
-        if [ -z "$config_dir" ]; then
-            config_dir="/home/agent/.config/git"
-        fi
+        config_dir="${GIT_SSH_SIGN_CONFIG_DIR:-/home/agent/.config/git}"
         mkdir -p "$config_dir"
 
         email=$(git config user.email 2>/dev/null || printf '%s' "agent@sandbox.local")

--- a/git-ssh-sign/spec.yaml
+++ b/git-ssh-sign/spec.yaml
@@ -12,16 +12,22 @@ agentInstructions:
     signatures on existing commits.
 
     Automatic signing is scoped to repositories that **have at least one
-    remote**. A throwaway repository created by a test fixture
-    (`git init` with no remote) commits unsigned, so an unrelated test
-    suite is never blocked by signing. `git commit -S` still signs
-    anywhere.
+    remote**. A repository is exempt only for as long as it has no remote:
+    a test fixture that runs `git init` and stops there commits unsigned,
+    but one that goes on to `git remote add` is signed like any other
+    repository. `git commit -S` still signs anywhere.
+
+    The scoping needs git >= 2.36. On an older git the install falls back
+    to signing machine-wide and says so on stderr, and then nothing is
+    exempt — if `git init` fixtures are failing to commit, check
+    `git config --system --get commit.gpgSign` before believing the
+    paragraph above.
 
     ### When signing fails
 
     The key is resolved at signing time from the forwarded agent, so a
-    signing failure almost always means the agent is unreachable, not that
-    a config value is missing. Git reports it as:
+    signing failure almost always means the agent is unreachable or holds
+    no usable key, not that a config value is missing. Git reports it as:
 
         warning: gpg.ssh.defaultKeyCommand failed: [git-ssh-sign] ...
         error: user.signingKey needs to be set for ssh signing

--- a/git-ssh-sign/spec.yaml
+++ b/git-ssh-sign/spec.yaml
@@ -35,7 +35,7 @@ agentInstructions:
     ```console
     echo "$SSH_AUTH_SOCK"      # always set inside a sandbox; proves nothing
     test -S "$SSH_AUTH_SOCK"   # the real check — is the relay socket there?
-    ssh-add -l                 # 0 = keys; 1 = reachable, no usable key; 2 = no agent
+    ssh-add -l                 # 0 = keys; 1 = connected, no usable key; 2 = no connection
     ```
 
     Recovery, all of it **on the host**, not in the sandbox:
@@ -47,24 +47,33 @@ agentInstructions:
        sbx settings set ssh.agentForwardingEnabled true
        ```
 
-       Do this first. When it is `false` the daemon never records a socket
-       for the sandbox and the relay closes every connection without
-       writing a byte, so `ssh-add` in the sandbox reports a broken agent
-       rather than a disabled feature — and no amount of reloading keys or
-       restarting the sandbox changes it. The setting defaults to `true`,
-       so a `false` means it was turned off explicitly, e.g. by declining
-       agent forwarding during `sbx setup`.
+       Do this first. While it is `false` the forwarded agent is never
+       wired up, so `ssh-add` inside the sandbox reports a broken agent
+       (exit 1 or 2, depending on how far the connection gets) rather than
+       a disabled feature — and no amount of reloading keys or restarting
+       the sandbox changes it. The setting defaults to `true`, so a
+       `false` means it was turned off explicitly, e.g. by declining agent
+       forwarding during `sbx setup`.
 
     2. Make sure the host agent actually holds the key:
        `ssh-add -l`, and `ssh-add ~/.ssh/id_ed25519` if it does not.
-    3. From that same shell (the daemon adopts the client's
-       `SSH_AUTH_SOCK`), restart the sandbox: `sbx start <sandbox-name>`.
-       Inside the sandbox `<sandbox-name>` is `$SANDBOX_NAME`.
-    4. If the socket still does not come back, restart the daemon:
-       `sbx daemon restart`. The gateway listener is created when the
-       daemon builds the sandbox's runtime, and `ssh.agentForwardingEnabled`
-       / `ssh.agentSocketPath` changes only take effect for existing
-       forwarders after a daemon restart.
+    3. If step 1 changed the setting, restart the daemon:
+       `sbx daemon restart`. Changes to `ssh.agentForwardingEnabled` and
+       `ssh.agentSocketPath` only reach sandboxes that already exist once
+       the daemon has restarted.
+    4. From that same shell — the daemon adopts the requesting client's
+       `SSH_AUTH_SOCK` — restart this sandbox's container so the relay
+       comes back:
+
+       ```console
+       sbx stop <sandbox-name>
+       sbx run --name <sandbox-name>
+       ```
+
+       Stop-then-run is the supported restart cycle; there is no
+       `sbx start`. Substitute the sandbox's own name: `hostname` prints
+       it *inside* the sandbox, but `$SANDBOX_NAME` does not exist in a
+       host shell, so type the literal name there.
 
     To make one commit without a signature while you sort that out:
 


### PR DESCRIPTION
## Summary

Two problems with `git-ssh-sign`, both found while debugging a real signing outage in a long-lived sandbox.

**1. Signing policy was machine-wide.** The kit set `commit.gpgSign=true` in `/etc/gitconfig`, so *every* `git commit` anywhere in the sandbox required a live forwarded SSH agent — including throwaway repositories created by test fixtures that have nothing to do with the user's commits. When the forwarded agent went away, unrelated test suites started failing with a signing error.

This PR scopes the policy to repositories that have at least one remote, via `includeIf "hasconfig:remote.*.url:**"`. The signing *machinery* (`gpg.format`, the key command, the allowed-signers file) stays machine-wide, so `git commit -S` still works in any repository — only the automatic-signing default is scoped.

**2. The failure message pointed at the wrong thing.** Git reports a failed key command as a `warning:` and then emits its own `error: user.signingKey needs to be set for ssh signing`. That second line is the one people act on, and it is misleading — this kit deliberately leaves `user.signingKey` unset, because git only runs `gpg.ssh.defaultKeyCommand` when it *is* unset.

The key command now distinguishes a missing relay socket from an agent that is reachable but holds no usable key, quotes `ssh-add`'s own stderr instead of guessing, explicitly pre-empts git's misleading line, and prints the escape hatch (`git -c commit.gpgsign=false commit …`). The old `[ -z "$SSH_AUTH_SOCK" ]` check was dead code: `SSH_AUTH_SOCK` is always set inside a sandbox, so it never fired. It is now `test -S`, which is what actually distinguishes the common case.

The README and `agentInstructions` gain a recovery runbook that leads with `sbx settings get ssh.agentForwardingEnabled`. In the outage that prompted this, that setting was `false` — which presents inside the sandbox as a *broken* agent rather than a disabled feature, and survives any number of key reloads and sandbox restarts. Checking it first would have turned a long debugging session into one command.

## Spec choices worth flagging for review

- **`hasconfig:remote.*.url:**` needs git ≥ 2.36.** The install probes for support by building a throwaway repo with a remote and checking whether the include actually fires, rather than parsing a version string. On older git it **fails closed** — signing machine-wide, as today — because an unrecognised `includeIf` keyword evaluates false and would otherwise silently disable signing everywhere.
- **The `**` glob is deliberately bare.** `**` is only a cross-slash wildcard as a whole path component, so `git@github.com:**` does *not* match `git@github.com:org/repo.git`. "Has any remote at all" is the only robust pattern here.
- **`user.signingKey` must stay unset**, and the install keeps `--unset-all`-ing it. Setting it to any value — even a placeholder chosen to produce a nicer error — stops git from ever invoking the key command, which breaks dynamic key resolution in the working case too. There is now a comment saying so.
- **Behaviour change to accept:** a genuinely local-only repository (no remote) stops being signed automatically. That is the point, but it is a narrowing, and a test fixture that *does* add a remote is still subject to signing.
- The install clears any machine-wide `commit.gpgSign`/`tag.gpgSign` an earlier version of this kit left behind, so re-installing converges rather than layering.

## Origin

Existing first-party kit; this is a fix, not a new kit. The scoping problem surfaced when a forwarded agent dropped mid-session and broke `git commit` in unrelated Go test fixtures inside the sandbox.

## Test plan

- [x] `./scripts/test-kit.sh git-ssh-sign` passes (the TCK — includes spec validation, `commands_validation`, and in-container `install_execution`). Re-run after rebasing onto `main`.
- [x] `includeIf` scoping verified directly against git 2.53: a repo **with** a remote resolves `commit.gpgSign=true`; a repo **without** one leaves it unset.
- [x] All four key-command states exercised against the real script: missing socket, agent with no identities, relay up but host agent gone, and healthy (signs, `Good "git" signature`).
- [ ] `sbx kit validate ./git-ssh-sign/` — **not run separately**; `sbx` cannot run inside a sandbox. The TCK's validation subtests cover the same spec checks.
- [ ] `./scripts/test-kit-e2e.sh git-ssh-sign` — **not run**, same reason: needs a scoped `sbx` daemon on a host.
- [ ] Manual smoke (`sbx run --kit ./git-ssh-sign/ <agent>`) — **not run**, same reason.

The three unchecked items need a host run before merge. This kit ships no image and no `network.allowedDomains`, so the cross-arch domain gotchas in the template do not apply.
