### PR TITLE
fix(openclaw): declare the sandbox labels so sbx reports the right agent

### DIFF
--- a/openclaw/Dockerfile
+++ b/openclaw/Dockerfile
@@ -11,7 +11,19 @@
 # pipeline (see ../PUBLISHING.md) -- no bespoke workflow needed, same as
 # kiro/copilot.
 
-FROM docker/sandbox-templates:shell-docker
+# Parameterised rather than hard-coded so a build can be aimed at a specific
+# base digest without editing this file. Nothing in this repository passes the
+# arg, so the default is what ships -- and it is the same tag this image has
+# always been built on. Unlike OPENCLAW_VERSION below, the base is left
+# floating on purpose, so the shared pipeline's nightly rebuild picks up
+# template fixes.
+ARG BASE_IMAGE=docker/sandbox-templates:shell-docker
+FROM ${BASE_IMAGE}
+
+# Re-declared inside the stage: an ARG defined before the first FROM is a
+# global build arg, visible only to FROM lines. Without this, the LABEL below
+# would expand to an empty string.
+ARG BASE_IMAGE
 
 # Date-based upstream versioning; releases are ~daily. Pin deliberately.
 ARG OPENCLAW_VERSION=2026.6.5
@@ -54,5 +66,36 @@ WORKDIR /home/agent
 # keep this tiny.
 RUN mkdir -p /home/agent/.openclaw && \
     printf '{\n  "gateway": {\n    "mode": "local"\n  }\n}\n' > /home/agent/.openclaw/openclaw.json
+
+# Inherited from the base image, but re-declared deliberately so the value is
+# owned here rather than depending on inheritance from an image this repository
+# does not own.
+#
+# This is a *request* to the runtime, not a description of the image: setting it
+# over a base with no Docker engine yields a sandbox started in Docker mode with
+# nothing to run. Since BASE_IMAGE is overridable, CI asserts the engine is
+# really present rather than trusting this label.
+LABEL com.docker.sandboxes.start-docker="true"
+
+# Both labels below OVERRIDE values inherited from the base image, which
+# describe the base rather than this image.
+#
+# Overriding `flavor` is not optional. sbx reads it as an agent identifier: it
+# surfaces the value as an image's `Agent`, and uses it to warn when a template
+# looks built for a different agent than the one being run. Left inherited it
+# reads "shell-docker", so sbx reports this image's agent as the base template
+# rather than OpenClaw. It must be the kit name exactly as spec.yaml uses it:
+# `openclaw`.
+LABEL com.docker.sandboxes.flavor="openclaw"
+
+# Informational only -- nothing in sbx reads this. Worth setting because it is
+# the one place the produced image itself records what it was built on: the
+# default tag above, or whatever a build passed instead.
+LABEL com.docker.sandboxes.base="${BASE_IMAGE}"
+
+# Note: `com.docker.sandboxes=templates` also appears on this image. It is
+# inherited from the base and is not set here -- nothing reads it, and this
+# image is not part of that template family, so it is left alone rather than
+# asserted.
 
 CMD ["/usr/local/bin/openclaw-start"]

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -150,7 +150,7 @@ directory:
 
 ```
 docker.io/sbx/openclaw-image
-└── FROM docker/sandbox-templates:shell-docker
+└── FROM ${BASE_IMAGE}  (defaults to docker/sandbox-templates:shell-docker)
     ├── Node 22 (openclaw requires >= 22.19)
     ├── openclaw @ pinned version   npm global install (+ /usr/local/bin symlink)
     └── /opt/ms-playwright          Chromium + xvfb for the browser tool

--- a/openclaw/spec.yaml
+++ b/openclaw/spec.yaml
@@ -76,11 +76,11 @@ credentials:
         - domain: console.anthropic.com
           header: x-api-key
           format: '%s'
-    # Without this block a host whose stored anthropic credential is an OAuth
-    # login -- what `sbx login` produces, and what CONTRIBUTING documents as
-    # the one-time e2e setup -- has no usable credential here at all: the
-    # apiKey sentinel reaches Anthropic unswapped and every model call is a
-    # 401. Declaring oauth lets the proxy authenticate egress with it.
+    # For a host whose stored anthropic credential is an OAuth login -- signed
+    # in from a `claude` sandbox. Without this block such a host has no usable
+    # credential here at all: the apiKey sentinel reaches Anthropic unswapped
+    # and every model call is a 401. Declaring oauth lets the proxy
+    # authenticate egress with it.
     # credentialFile is what makes the OAuth path detectable from inside the
     # sandbox. SBX_CRED_ANTHROPIC_MODE reports "none" even when this credential
     # resolves, so it cannot discriminate oauth from apikey; the materialized


### PR DESCRIPTION
## Summary

The published `openclaw` image reports the wrong agent. It never declared
`com.docker.sandboxes.flavor`, so it inherits the base image's value and
`docker buildx imagetools inspect docker.io/sbx/openclaw-image:latest` comes
back with `flavor=shell-docker` and `base=ubuntu:questing` — both describing
the base template, not this image. sbx reads `flavor` as an agent identifier,
so the image currently announces its agent as `shell-docker`.

This declares the labels here instead of inheriting them, following what
`kiro`, `copilot`, `droid` and `pi` already do:

- `ARG BASE_IMAGE` before the `FROM`, defaulting to the exact tag that was
  hard-coded before, re-declared inside the stage so the label expands.
- `start-docker=true`, `flavor=openclaw`, `base=${BASE_IMAGE}`, placed after
  the build steps so touching a label doesn't bust the npm/Playwright cache.

Second, unrelated but one-line: the `oauth:` comment in `spec.yaml` said the
host's Anthropic OAuth credential is "what `sbx login` produces". It isn't —
`sbx login` is a Docker sign-in. The credential comes from signing in from a
`claude` sandbox, which this kit's own README already says in its credential
table. Reworded to match `pi/spec.yaml`. The rest of that comment block is
correct and untouched.

## Spec choices worth flagging for review

`BASE_IMAGE` stays on the floating tag by default — nothing in this repo
passes the arg, and the nightly rebuild is how template fixes reach this
image. The arg exists so a build can be digest-pinned without editing the
Dockerfile.

`README.md` picks up the `${BASE_IMAGE}` spelling in the base-image diagram —
small precision touch, nothing behavioural.

## Origin

Follow-up on the existing `openclaw` kit in this repo.

## Test plan

- [ ] `sbx kit validate ./openclaw/` — not run. I did this from a sandbox and
      `sbx` can't run inside one.
- [x] `./scripts/test-kit.sh openclaw` — the TCK passes (all of `validation`,
      `network_policy`, `credential_policy`, `environment_policy`,
      `oauth_policy`, `container`). **Caveat:** my sandbox's egress policy
      blocks `cdn.playwright.dev` / `playwright.download.prss.microsoft.com`,
      so the Chromium layer can't build here and I ran the suite with
      `SBX_KIT_SKIP_IMAGE_BUILD=1`. CI has the network to do the real build.
- [ ] `./scripts/test-kit-e2e.sh openclaw` — **not run.** It drives a real
      `sbx`, which needs a host. This has not been verified end to end.
- [ ] Manual smoke via `sbx run` — same reason.

What I did verify directly, since the labels are the point of the change:

- `scripts/check-image-ref.sh docker.io/sbx latest` — all 7 kits ok.
- `docker build --check openclaw` — clean, no warnings.
- Built the Dockerfile with only the network-blocked `RUN`/`COPY` steps
  removed (the `ARG`/`FROM`/`LABEL` lines byte-identical) and inspected it:

  ```json
  {
    "com.docker.sandboxes": "templates",
    "com.docker.sandboxes.base": "docker/sandbox-templates:shell-docker",
    "com.docker.sandboxes.flavor": "openclaw",
    "com.docker.sandboxes.start-docker": "true"
  }
  ```

  against today's published image, which gives `flavor=shell-docker` and
  `base=ubuntu:questing`.
- Confirmed `docker/sandbox-templates:shell-docker` really does ship an engine
  (`dockerd` 29.7.2 on PATH), so re-declaring `start-docker=true` is accurate.

Worth a second pair of eyes on the label values before merge, since e2e didn't
run on my side.
