### PR TITLE
docs(openclaw): add a step-by-step guide and troubleshooting

### DIFF
--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -40,6 +40,125 @@ immediately after the sandbox starts can beat the gateway to it. Wait for
 `~/.openclaw/gateway-ready`, the sentinel the script writes once `/readyz`
 is green (this is what `testdata/tck.yaml` polls as its `readyFile`).
 
+## Step by step
+
+A first run, end to end. The reasoning behind each step is in
+[How auth works](#how-auth-works).
+
+**1. Store the credential before creating the sandbox.** Credential *bindings*
+are wired at create time, so a first one stored later has no effect until a new
+sandbox exists. For an Anthropic API key:
+
+```console
+sbx secret set anthropic
+```
+
+For a Claude subscription token from `claude setup-token`, use the
+`set-custom` form under
+[Barebones sandbox](#barebones-sandbox-no-credential-yet) instead. The two are
+not interchangeable on the wire, and binding both at once puts two auth headers
+on the request.
+
+If the host already holds an anthropic OAuth login — signed in from a `claude`
+sandbox — there is nothing to store: skip to step 2 rather than overwriting it
+with `sbx secret set anthropic`.
+
+**2. Start it.**
+
+```console
+sbx run --kit "docker.io/sbx/openclaw-kit:latest" openclaw
+```
+
+You land in `openclaw chat`. A reply there means the provider credential is
+wired — the TUI runs the agent in-process rather than through the gateway, so
+it is steps 3 and 4 that exercise the gateway and its token.
+
+The remaining steps are host-side `sbx` commands, so run them from a second
+terminal while the TUI holds this one. `<sandbox-name>` below is the name
+`sbx run` reports at start, also listed by `sbx ls`.
+
+**3. Open the Control UI.** Pin the host port to 18789 rather than taking the
+ephemeral one the runtime assigns. On a non-loopback bind openclaw seeds its
+Control UI origin allowlist with the gateway's own port and nothing else, and
+a port-forwarded connection does not count as a local client, so a browser
+arriving on any other port is closed with `origin not allowed`:
+
+```console
+sbx ports <sandbox-name> --publish 18789:18789/tcp
+```
+
+Open `http://127.0.0.1:18789/` and paste the gateway token when asked. Read it
+from the config file once `~/.openclaw/gateway-ready` exists — earlier, the key
+is absent and `jq -r` prints `null`. `openclaw config get gateway.auth.token` is
+not the route — it returns a redaction placeholder rather than the value.
+
+```console
+sbx exec <sandbox-name> -- sh -lc 'jq -r .gateway.auth.token ~/.openclaw/openclaw.json'
+```
+
+**4. Drive it without attaching.**
+
+```console
+sbx exec <sandbox-name> -- openclaw agent --agent main --message "what version are you running"
+```
+
+That runs through the gateway, which holds the provider credential already, so
+the calling shell's environment does not come into it. Embedded commands such
+as `openclaw doctor` do depend on it — see [Debugging](#debugging).
+
+Straight after a start, wait for `~/.openclaw/gateway-ready` first — startup
+commands do not block `sbx exec`, as [Usage](#usage) covers.
+
+**5. Change the credential, or move to a newer kit.** What is fixed at create
+time is the *binding*: going from none to bound, switching shape, or re-running
+`set-custom`, whose `{rand}` placeholder is minted afresh so the running sandbox
+holds a stale one. Kit content is fixed at create time too. Rotating the value
+behind a binding that already exists is a smaller change, but a running sandbox
+can go on serving what it synced at create — if calls still fail after a
+rotation, recreate rather than debug it.
+
+Switching shape means removing the old binding first, or both stay bound and
+the request carries two auth headers — `sbx secret rm anthropic` for the
+service secret, `sbx secret rm -g --host api.anthropic.com` for the custom one.
+Check what `anthropic` holds before removing it: if it is the host's OAuth
+login, that entry is shared with every other sandbox, not just this kit.
+
+Then recreate:
+
+```console
+sbx rm -f <sandbox-name>
+sbx run --kit "docker.io/sbx/openclaw-kit:latest" openclaw
+```
+
+Recreating discards everything living inside the sandbox — the gateway token
+minted on first boot, and any channel tokens configured from within the
+session, which have to be set up again.
+
+This kit never updates openclaw in place. A fresh sandbox boots whatever
+`docker.io/sbx/openclaw-image:latest` holds at create time, and the openclaw
+version in it is bumped deliberately in this kit's `Dockerfile` — see
+[Base image](#base-image). Openclaw's own `openclaw update` does work in there,
+but it leaves the sandbox diverged from the image it booted from.
+
+### Pinning a kit revision
+
+`latest` follows `main`, so it moves. Every build also publishes an immutable
+`<YYYYMMDD>-<sha>` tag resolving to the same digest — pin that to hold a
+sandbox on a known revision of this kit:
+
+```console
+sbx run --kit "docker.io/sbx/openclaw-kit:20260828-4da0c58e0844b8358e0353c020bf7a438e01f8ca" openclaw
+```
+
+That pins **kit content**: the spec, the egress policy, the startup scripts. It
+does not pin the environment they run in. `sandbox.image` is
+`docker.io/sbx/openclaw-image:latest`, a rolling tag, so a new sandbox boots
+whatever that image holds at create time — the `OPENCLAW_VERSION` pinned in the
+`Dockerfile` as of its last rebuild, on a base template that floats by design.
+
+[PUBLISHING.md](../PUBLISHING.md#tags) has the scheme, and why there is no bare
+`<sha>` tag.
+
 ## Published ports
 
 | Port  | Name    | Purpose |
@@ -50,7 +169,8 @@ The sandbox runtime publishes the declared port on an ephemeral host port
 at start time — find it with `sbx ports <sandbox-name>`. If you'd rather
 pin the host port to a fixed value, the classic
 `sbx ports <sandbox-name> --publish 18789:18789/tcp` still works alongside
-the declared ephemeral binding.
+the declared ephemeral binding. The Control UI needs that pin rather than the
+ephemeral port — see [step 3](#step-by-step).
 
 ## How auth works
 
@@ -64,8 +184,10 @@ OpenClaw picks the wire format from the token it holds — a value containing
 headers, anything else as `x-api-key` — and Anthropic rejects either shape sent
 in the wrong header. So the kit's job is to hand it the shape that matches the
 credential the host actually holds. `openclaw-gateway-up.sh` works that out and
-writes it to an env file that the gateway, the TUI (which runs the agent
-in-process, not through the gateway) and `sbx exec` shells all read.
+writes it to an env file that the gateway and the TUI (which runs the agent
+in-process, not through the gateway) both read. A `sbx exec` shell picks it up
+via the `~/.profile` hook, so scripted calls that dispatch in-process need
+`sh -lc`.
 
 | host credential | sandbox receives | wire format |
 |---|---|---|
@@ -100,7 +222,9 @@ To give it a Claude subscription credential, run `claude setup-token` on a
 machine with Claude Code, then:
 
 ```console
-# Required: a service secret would collide, per the note above.
+# Required: a service secret would collide, per the note above. Check what it
+# holds first -- if `anthropic` is the host's OAuth login, this removes it for
+# every sandbox, not just this one.
 sbx secret rm anthropic
 
 # Reads the token from stdin, so it stays out of shell history.
@@ -115,8 +239,8 @@ OAuth-shaped `ANTHROPIC_OAUTH_TOKEN` such as `sk-ant-oat01-c2kjiKGuE9Qcfibj`,
 and the proxy swaps the placeholder for the real token on egress to `--host`.
 For an API key instead, `echo "$ANTHROPIC_API_KEY" | sbx secret set anthropic`.
 
-Either way, **recreate the sandbox** — credentials and kit content are wired at
-create time, so a running sandbox never picks up a newly stored secret.
+Either way, **recreate the sandbox** — credential *bindings* and kit content are
+wired at create time, so a running sandbox never picks up a newly bound secret.
 
 Do not authenticate from inside the sandbox. OpenClaw's own auth commands will
 accept a real credential and write it to the agent's auth store in the
@@ -192,13 +316,24 @@ docker build -t docker.io/sbx/openclaw-image:latest openclaw
 `scripts/test-kit.sh` builds the kit's own image before running the suite
 (`SBX_KIT_SKIP_IMAGE_BUILD=1` to skip and reuse what's already built).
 
+## Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| `No API key found for provider "anthropic"` | No credential bound on the host, or a bound OAuth login whose credential file did not materialize. Check `sbx secret ls` before storing anything. |
+| `authentication_error: API key is invalid` | The credential reached Anthropic in the wrong shape — a subscription token bound as a service secret, a stale service secret still setting `x-api-key`, or a rotated value the running sandbox has not picked up. |
+| `authentication_error: OAuth access token is invalid` | The bearer placeholder went out unswapped: no credential is bound for that host, the host login behind it has expired or been revoked, or `set-custom` was re-run and minted a fresh `{rand}` the running sandbox never saw. |
+| `auth flow failed (exit 1)` after `/auth` | Interactive login needs a TTY the TUI's subprocess does not get. Credentials belong on the host. |
+| `Sandbox image not found: docker/sandbox-templates:shell-docker. Build or pull it first.` | The first-boot pull of the tool-call image has not landed yet. Check `~/.openclaw/sandbox-image-pull.log`. |
+| A newly bound secret changes nothing | Bindings are wired at create time. Create a fresh sandbox. |
+
 ## Debugging
 
 ```console
 sbx exec <sandbox> -- tail -f /home/agent/.openclaw/gateway.log
 sbx exec <sandbox> -- sh /home/agent/.local/bin/openclaw-gateway-up.sh   # idempotent
 sbx exec <sandbox> -- curl -s http://127.0.0.1:18789/healthz
-sbx exec <sandbox> -- openclaw doctor
+sbx exec <sandbox> -- sh -lc 'openclaw doctor'   # login shell: sees the auth env file
 ```
 
 See [`docs/recipe-prebaked-image-kit.md`](../docs/recipe-prebaked-image-kit.md)

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -119,7 +119,7 @@ rotation, recreate rather than debug it.
 
 Switching shape means removing the old binding first, or both stay bound and
 the request carries two auth headers — `sbx secret rm anthropic` for the
-service secret, `sbx secret rm -g --host api.anthropic.com` for the custom one.
+service secret, `sbx secret rm --host api.anthropic.com` for the custom one.
 Check what `anthropic` holds before removing it: if it is the host's OAuth
 login, that entry is shared with every other sandbox, not just this kit.
 

--- a/openclaw/files/home/.local/bin/openclaw-gateway-up.sh
+++ b/openclaw/files/home/.local/bin/openclaw-gateway-up.sh
@@ -112,6 +112,9 @@ fi
 
 # The state has to reach every process that runs the agent: the gateway
 # launched below, the TUI (which runs it in-process), and `sbx exec` shells.
+# The last of those is why the hook goes in ~/.profile -- but `sbx exec` runs
+# `<shell> -c <command>`, a non-login shell, so a scripted call that dispatches
+# in-process only picks this up when it asks for one (`sbx exec -- sh -lc ...`).
 if [ -f "$AUTH_ENV_FILE" ]; then
     . "$AUTH_ENV_FILE"
     if ! grep -qF "$AUTH_ENV_FILE" "$HOME/.profile" 2>/dev/null; then


### PR DESCRIPTION
## Summary

The openclaw README explains the mechanisms but never walks through a first run. I was writing that walkthrough into the OpenClaw docs ([openclaw/openclaw#127099](https://github.com/openclaw/openclaw/pull/127099)), which is the wrong home for it — the kit is owned here, so the operational detail should live here and the docs page should link to it.

Writing it up turned up four things the existing docs got wrong:

- **The Control UI needs the host port pinned to 18789.** On a non-loopback bind openclaw seeds its Control UI origin allowlist with the gateway's own port and nothing else, and a port-forwarded connection is not a local client, so a browser on the ephemeral port is closed with `origin not allowed`.
- **Pinning a kit tag pins kit content, not openclaw** — `sandbox.image` is a rolling `latest` by design.
- **What is fixed at create time is the credential *binding*,** not the value behind it. The old blanket "a running sandbox never picks up a newly stored secret" over-claimed.
- **`sbx exec` runs a non-login shell,** so in-process commands like `openclaw doctor` need `sh -lc` to see the auth env file. The comment in `openclaw-gateway-up.sh` claimed otherwise; corrected.

## Spec choices worth flagging for review

None — no spec change. The only non-docs edit is a comment in `openclaw-gateway-up.sh`, so kit behavior is unchanged.

## Origin

Follow-on from #229, while documenting the kit for the OpenClaw docs.

## Test plan

Docs plus one comment, no behavior change, so the kit test matrix has nothing new to exercise. `sbx` does not run inside a sandbox, so I could not run e2e from here; CI's `kit validate` and TCK cover that this branch does not break the kit.

Claims in the new text were checked against the kit sources and the shipped `openclaw@2026.6.5` package rather than from memory — in particular the origin-allowlist seeding in `gateway-control-ui-origins`, and `checkBrowserOrigin`'s local-client requirement.

- [ ] `sbx kit validate ./openclaw/` — not run (no sbx in sandbox), no spec change
- [ ] `./scripts/test-kit.sh openclaw` — not run, no behavior change
- [ ] `./scripts/test-kit-e2e.sh openclaw` — not run, no behavior change
- [ ] Manual smoke — not applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)