### PR TITLE
fix(e2e): actually reset an already-initialized policy, and keep the script non-interactive

### DIFF
--- a/scripts/test-kit-e2e.sh
+++ b/scripts/test-kit-e2e.sh
@@ -103,7 +103,11 @@ kit_sandbox_prefix="e2e-$(basename "$kit_abs" | tr '[:upper:]_' '[:lower:]-')-"
 # fails ~minutes into the test), but the same probe also catches a dead
 # daemon, KVM access issues, etc. `sbx ls` exercises the runtime and is
 # a no-op when everything is fine, making it safe to run unconditionally.
-probe_err=$(sbx --app-name "$APP_NAME" ls 2>&1 >/dev/null) || {
+# stdin comes from /dev/null so an interactive sbx prompt (e.g. "Docker
+# Sandboxes has been updated and needs to restart. Restart now? (y/N)" after
+# a CLI upgrade) fails the probe with its message instead of waiting on a
+# terminal behind the suppressed output, which looks like a silent hang.
+probe_err=$(sbx --app-name "$APP_NAME" ls 2>&1 >/dev/null </dev/null) || {
   cat >&2 <<EOF
 ERROR: smoke test failed — sbx --app-name $APP_NAME is not usable.
 
@@ -156,10 +160,11 @@ done
 
 # Configure the scoped daemon's global network policy. `policy init` is
 # one-time per daemon (sbx errors with "already initialized" on the second
-# call), so to stay idempotent we try `init` first and fall back to
-# `reset --force` + `init` when a policy is already set — that lands the
-# scoped daemon on the desired baseline regardless of prior state. The
-# `--force` skips the confirmation prompt about stopping running sandboxes
+# call), so to stay idempotent we try `init` first and fall back to a reset
+# when a policy is already set — that lands the scoped daemon on the desired
+# baseline regardless of prior state (a reused local daemon is the normal
+# case; CI runners are always fresh, so the first `init` succeeds there).
+# The `--force` skips the confirmation prompt about stopping running sandboxes
 # (a stale one from a previous failed run was just removed above; a
 # currently-running sandbox here would mean a concurrent invocation, which
 # isn't a supported use of this script). Skipped when POLICY is explicitly
@@ -167,7 +172,25 @@ done
 if [ -n "$POLICY" ]; then
   echo "Initializing --app-name=$APP_NAME global policy to $POLICY"
   if ! sbx --app-name "$APP_NAME" policy init "$POLICY" >/dev/null 2>&1; then
-    sbx --app-name "$APP_NAME" policy init "$POLICY"
+    # `policy reset` wipes the store, restarts the daemon, and then — when its
+    # stdin is a terminal — opens the interactive policy chooser ITSELF, which
+    # is how a reused daemon ended up on allow-all/balanced behind this
+    # script's back. With stdin from /dev/null it skips the chooser and may
+    # exit non-zero complaining the policy is not initialized: that is exactly
+    # the state we want, so its exit code is ignored and the `init` below is
+    # the real check.
+    reset_out=$(sbx --app-name "$APP_NAME" policy reset --force </dev/null 2>&1) || true
+    printf '%s\n' "$reset_out"
+    # `init` sets the preset and prints 'Global network policy initialized to
+    # "<preset>"'. If anything else initialized the policy first, `init` fails
+    # as already initialized, which aborts the run instead of testing under a
+    # baseline we did not ask for.
+    init_out=$(sbx --app-name "$APP_NAME" policy init "$POLICY" </dev/null 2>&1) || {
+      printf '%s\n' "$init_out" >&2
+      echo "ERROR: could not re-initialize the --app-name=$APP_NAME global policy to $POLICY after reset" >&2
+      exit 1
+    }
+    printf '%s\n' "$init_out"
   fi
 fi
 


### PR DESCRIPTION
## Summary

Two small fixes to `scripts/test-kit-e2e.sh`, both hit while running it against a kit on a reused local daemon (macOS arm64, sbx v0.39.0).

1. **The "already initialized" fallback never reset.** The comment says the script falls back to a reset when the scoped daemon's global policy is already initialized, but the code just ran `policy init` a second time, so every run after the first failed with:

   ```
   Initializing --app-name=sbx-kits-contrib-tck global policy to deny-all
   ERROR: global network policy is already initialized; use "sbx policy reset" first to change it
   ```

   CI never sees this because runners are fresh.

   A plain `policy reset --force` + `policy init` is not enough on a terminal. `policy reset` wipes the store, restarts the daemon and then, when its stdin is a terminal, runs the interactive policy chooser **itself** (v0.39.0, from the CLI binary: `policyResetCmd → runPolicyReset → startDaemon → ensurePolicyDefaults`, gated on `isInteractiveTerminal` = isatty on stdin). That chooser initialized the policy to allow-all/balanced behind the script's back, and `init` then failed as already initialized. Seen on the host, three variants (`init`; `daemon start --detach --policy`; `init` with its own stdio detached), same result each time:

   ```
   ✓ Daemon stopped successfully
   ✓ Policies reset.
   Initialize the global network policy for your sandboxes:
     ❯  1. Open  2. Balanced  3. Locked Down
   Network policy set to "Open". ...
   ERROR: global network policy is already initialized; use "sbx policy reset" first to change it
   ```

   The fix runs the **reset** with stdin from `/dev/null`, so the chooser is skipped (the reset may then exit non-zero complaining the policy is not initialized, which is exactly the state we want, so its exit code is ignored). `policy init` is exempt from the chooser (`skipsAuthPreflight → isPolicyInitCommand`) and sets the preset, printing `Global network policy initialized to "deny-all"`; its exit code is the check, so if anything initialized the policy first the script aborts instead of continuing under a baseline it did not ask for. Stale sandboxes are already removed earlier in the script, so the reset stops nothing that matters.

2. **Smoke probe could hang silently.** `sbx ls` runs with its output captured. After a CLI upgrade sbx asks `Docker Sandboxes has been updated and needs to restart. Restart now? (y/N)` on that call; the prompt was hidden behind the suppressed output and waited on the terminal, which looks like the script doing nothing. With `</dev/null` the probe fails and the script prints the message.

## Test plan

- [x] `shellcheck scripts/test-kit-e2e.sh` clean
- [x] Before the change, on a daemon initialized by an earlier run: `./scripts/test-kit-e2e.sh pulumi` fails with the error above; `POLICY= ./scripts/test-kit-e2e.sh pulumi` (skip the step) passes. So the step, not the kit, was the failure.
- [x] Intermediate variants (`reset --force` + `init`; `reset --force` + `daemon start --detach --policy`; `reset --force` + `init` with init's stdio detached): all reproduce the chooser + "already initialized" failure quoted above, which is what pinned the chooser to the reset command.
- [x] After the change, on a daemon previously initialized to "Balanced" by the chooser: `./scripts/test-kit-e2e.sh glab` → `✓ Policies reset.`, the reset's one-line "Run 'sbx policy init ...'" note, `Global network policy initialized to "deny-all".`, no chooser, then `TestE2EKit/glab` PASS (9.3s) under deny-all. macOS arm64, sbx v0.39.0.
