### PR TITLE
fix(spec): validate AI filenames

### DIFF
--- a/spec/validate.go
+++ b/spec/validate.go
@@ -15,6 +15,9 @@ import (
 // must start and end with alphanumeric, 1-64 characters.
 var namePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,62}[a-z0-9])?$`)
 
+// aiFilenamePattern restricts the AI profile name to one portable path component.
+var aiFilenamePattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+
 // shellIdentifierPattern matches valid shell variable names.
 var shellIdentifierPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
@@ -68,6 +71,10 @@ func validateManifest(m *Manifest, inheritsImage bool) error {
 	}
 	if !namePattern.MatchString(m.Name) {
 		return fmt.Errorf("manifest: invalid name %q (must be lowercase alphanumeric with hyphens, 1-64 chars)", m.Name)
+	}
+
+	if m.AIFilename != "" && (m.AIFilename == "." || m.AIFilename == ".." || !aiFilenamePattern.MatchString(m.AIFilename)) {
+		return fmt.Errorf("manifest: invalid aiFilename %q (must be a filename containing only letters, numbers, dots, underscores, or hyphens)", m.AIFilename)
 	}
 
 	if (m.Kind == KindSandbox || m.Kind == KindAgent) && !inheritsImage {

--- a/spec/validate_test.go
+++ b/spec/validate_test.go
@@ -85,6 +85,32 @@ func TestValidateManifest(t *testing.T) {
 		require.ErrorContains(t, ValidateManifest(&m), "invalid name")
 	})
 
+	t.Run("valid_ai_filename", func(t *testing.T) {
+		for _, name := range []string{"AGENTS.md", "agent_profile-1.md", ".agent.md"} {
+			m := valid
+			m.AIFilename = name
+			require.NoError(t, ValidateManifest(&m))
+		}
+	})
+
+	for _, tc := range []struct {
+		name     string
+		filename string
+	}{
+		{name: "current_directory", filename: "."},
+		{name: "parent_directory", filename: ".."},
+		{name: "absolute_path", filename: "/tmp/AGENTS.md"},
+		{name: "relative_path", filename: "../AGENTS.md"},
+		{name: "windows_separator", filename: `dir\AGENTS.md`},
+		{name: "shell_metacharacters", filename: "AGENTS.md; touch /tmp/pwned"},
+	} {
+		t.Run("invalid_ai_filename_"+tc.name, func(t *testing.T) {
+			m := valid
+			m.AIFilename = tc.filename
+			require.ErrorContains(t, ValidateManifest(&m), "invalid aiFilename")
+		})
+	}
+
 	t.Run("agent_missing_template", func(t *testing.T) {
 		m := Manifest{
 			SchemaVersion: SchemaVersion,


### PR DESCRIPTION
<!--
Thanks for contributing to sbx-kits-contrib!

PRs from forks have CI's `test-kit-e2e` job SKIPPED because GitHub does not
expose `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` to fork-triggered workflows.
The e2e assertions will not run on your PR — your laptop is the only place
they run before merge. See the checklist below.
-->

## Summary

Validate `AIFilename` as a safe, single path component. Rejects shell metacharacters, path separators, `.` and `..`, with regression coverage for valid and malicious filenames.

## Spec choices worth flagging for review

<!-- Decisions a reviewer should sanity-check: unusual image, deliberately narrow
allowedDomains, workaround for a known bug, etc. -->

## Origin

<!-- Where did the kit come from? One sentence is enough. -->

## Test plan

CI runs `kit validate` and the TCK on every PR. CI does **not** run e2e on
fork PRs (Docker Hub secrets aren't exposed there), so the e2e step below is
required from your side before requesting review.

- [ ] `sbx kit validate ./<kit>/` passes
- [ ] `./scripts/test-kit.sh <kit>` passes (the TCK)
- [ ] `./scripts/test-kit-e2e.sh <kit>` passes. The script applies the same
      `deny-all` baseline CI uses and scopes everything to its own daemon
      (`--app-name sbx-kits-contrib-tck`), so my main sbx state is untouched.
      Every entry I added to `network.allowedDomains` came from
      `sbx --app-name sbx-kits-contrib-tck policy log <tck-e2e-…>`, not a guess.
- [ ] Manual smoke: `sbx run --kit ./<kit>/ <agent>` and verified the kit's
      binary / files / env are inside the running container.

One-time setup if you haven't run e2e on this machine before:
`sbx --app-name sbx-kits-contrib-tck login`.

See [CONTRIBUTING.md → Verifying locally](../CONTRIBUTING.md#verifying-locally)
and [README → Declare every domain your kit needs](../README.md#declare-every-domain-your-kit-needs)
for the cross-arch domain gotchas (`archive.ubuntu.com`,
`security.ubuntu.com`, `ports.ubuntu.com`) and the package-manager refresh trap.
