### PR TITLE
fix(gstack,paperclip): stop inheriting the base template's flavor label

### DIFF
--- a/gstack/Dockerfile
+++ b/gstack/Dockerfile
@@ -11,8 +11,15 @@
 # Built and published by build-and-publish-kits.yml, the shared kit-image
 # pipeline (see ../PUBLISHING.md) -- no bespoke workflow needed, same as
 # kiro/copilot.
+#
+# The base is a floating tag, which is why CI also rebuilds on a schedule.
+ARG BASE_IMAGE=docker/sandbox-templates:claude-code
+FROM ${BASE_IMAGE}
 
-FROM docker/sandbox-templates:claude-code
+# Re-declared inside the stage: an ARG defined before the first FROM is a
+# global build arg, visible only to FROM lines. Without this, the LABEL near
+# the end of this file would expand to an empty string.
+ARG BASE_IMAGE
 
 # gstack has no release tags; pin a commit SHA (VERSION 1.57.10.0).
 ARG GSTACK_REF=a5833c413f98b13f105beac96262e8098b628461
@@ -55,5 +62,20 @@ RUN git clone https://github.com/garrytan/gstack.git /home/agent/.claude/skills/
 # baseline (users can enable later with `./setup`).
 RUN cd /home/agent/.claude/skills/gstack && \
     GSTACK_SKIP_FONTS=1 GSTACK_PLAN_TUNE_HOOKS=no ./setup --no-prefix
+
+# This OVERRIDES the value inherited from the base image, which describes the
+# base rather than this image. Overriding is not optional: left inherited it
+# would read "claude-code", and sbx would report this image's agent as
+# "claude-code" instead of "gstack".
+#
+# sbx reads `flavor` and treats it as an agent identifier — it surfaces the
+# value as an image's `Agent` in the API. So it must be the kit's own name:
+# `gstack`.
+LABEL com.docker.sandboxes.flavor="gstack"
+
+# Informational only — nothing in sbx reads this. Worth setting because the
+# base is a floating tag rebuilt nightly, so this is the one place the
+# produced image records what it was actually built on.
+LABEL com.docker.sandboxes.base="${BASE_IMAGE}"
 
 CMD ["claude"]

--- a/paperclip/Dockerfile
+++ b/paperclip/Dockerfile
@@ -13,8 +13,15 @@
 # Built and published by build-and-publish-kits.yml, the shared kit-image
 # pipeline (see ../PUBLISHING.md) -- no bespoke workflow needed, same as
 # kiro/copilot.
+#
+# The base is a floating tag, which is why CI also rebuilds on a schedule.
+ARG BASE_IMAGE=docker/sandbox-templates:claude-code
+FROM ${BASE_IMAGE}
 
-FROM docker/sandbox-templates:claude-code
+# Re-declared inside the stage: an ARG defined before the first FROM is a
+# global build arg, visible only to FROM lines. Without this, the LABEL near
+# the end of this file would expand to an empty string.
+ARG BASE_IMAGE
 
 # Calendar versioning upstream (vYYYY.MDD.P). Pin deliberately.
 ARG PAPERCLIP_VERSION=2026.609.0
@@ -49,5 +56,20 @@ USER agent
 WORKDIR /home/agent
 # State root for config, embedded postgres data, assets, secrets.
 RUN mkdir -p /home/agent/.paperclip
+
+# This OVERRIDES the value inherited from the base image, which describes the
+# base rather than this image. Overriding is not optional: left inherited it
+# would read "claude-code", and sbx would report this image's agent as
+# "claude-code" instead of "paperclip".
+#
+# sbx reads `flavor` and treats it as an agent identifier — it surfaces the
+# value as an image's `Agent` in the API. So it must be the kit's own name:
+# `paperclip`.
+LABEL com.docker.sandboxes.flavor="paperclip"
+
+# Informational only — nothing in sbx reads this. Worth setting because the
+# base is a floating tag rebuilt nightly, so this is the one place the
+# produced image records what it was actually built on.
+LABEL com.docker.sandboxes.base="${BASE_IMAGE}"
 
 CMD ["/usr/local/bin/paperclip-start"]


### PR DESCRIPTION
## Summary

Both `gstack` and `paperclip` build on `docker/sandbox-templates:claude-code`, and neither Dockerfile declared its own `com.docker.sandboxes.flavor` label. So both images were quietly inheriting `flavor="claude-code"` from the base. `sbx` reads that label as the image's agent identity, so both kits currently report the wrong agent.

This brings both Dockerfiles in line with the `kiro`/`copilot`/`droid`/`pi` pattern already established in this repo: parameterize the base as a `BASE_IMAGE` build arg (default unchanged) and explicitly set:

- `com.docker.sandboxes.flavor="gstack"` / `"paperclip"`
- `com.docker.sandboxes.base="${BASE_IMAGE}"` (informational, records what the image was actually built on)

I deliberately did **not** add `com.docker.sandboxes.start-docker="true"`. That label exists on `kiro`/`copilot`/`droid` because they build on `shell-docker`, which ships an engine. `gstack` and `paperclip` build on `claude-code`, which has no Docker engine — setting that label here would be a false claim about the image.

## Spec choices worth flagging for review

None — this only touches labels on the image, not `spec.yaml`.

## Origin

N/A — no new kit, just fixing existing `gstack`/`paperclip` images.

## Test plan

- [x] `./scripts/check-image-ref.sh docker.io/sbx latest` passes (both kits still resolve to their expected `sandbox.image`).
- [x] `./scripts/test-kit.sh paperclip` passes (TCK green), and `docker inspect` on the built image confirms `flavor="paperclip"`, `base="docker/sandbox-templates:claude-code"`, and no `start-docker` key.
- [ ] `./scripts/test-kit.sh gstack` — I could not get a full build in my sandbox: the Chromium install step (`npx playwright install`) needs `cdn.playwright.dev` / `playwright.download.prss.microsoft.com`, which my sandbox's network policy denies by default. I confirmed this is pre-existing and unrelated to this change (the unmodified Dockerfile on `main` fails identically in the same sandbox). I separately verified the exact `ARG BASE_IMAGE` / `LABEL` mechanism this PR adds against a minimal reproduction and confirmed it resolves `flavor`/`base` correctly.
- [ ] `./scripts/test-kit-e2e.sh` — not run; it drives a real `sbx`, which needs a host and can't run inside this sandbox.
- [ ] Manual `sbx run` smoke test — not run, same reason as e2e.