### PR TITLE
ci(publish): bypass the build cache nightly, and assert the flavor label

### DIFF
--- a/.github/workflows/build-and-publish-kits.yml
+++ b/.github/workflows/build-and-publish-kits.yml
@@ -31,8 +31,10 @@ name: Build and publish kits
 #   * `com.docker.sandboxes.start-docker=true` may only be set on an image that
 #     actually ships a Docker engine; the build asserts this.
 #   * `com.docker.sandboxes.flavor` must be the kit's own name. sbx reads it as
-#     the image's agent, and an image that does not set it inherits the base
-#     image's value rather than reporting nothing; the build asserts this too.
+#     the image's agent, and an image that does not set it inherits whatever
+#     its base sets — today's bases all carry their own flavor, so forgetting
+#     it usually reports the wrong agent rather than none; the build asserts
+#     this too.
 #
 # Shared coordinates (registry, namespace, rolling tag, platforms) come from
 # repository/organisation variables with documented fallbacks, so retargeting is

--- a/.github/workflows/build-and-publish-kits.yml
+++ b/.github/workflows/build-and-publish-kits.yml
@@ -30,6 +30,9 @@ name: Build and publish kits
 #     image living in the namespace CI can push to.
 #   * `com.docker.sandboxes.start-docker=true` may only be set on an image that
 #     actually ships a Docker engine; the build asserts this.
+#   * `com.docker.sandboxes.flavor` must be the kit's own name. sbx reads it as
+#     the image's agent, and an image that does not set it inherits the base
+#     image's value rather than reporting nothing; the build asserts this too.
 #
 # Shared coordinates (registry, namespace, rolling tag, platforms) come from
 # repository/organisation variables with documented fallbacks, so retargeting is

--- a/.github/workflows/publish-one-kit.yml
+++ b/.github/workflows/publish-one-kit.yml
@@ -256,7 +256,7 @@ jobs:
           # that declares the wrong name reads back as that. Every kit declaring
           # the label today uses exactly its own directory name.
           if [ "$flavor" != "${{ inputs.kit }}" ]; then
-            echo "::error::${{ inputs.kit }}: image reports flavor '${flavor:-(unset)}', expected '${{ inputs.kit }}'. Add: LABEL com.docker.sandboxes.flavor=\"${{ inputs.kit }}\" to ${{ inputs.kit }}/Dockerfile — undeclared, the label is inherited from the base image and sbx reports that base's agent for this kit."
+            echo "::error::${{ inputs.kit }}: image reports flavor '${flavor:-(unset)}', expected '${{ inputs.kit }}'. Set LABEL com.docker.sandboxes.flavor=\"${{ inputs.kit }}\" in ${{ inputs.kit }}/Dockerfile — add it if the Dockerfile declares none, correct it if it declares another name. sbx reports this label as the kit's agent, and a Dockerfile that declares none inherits whatever its base image sets."
             exit 1
           fi
 

--- a/.github/workflows/publish-one-kit.yml
+++ b/.github/workflows/publish-one-kit.yml
@@ -204,11 +204,12 @@ jobs:
         #   3. Sandboxes do not run as root.
         #   4. `com.docker.sandboxes.flavor` names this kit. sbx reads that
         #      label as the image's agent, and an image that does not declare
-        #      one inherits the base image's value — so a Dockerfile that
-        #      forgets it does not produce a missing agent, it produces a
-        #      confidently wrong one. Nothing derives the label from the kit
-        #      directory, so this is the only thing standing between a new kit
-        #      and shipping under someone else's name.
+        #      one inherits whatever its base sets — today's bases all carry
+        #      their own flavor, so a Dockerfile that forgets it does not
+        #      produce a missing agent, it produces a confidently wrong one.
+        #      Nothing derives the label from the kit directory, so this is the
+        #      only thing standing between a new kit and shipping under someone
+        #      else's name.
         run: |
           set -euo pipefail
           img="${{ steps.coords.outputs.image }}:ci-verify"

--- a/.github/workflows/publish-one-kit.yml
+++ b/.github/workflows/publish-one-kit.yml
@@ -67,7 +67,15 @@ jobs:
   image:
     if: inputs.has-image
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # Generous because the nightly builds every layer from scratch (see the
+    # `no-cache` note below) and does it twice: once for the amd64 verification
+    # image and once for the multi-arch push. The slowest kit's first-ever
+    # build — cold cache, emulated arm64 leg included — took 19 minutes, so
+    # what the nightly adds on top of that is one more NATIVE amd64 pass, not
+    # another emulated one. 90 is therefore a wide margin rather than a tight
+    # estimate; the failure mode if the cap is hit is a rolling tag that
+    # quietly stops moving, which is worth more headroom than headroom costs.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -142,6 +150,34 @@ jobs:
         # cache, so it costs little, and gives a concrete image to assert
         # against. It runs on pull requests too — the point is to catch a broken
         # image before it is published, not after.
+        #
+        # The nightly run bypasses that cache, here and on the push build below.
+        # These Dockerfiles install their agent from a `latest` channel with a
+        # fixed `RUN ... curl ... | sh` line, so with the cache on, the
+        # instruction text and the build context are identical every night and
+        # the install layer is always a hit — three consecutive nightly builds
+        # of one commit published byte-identical rootfs diff IDs under three
+        # different manifest digests. The only thing that ever busts that layer
+        # is the base image moving, which happens on the BASE's cadence, not the
+        # agent's; until then the nightly just re-tags yesterday's bytes with
+        # today's date. That defeats the reason the schedule exists (see
+        # build-and-publish-kits.yml's `schedule:` comment), so on `schedule`
+        # the cache is written but not read.
+        #
+        # Both builds need it. Busting the cache only here and letting the push
+        # build reuse what this one just wrote looks cheaper but is wrong: this
+        # build is linux/amd64 only and the push build is multi-arch, so arm64
+        # would still be served from the stale cache.
+        #
+        # Two consequences, both deliberate. The nightly's verified image and
+        # its published amd64 image become two independent builds rather than
+        # the same cached layers, so on the one run where upstream content can
+        # move under us, "verified" means "a build of this Dockerfile minutes
+        # earlier passed" — the alternative buys that back by publishing a
+        # stale arm64, which is worse. And `workflow_dispatch` keeps the cache
+        # even though the caller lumps it with `schedule`: a manual run is also
+        # how a publish that failed on something other than the image gets
+        # retried, and that should not cost an uncached multi-arch rebuild.
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ${{ inputs.kit }}
@@ -149,6 +185,7 @@ jobs:
           platforms: linux/amd64
           load: true
           tags: ${{ steps.coords.outputs.image }}:ci-verify
+          no-cache: ${{ github.event_name == 'schedule' }}
           cache-from: type=gha,scope=${{ inputs.kit }}
           cache-to: type=gha,mode=max,scope=${{ inputs.kit }}
 
@@ -165,6 +202,13 @@ jobs:
         #      started in Docker mode with nothing to run, so the claim is
         #      checked against reality.
         #   3. Sandboxes do not run as root.
+        #   4. `com.docker.sandboxes.flavor` names this kit. sbx reads that
+        #      label as the image's agent, and an image that does not declare
+        #      one inherits the base image's value — so a Dockerfile that
+        #      forgets it does not produce a missing agent, it produces a
+        #      confidently wrong one. Nothing derives the label from the kit
+        #      directory, so this is the only thing standing between a new kit
+        #      and shipping under someone else's name.
         run: |
           set -euo pipefail
           img="${{ steps.coords.outputs.image }}:ci-verify"
@@ -177,7 +221,9 @@ jobs:
           user=$(docker inspect --format '{{ .Config.User }}' "$img")
           label=$(docker inspect --format \
             '{{ if .Config.Labels }}{{ index .Config.Labels "com.docker.sandboxes.start-docker" }}{{ end }}' "$img")
-          echo "kit=${{ inputs.kit }} cmd=${cmd} user=${user} start-docker=${label}"
+          flavor=$(docker inspect --format \
+            '{{ if .Config.Labels }}{{ index .Config.Labels "com.docker.sandboxes.flavor" }}{{ end }}' "$img")
+          echo "kit=${{ inputs.kit }} cmd=${cmd} user=${user} start-docker=${label} flavor=${flavor}"
 
           if [ -z "$cmd" ]; then
             echo "::error::${{ inputs.kit }}: image sets no CMD, so the sandbox entrypoint cannot be verified"
@@ -204,6 +250,15 @@ jobs:
               exit 1
               ;;
           esac
+
+          # One comparison covers both failure modes: a Dockerfile that declares
+          # no flavor reads back as the base image's value (or empty), and one
+          # that declares the wrong name reads back as that. Every kit declaring
+          # the label today uses exactly its own directory name.
+          if [ "$flavor" != "${{ inputs.kit }}" ]; then
+            echo "::error::${{ inputs.kit }}: image reports flavor '${flavor:-(unset)}', expected '${{ inputs.kit }}'. Add: LABEL com.docker.sandboxes.flavor=\"${{ inputs.kit }}\" to ${{ inputs.kit }}/Dockerfile — undeclared, the label is inherited from the base image and sbx reports that base's agent for this kit."
+            exit 1
+          fi
 
           echo "${{ inputs.kit }} verified."
 
@@ -242,6 +297,11 @@ jobs:
         # Only the immutable <date>-<sha> tag is built and pushed here; the
         # rolling tag is re-pointed at this manifest in the next step rather than
         # built again.
+        #
+        # `no-cache` on the nightly for the reason spelled out on the
+        # verification build above — and it is repeated here rather than relying
+        # on that build having refreshed the cache, because that one is amd64
+        # only while this one is multi-arch.
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ${{ inputs.kit }}
@@ -249,6 +309,7 @@ jobs:
           platforms: ${{ env.PLATFORMS }}
           push: ${{ env.DRY_RUN == '' }}
           tags: ${{ steps.coords.outputs.image }}:${{ inputs.dated }}
+          no-cache: ${{ github.event_name == 'schedule' }}
           cache-from: type=gha,scope=${{ inputs.kit }}
           cache-to: type=gha,mode=max,scope=${{ inputs.kit }}
 

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -318,8 +318,10 @@ the image itself:
 
 1. Put a `Dockerfile` at the kit root; the kit directory is the build context.
 2. Set `LABEL com.docker.sandboxes.flavor="<kit>"` in it. Nothing derives this
-   from the directory name, and leaving it out inherits the base image's value
-   rather than none, so CI rejects an image that omits it.
+   from the directory name, and leaving it out inherits whatever the base sets —
+   with today's bases that is the base's own flavor, so the kit ships under
+   another agent's name; on a base that carries no such label it is left unset.
+   CI rejects the image either way.
 3. Set `sandbox.image` to `docker.io/sbx/<kit>-image:latest` in `spec.yaml`.
 4. Run `./scripts/check-image-ref.sh docker.io/sbx latest` before pushing.
 5. Build locally to check it works — `docker build -t docker.io/sbx/<kit>-image:latest <kit>`.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -310,9 +310,9 @@ the image itself:
   Docker-in-Docker — since the base is a build arg, this check is what stops an
   image asking for an engine it does not have.
 - `com.docker.sandboxes.flavor` names the kit itself. `sbx` reads that label as
-  the image's agent, and an image that does not declare one inherits the base
-  image's value — so a Dockerfile that forgets it does not report a missing
-  agent, it reports the base's.
+  the image's agent, and an image that does not declare one inherits whatever
+  its base sets — today's bases all carry their own flavor, so a Dockerfile
+  that forgets it does not report a missing agent, it reports the base's.
 
 ## Adding an image-publishing kit
 

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -309,13 +309,20 @@ the image itself:
   `dockerd`, `docker` and `containerd`. That label only *requests*
   Docker-in-Docker — since the base is a build arg, this check is what stops an
   image asking for an engine it does not have.
+- `com.docker.sandboxes.flavor` names the kit itself. `sbx` reads that label as
+  the image's agent, and an image that does not declare one inherits the base
+  image's value — so a Dockerfile that forgets it does not report a missing
+  agent, it reports the base's.
 
 ## Adding an image-publishing kit
 
 1. Put a `Dockerfile` at the kit root; the kit directory is the build context.
-2. Set `sandbox.image` to `docker.io/sbx/<kit>-image:latest` in `spec.yaml`.
-3. Run `./scripts/check-image-ref.sh docker.io/sbx latest` before pushing.
-4. Build locally to check it works — `docker build -t docker.io/sbx/<kit>-image:latest <kit>`.
+2. Set `LABEL com.docker.sandboxes.flavor="<kit>"` in it. Nothing derives this
+   from the directory name, and leaving it out inherits the base image's value
+   rather than none, so CI rejects an image that omits it.
+3. Set `sandbox.image` to `docker.io/sbx/<kit>-image:latest` in `spec.yaml`.
+4. Run `./scripts/check-image-ref.sh docker.io/sbx latest` before pushing.
+5. Build locally to check it works — `docker build -t docker.io/sbx/<kit>-image:latest <kit>`.
 
 No workflow edit is needed; discovery picks the kit up. Note that
 `sandbox.image` must reference a tag CI actually publishes, so the first


### PR DESCRIPTION
## Summary

Two fixes to the kit image pipeline, both about images that claim to be
something they aren't.

**The nightly rebuild wasn't rebuilding anything.** Both `build-push-action`
steps read and write a `type=gha` cache and nothing ever invalidated it. For a
kit that installs its agent from a `latest` channel with a fixed
`RUN … curl … | sh` line, the instruction text and the build context are
identical every night, so that layer is always a cache hit — the only thing
that ever busts it is the base image moving, and the base moves on its own
cadence rather than the agent's. It's visible in the registry: three
consecutive nightlies of the same source commit — `sbx/kiro-image:20260822-cc502cd`,
`:20260823-cc502cd`, `:20260824-cc502cd` — have byte-identical
`rootfs.diff_ids`, install layer included, under three different manifest
digests. We were re-tagging yesterday's bytes with today's date, which is the
opposite of why the schedule exists.

So: `no-cache` on `schedule`, on **both** builds. Doing it only on the
verification build and letting the push build reuse what it just wrote looks
cheaper, but the verification build is amd64-only and the push build is
multi-arch, so arm64 would still ship from stale cache.

**Three of the seven image kits don't declare `com.docker.sandboxes.flavor`.**
The label is hand-declared per Dockerfile and nothing derives it from the kit
directory, so an image that omits it silently inherits its base template's
value and `sbx` reports the wrong agent for that kit. A forgotten label isn't a
missing agent — it's a confidently wrong one, which is why a convention isn't
enough. The verify step now asserts the label equals the kit name, alongside
the three assertions it already makes, and `PUBLISHING.md` picks it up both as
a pre-publish check and as a step in the "adding an image-publishing kit"
recipe.

## The kits this guards are fixed — #251 and #252 have merged

This was a draft because the guard failed for exactly the three kits that had
the bug. Both fixes are in, so it's now rebased on a `main` where all seven
image kits declare their own `flavor`, and this should be green.

Worth keeping on the record: the pre-rebase run here is the best evidence the
guard works, because it caught the bug on the real publish path rather than by
inspection. `gstack`, `openclaw` and `paperclip` failed — the exact three — and
the other four passed, which also confirms `flavor == kit name` holds in
practice for every kit that already declared it:

```
kit=gstack cmd=claude user=agent start-docker= flavor=claude-code
##[error]gstack: image reports flavor 'claude-code', expected 'gstack'. Add:
  LABEL com.docker.sandboxes.flavor="gstack" to gstack/Dockerfile — undeclared,
  the label is inherited from the base image and sbx reports that base's agent
  for this kit.
```

## Choices worth flagging for review

- **CI budget.** On the nightly this is a genuine from-scratch rebuild of all 7
  image kits — the amd64 verification build *and* the amd64+arm64 push build.
  For calibration, the current cached nightly's image jobs run 1–10 minutes
  each; the slowest kit's first-ever build, cold cache and emulated arm64
  included, was 19 minutes. The extra work `no-cache` adds on top of that is one
  more native amd64 pass, so I've raised the image job's `timeout-minutes` from
  45 to 90 — a wide margin rather than a tight estimate, because a job that
  trips its cap leaves the rolling tag quietly not moving. Happy to dial the
  frequency back if the runner minutes aren't worth it, but I don't think a
  nightly that can't pick up a new agent release is worth much either.
- **`workflow_dispatch` deliberately keeps the cache**, even though
  `build-and-publish-kits.yml` otherwise lumps it with `schedule`. A manual run
  is also how you retry a publish that failed on something other than the image,
  and that shouldn't cost an uncached multi-arch rebuild. If you'd rather manual
  runs could force a refresh too, I'd add an optional `no-cache` boolean input to
  the dispatch trigger rather than flip the condition — say the word and I'll
  put it in.
- **The guard compares against the kit directory name.** That's exactly what all
  four kits declaring the label do today, and `spec.yaml` has no flavor field to
  read it from instead. A kit whose agent identifier genuinely differs from its
  directory would need an escape hatch; there isn't one today, and I'd rather add
  it when there's a real case than guess at the shape now.
- **Actions cache pressure, noted not fixed.** The repo's active cache is
  already ~13.6 GB across 150 entries, so entries are being evicted. A fully
  uncached nightly writes fresh blobs from both builds instead of re-importing,
  which makes that worse. Skipping the verification build's `cache-to` on
  `schedule` (where the push build can't read it anyway) would halve it, but the
  expression is fiddly enough that I'd rather it be its own change than ride
  along here.

## Origin

Not a kit change — pipeline only.

## Test plan

The kit-facing boxes below don't apply: this PR touches no kit, no spec and no
Dockerfile, so there's nothing for `kit validate`, the TCK or e2e to say about
it that they wouldn't say about `main`. What I did instead:

- Confirmed `no-cache` is a real input of `docker/build-push-action` at the
  pinned commit (`53b7df9`, v7.3.0) by reading its `action.yml` there.
- Confirmed `github.event_name` reaches this reusable workflow as the caller's
  trigger — the existing `DRY_RUN` expression already depends on that.
- Extracted the verify step's shell, rendered the expressions, and checked it
  under `bash -n`; walked the three cases (label correct → passes; label absent
  → `flavor=(unset)`, fails; label inherited/mismatched → fails with the value
  in the message).
- Checked the guarded `docker inspect` template against real images with no
  labels, with other labels but no `flavor`, and with `flavor` set: empty rather
  than a template abort in the first two, the value in the third.
- `./scripts/check-image-ref.sh docker.io/sbx latest` still passes (7 kits).

- [ ] `sbx kit validate ./<kit>/` passes — n/a, no kit changed
- [ ] `./scripts/test-kit.sh <kit>` passes (the TCK) — n/a, no kit changed
- [ ] `./scripts/test-kit-e2e.sh <kit>` passes — n/a, no kit changed
- [ ] Manual smoke: `sbx run --kit ./<kit>/ <agent>` — n/a, no kit changed

