### PR TITLE
feat: add freebuff kit

### DIFF
--- a/freebuff/README.md
+++ b/freebuff/README.md
@@ -1,0 +1,40 @@
+# freebuff
+
+A standalone agent kit for [Freebuff](https://freebuff.com/) — a free AI coding agent accessible through a chat interface. The kit installs `freebuff` via npm globally and drops you into a bash shell with your workspace mounted as the working directory.
+
+## Usage
+
+```console
+cd ~/work/some-project
+sbx run --kit "docker.io/sbx/freebuff-kit:latest" freebuff
+```
+
+Or from a git URL targeting this repo:
+
+```console
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=freebuff" freebuff
+```
+
+Or with a local clone:
+
+```console
+sbx run --kit ./freebuff/ freebuff
+```
+
+The first launch installs Freebuff via npm. Subsequent launches reuse the sandbox with the binary already on `PATH`.
+
+## Network access
+
+The kit allows outbound traffic to:
+
+| Host | Why |
+| --- | --- |
+| `freebuff.com` | Freebuff product domain |
+| `codebuff.com:443` | Codebuff service endpoint |
+| `registry.npmjs.org` | npm registry for installing Freebuff |
+| `*.cloudflarestorage.com` | Cloudflare R2 object storage |
+| `*.s3.amazonaws.com` | AWS S3 object storage |
+
+## Versioning
+
+To update Freebuff, change the install command in `spec.yaml` — for example, pinning to a specific npm package version.

--- a/freebuff/spec.yaml
+++ b/freebuff/spec.yaml
@@ -1,0 +1,37 @@
+schemaVersion: 2
+kind: sandbox
+name: freebuff
+displayName: Freebuff
+description: Freebuff AI coding agent sandbox
+sandbox:
+  image: docker/sandbox-templates:shell-docker
+  entrypoint:
+    - freebuff
+
+agentInstructions:
+  filename: AGENTS.md
+  content: |
+    ## Sandbox environment
+
+    You are running inside a Docker sandbox. The workspace is mounted at
+    its absolute host path. `sudo` is passwordless; use it for package
+    installs.
+
+permissions:
+  network:
+    allow:
+      - freebuff.com
+      - "codebuff.com:443"
+      - registry.npmjs.org
+      - "*.cloudflarestorage.com"
+      - "*.s3.amazonaws.com"
+
+environment:
+  variables:
+    FREEBUFF_CODING_AGENT_DIR: "~"
+
+setup:
+  install:
+    - command: npm install -g freebuff
+      user: 1000
+      description: Install Freebuff


### PR DESCRIPTION
<!--
Thanks for contributing to sbx-kits-contrib!

PRs from forks have CI's `test-kit-e2e` job SKIPPED because GitHub does not
expose `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` to fork-triggered workflows.
The e2e assertions will not run on your PR — your laptop is the only place
they run before merge. See the checklist below.
-->

## Summary
Add Freebuff kit
<!-- What changed and why. -->

## Spec choices worth flagging for review

<!-- Decisions a reviewer should sanity-check: unusual image, deliberately narrow
allowedDomains, workaround for a known bug, etc. -->

## Origin

<!-- Where did the kit come from? One sentence is enough. -->

## Test plan

CI runs `kit validate` and the TCK on every PR. CI does **not** run e2e on
fork PRs (Docker Hub secrets aren't exposed there), so the e2e step below is
required from your side before requesting review.

- [x] `sbx kit validate ./<kit>/` passes
- [x] `./scripts/test-kit.sh <kit>` passes (the TCK)
- [x] `./scripts/test-kit-e2e.sh <kit>` passes. The script applies the same
      `deny-all` baseline CI uses and scopes everything to its own daemon
      (`--app-name sbx-kits-contrib-tck`), so my main sbx state is untouched.
      Every entry I added to `network.allowedDomains` came from
      `sbx --app-name sbx-kits-contrib-tck policy log <tck-e2e-…>`, not a guess.
- [x] Manual smoke: `sbx run --kit ./<kit>/ <agent>` and verified the kit's
      binary / files / env are inside the running container.

One-time setup if you haven't run e2e on this machine before:
`sbx --app-name sbx-kits-contrib-tck login`.

See [CONTRIBUTING.md → Verifying locally](../CONTRIBUTING.md#verifying-locally)
and [README → Declare every domain your kit needs](../README.md#declare-every-domain-your-kit-needs)
for the cross-arch domain gotchas (`archive.ubuntu.com`,
`security.ubuntu.com`, `ports.ubuntu.com`) and the package-manager refresh trap.
