### PR TITLE
Add re_gent kit

### DIFF
--- a/re-gent/README.md
+++ b/re-gent/README.md
@@ -24,68 +24,39 @@ ship `jq`.
 
 ## Usage
 
-The kit installs the CLI by default and does nothing else. Pass
-`re-gent.hooks=claude` to also wire the capture hooks, which is what makes
-`rgt log` actually fill up:
+The kit is opinionated: installing it gets you the CLI, an initialized
+`.regent/` store, and Claude Code capture hooks, all unconditionally — no
+flags to set.
 
 ```console
-sbx run claude --kit "docker.io/sbx/re-gent-kit:latest" --kit-arg re-gent.hooks=claude .
+sbx run claude --kit "docker.io/sbx/re-gent-kit:latest" .
 ```
 
 Or target this repo over git:
 
 ```console
-sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=re-gent" --kit-arg re-gent.hooks=claude .
+sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=re-gent" .
 ```
 
 For local development:
 
 ```console
-sbx run claude --kit ./re-gent/ --kit-arg re-gent.hooks=claude .
+sbx run claude --kit ./re-gent/ .
 ```
 
-Install-only, leaving your repository untouched:
-
-```console
-sbx run claude --kit "docker.io/sbx/re-gent-kit:latest" --kit-arg re-gent.init=false .
-```
-
-`hooks` needs a store to capture into, so `hooks=claude` with `init=false`
-wires nothing unless the workspace already has a `.regent/` from an earlier
-run. Pair `init=false` with the default `hooks=none`.
-
-`--kit-arg` and `--kit-args-file` are experimental flags. A `--kit-arg` no kit
-declares is rejected, so a typo fails loudly instead of silently installing the
-default.
-
-## Arguments
-
-| Argument | Values | Default | Effect |
-| --- | --- | --- | --- |
-| `init` | `true`, `false` | `true` | Create the `.regent/` store in the workspace when it is absent, and add it to `.git/info/exclude`. |
-| `hooks` | `none`, `claude` | `none` | Wire re_gent capture hooks into `<workspace>/.claude/settings.json`. |
-
-Both accept the unscoped form too (`--kit-arg hooks=claude`), which applies to
-every kit that declares an argument of that name.
-
-### Why the defaults differ
-
-`init` defaults to **on**: creating `.regent/` is local, needs no network, and
-`rm -rf .regent` fully reverses it.
+There is no way to opt out of init or hook wiring short of not using the kit.
+An earlier revision offered both as kit arguments, but v2's `args:` block
+isn't supported by any shipped `sbx` release yet — `sbx` v0.39.0 rejects a
+spec.yaml that declares one outright at load, with `field args not found in
+type spec.specFileV2`. Configurability is off the table until that ships.
 
 One thing worth knowing, because it is easy to misread: `rgt` *does* write a
-`.gitignore`, but it lives **inside** `.regent/` and only covers `*.backup` and
-`log/`. It does not ignore `.regent/` itself — a fresh `rgt init` leaves
+`.gitignore`, but it lives **inside** `.regent/` and only covers `*.backup`
+and `log/`. It does not ignore `.regent/` itself — a fresh `rgt init` leaves
 `?? .regent/` in `git status`, so a `git add -A` would commit your prompt and
 conversation history. The kit therefore adds `.regent/` to the repository's
 `.git/info/exclude`, which is per-clone and never committed, in preference to
 editing a tracked `.gitignore`.
-
-`hooks` defaults to **off**: wiring hooks edits `.claude/settings.json`, a file
-that is normally committed, and changes what happens on every agent turn. Under
-a direct-mount workspace (the default) that file is the real one in your
-repository on the host, not a copy. Opting in should be a decision you make,
-not a side effect of adding a kit.
 
 ## How the install works
 
@@ -171,20 +142,24 @@ genuinely empty, which takes the same path for the same reason.
 
 ## Agent support
 
-No `requires.agent` affinity is declared. The `rgt` CLI is agent-agnostic —
-`log`, `blame`, and `show` work regardless of which agent produced the history —
-so pinning the mixin to one agent would block legitimate use. Only hook wiring
-is agent-specific, and the `hooks` argument selects that.
+The kit declares `requires.agent: claude` — composing it onto a different base
+agent is a composition error rather than a silently useless sandbox. That
+affinity exists because hook wiring is unconditional and Claude-specific (it
+writes `.claude/settings.json`); composed onto, say, a `codex` sandbox it would
+create a stray `.claude/` directory nothing reads. The `rgt` CLI itself is
+agent-agnostic — `log`, `blame`, and `show` work regardless of which agent
+produced the history — the affinity is purely about the hook-wiring half.
 
 Upstream also supports Codex (`.codex/config.toml`), OpenCode (an npm plugin),
 and Pi (a git-sourced extension). This kit implements Claude Code only: the
 other two pull from `registry.npmjs.org` and `github.com` at wiring time, which
-would widen the kit's network contract for agents it isn't otherwise set up
-for. `hooks` is an enum so those can be added later without changing its shape.
+would widen the kit's network contract, and — now that behavior can't be
+gated by an argument — there'd be no way to install `rgt` for one of those
+agents without also taking on that egress.
 
 ## What lands in your repository
 
-With the defaults plus `hooks=claude`, inside the workspace:
+Inside the workspace:
 
 - `.regent/` — the object store, SQLite index, and refs. Added to
   `.git/info/exclude` by the kit, so it stays out of `git status` and out of
@@ -211,13 +186,11 @@ then remove the three `rgt` entries from `.claude/settings.json` (or restore
 `.claude/settings.json.re-gent-backup` if the kit made one), and drop the
 `.regent/` line from `.git/info/exclude`.
 
-**Removing the hooks is a manual step on purpose.** The kit never unwires
-hooks, not even when `hooks=none` — and since `none` is the default, doing so
-would mean every sandbox that merely installs the CLI strips hooks a user
-deliberately configured with `rgt init`. The cost of that choice is that hooks
-left in a committed `.claude/settings.json` will fail on any machine where
-`rgt` isn't installed, including your host. Remove them when you're done, or
-keep them out of the commit.
+**Removing the hooks is a manual step.** The kit never unwires them itself —
+there's no code path for it, since wiring is unconditional. Hooks left in a
+committed `.claude/settings.json` will fail on any machine where `rgt` isn't
+installed, including your host. Remove them when you're done, or keep them out
+of the commit.
 
 ## Upstream status
 

--- a/re-gent/README.md
+++ b/re-gent/README.md
@@ -25,8 +25,8 @@ ship `jq`.
 ## Usage
 
 The kit is opinionated: installing it gets you the CLI, an initialized
-`.regent/` store, and Claude Code capture hooks, all unconditionally — no
-flags to set.
+`.regent/` store, and capture hooks wired for whichever agent the sandbox
+runs — no flags to set.
 
 ```console
 sbx run claude --kit "docker.io/sbx/re-gent-kit:latest" .
@@ -74,7 +74,7 @@ which release it came from, so the pinned tarball digest is what establishes
 the version. The trailing `rgt version` call is a liveness check — "Install
 commands completed" only ever means the commands exited 0.
 
-## How hook wiring works
+## How Claude Code hook wiring works
 
 `rgt init` cannot do this unattended. Its hook-configuration step always opens
 an interactive multi-select, even when `--agent claude` is passed — the flag
@@ -142,20 +142,59 @@ genuinely empty, which takes the same path for the same reason.
 
 ## Agent support
 
-The kit declares `requires.agent: claude` — composing it onto a different base
-agent is a composition error rather than a silently useless sandbox. That
-affinity exists because hook wiring is unconditional and Claude-specific (it
-writes `.claude/settings.json`); composed onto, say, a `codex` sandbox it would
-create a stray `.claude/` directory nothing reads. The `rgt` CLI itself is
-agent-agnostic — `log`, `blame`, and `show` work regardless of which agent
-produced the history — the affinity is purely about the hook-wiring half.
+One mixin, not one per agent. No `requires.agent` affinity is declared; instead
+the setup script detects the agent at container start and wires that agent's
+hooks. There is no authoritative in-container signal for "which agent is this
+sandbox", so detection is a probe rather than a lookup: the agent binary on
+`PATH` is treated as authoritative, and a config directory (`.claude/`,
+`.codex/`, …) is consulted only as a fallback when no agent binary is found.
 
-Upstream also supports Codex (`.codex/config.toml`), OpenCode (an npm plugin),
-and Pi (a git-sourced extension). This kit implements Claude Code only: the
-other two pull from `registry.npmjs.org` and `github.com` at wiring time, which
-would widen the kit's network contract, and — now that behavior can't be
-gated by an argument — there'd be no way to install `rgt` for one of those
-agents without also taking on that egress.
+That is deliberately stricter than upstream's `rgt init --agent auto`, which
+weighs a project-level config directory equally. Plenty of repositories commit
+a `.claude/` directory while being worked on from a Codex sandbox — this one
+does — and treating that as "Claude is the agent" would merge rgt hooks into a
+tracked `settings.json` the running agent never reads.
+
+When more than one agent binary is present, every one this kit supports gets
+wired, matching upstream's `auto` behaviour. A sandbox normally has exactly
+one; the alternative — guessing a single winner — risks silently wiring nothing
+for the agent actually driving the session.
+
+| Agent | Capture wiring | Written to |
+| --- | --- | --- |
+| Claude Code | yes | `.claude/settings.json` |
+| Codex | yes | `.codex/config.toml` |
+| OpenCode | no — detected, reported | — |
+| Pi | no — detected, reported | — |
+
+OpenCode and Pi are deliberately left unwired. Both need network *at wiring
+time* — an npm plugin install and a git-sourced `pi install` respectively —
+which would add `registry.npmjs.org` to this kit's declared egress for every
+user, including the majority who never touch either agent, and both shell out
+to tooling whose failure modes are outside this script. The kit says so
+explicitly at startup rather than silently doing nothing, and points at
+`rgt init`, which wires them properly in a terminal.
+
+On any agent it can't wire, the CLI is still installed and the store still
+created — `rgt log`/`blame`/`show` remain useful against a store populated
+another way, since the CLI itself is agent-agnostic.
+
+### How Codex wiring works
+
+Codex needs `[features] hooks = true` plus four events (`SessionStart`,
+`UserPromptSubmit`, `PostToolUse`, `Stop`) pointing at `rgt codex-hook`.
+
+The kit appends that as new TOML tables rather than parsing and rewriting the
+file. There is no `jq` for TOML, and Python's `tomllib` is parse-only with no
+stdlib writer, so a read-modify-write would mean hand-rolling an emitter and
+re-emitting the user's whole config from a parsed model — silently dropping
+their comments and formatting, and risking mangled values. Appending a new
+`[table]` header to valid TOML is safe and touches nothing already there.
+
+The trade-off: it cannot *merge* into a config that already declares `[hooks]`
+or `[features]`, because a second such table is a duplicate-table error. That
+case refuses loudly and leaves the file untouched, pointing at `rgt init` for a
+real parse-and-merge. In a fresh sandbox the file usually doesn't exist at all.
 
 ## What lands in your repository
 
@@ -164,7 +203,8 @@ Inside the workspace:
 - `.regent/` — the object store, SQLite index, and refs. Added to
   `.git/info/exclude` by the kit, so it stays out of `git status` and out of
   your commits without touching a tracked file.
-- `.claude/settings.json` — merged, not replaced.
+- `.claude/settings.json` (Claude) — merged, not replaced.
+- `.codex/config.toml` (Codex) — appended to, never rewritten.
 - `.git/info/exclude` — an appended `.regent/` line, plus
   `.claude/settings.json.re-gent-backup` if a backup was ever taken. Not
   committed.

--- a/re-gent/README.md
+++ b/re-gent/README.md
@@ -1,0 +1,233 @@
+# re_gent
+
+Installs [re_gent](https://github.com/regent-vcs/re_gent) — content-addressed
+version control for **AI agent activity** — into a sandbox, from a pinned,
+SHA256-verified GitHub release.
+
+re_gent runs alongside git rather than instead of it. Git records human intent;
+re_gent records what the agent did, as a chain of content-addressed *steps*
+holding the tool call, its arguments and result, a workspace tree snapshot, and
+the surrounding conversation. You then ask it questions git can't answer:
+
+```console
+rgt log                       # step history for the session
+rgt blame src/server.go:42    # which prompt produced this line
+rgt show <step-hash>          # the full step: diff, tool call, conversation
+rgt sessions                  # every recorded session
+```
+
+The CLI binary is `rgt`. Everything is local: re_gent has no server, no
+account, no telemetry, and needs no credentials. At runtime the kit makes no
+network requests at all — the only egress is the one-shot release download at
+install time, plus an Ubuntu `apt` fetch on the rare image that doesn't already
+ship `jq`.
+
+## Usage
+
+The kit installs the CLI by default and does nothing else. Pass
+`re-gent.hooks=claude` to also wire the capture hooks, which is what makes
+`rgt log` actually fill up:
+
+```console
+sbx run claude --kit "docker.io/sbx/re-gent-kit:latest" --kit-arg re-gent.hooks=claude .
+```
+
+Or target this repo over git:
+
+```console
+sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=re-gent" --kit-arg re-gent.hooks=claude .
+```
+
+For local development:
+
+```console
+sbx run claude --kit ./re-gent/ --kit-arg re-gent.hooks=claude .
+```
+
+Install-only, leaving your repository untouched:
+
+```console
+sbx run claude --kit "docker.io/sbx/re-gent-kit:latest" --kit-arg re-gent.init=false .
+```
+
+`hooks` needs a store to capture into, so `hooks=claude` with `init=false`
+wires nothing unless the workspace already has a `.regent/` from an earlier
+run. Pair `init=false` with the default `hooks=none`.
+
+`--kit-arg` and `--kit-args-file` are experimental flags. A `--kit-arg` no kit
+declares is rejected, so a typo fails loudly instead of silently installing the
+default.
+
+## Arguments
+
+| Argument | Values | Default | Effect |
+| --- | --- | --- | --- |
+| `init` | `true`, `false` | `true` | Create the `.regent/` store in the workspace when it is absent, and add it to `.git/info/exclude`. |
+| `hooks` | `none`, `claude` | `none` | Wire re_gent capture hooks into `<workspace>/.claude/settings.json`. |
+
+Both accept the unscoped form too (`--kit-arg hooks=claude`), which applies to
+every kit that declares an argument of that name.
+
+### Why the defaults differ
+
+`init` defaults to **on**: creating `.regent/` is local, needs no network, and
+`rm -rf .regent` fully reverses it.
+
+One thing worth knowing, because it is easy to misread: `rgt` *does* write a
+`.gitignore`, but it lives **inside** `.regent/` and only covers `*.backup` and
+`log/`. It does not ignore `.regent/` itself — a fresh `rgt init` leaves
+`?? .regent/` in `git status`, so a `git add -A` would commit your prompt and
+conversation history. The kit therefore adds `.regent/` to the repository's
+`.git/info/exclude`, which is per-clone and never committed, in preference to
+editing a tracked `.gitignore`.
+
+`hooks` defaults to **off**: wiring hooks edits `.claude/settings.json`, a file
+that is normally committed, and changes what happens on every agent turn. Under
+a direct-mount workspace (the default) that file is the real one in your
+repository on the host, not a copy. Opting in should be a decision you make,
+not a side effect of adding a kit.
+
+## How the install works
+
+Pinned to v1.1.0 by version **and** per-architecture SHA256, both recorded in
+`spec.yaml`. The kit deliberately does not query `api.github.com` for
+`releases/latest`: unauthenticated calls from shared CI runner IPs hit the
+60-request/hour rate limit and 403, which makes installs flaky, and a pinned
+digest is the better supply-chain story anyway. To bump the version, change
+`RGT_VERSION` and both SHA256 values from the release's `checksums.txt`.
+
+The presence guard (`command -v rgt`) is deliberately *not* version-aware: the
+shipped v1.1.0 binary reports `re_gent version dev (commit: unknown)`, because
+the upstream ldflags fix landed after the tag was cut. The binary cannot say
+which release it came from, so the pinned tarball digest is what establishes
+the version. The trailing `rgt version` call is a liveness check — "Install
+commands completed" only ever means the commands exited 0.
+
+## How hook wiring works
+
+`rgt init` cannot do this unattended. Its hook-configuration step always opens
+an interactive multi-select, even when `--agent claude` is passed — the flag
+only narrows the list of options, it does not skip the prompt. Without a TTY it
+prints a warning, **exits 0, and configures nothing**, so any automation that
+shells out to it appears to succeed while doing nothing. Driving it through a
+pseudo-terminal just blocks on keystrokes.
+
+So the kit does the merge itself, with `jq`, in
+`files/home/.local/share/re-gent/claude-hooks.jq`. It mirrors what
+`installClaudeHook` does upstream:
+
+| Event | Command |
+| --- | --- |
+| `UserPromptSubmit` | `rgt message-hook user` |
+| `Stop` | `rgt message-hook assistant` |
+| `PostToolBatch` | `rgt tool-batch-hook` |
+
+and strips re_gent's own legacy `PostToolUse` entries, as upstream does. The
+merge is additive and idempotent: your existing hooks and every other key in
+`settings.json` are preserved, `rgt`-owned entries are replaced rather than
+duplicated on each restart, and a `settings.json` that isn't valid JSON is
+copied to `settings.json.re-gent-backup` rather than overwritten.
+
+Because this mirrors upstream rather than calling it, it can drift if re_gent
+changes its hook layout. The events above are the contract to re-check when
+bumping `RGT_VERSION`.
+
+Wiring needs `jq`. It ships in the sandbox templates this kit targets, so the
+install step that provides it is guarded by `command -v jq` and normally does
+nothing; on an image without it, the kit installs it from Ubuntu's archive
+(which is why the apt hosts appear in the allowlist). If `jq` is somehow still
+unavailable at startup the script reports `jq or the hook filter is
+unavailable; not wiring hooks` and leaves `settings.json` untouched.
+
+Two shapes of `settings.json` make the merge bail out rather than guess: one
+that isn't valid JSON at all (backed up to `settings.json.re-gent-backup`,
+which the kit also adds to `.git/info/exclude`), and one that is valid JSON but
+isn't an object — `false`, `[1,2]` — or whose `hooks` value can't be indexed.
+In the second case the file is left exactly as it was, with a
+`failed to merge hooks` note and no backup. Neither case aborts the sandbox
+start.
+
+## First start under `--clone`
+
+Kit startup commands run *before* the workspace is populated in `--clone` mode —
+the clone itself is a later, system-level startup command. Creating `.regent/`
+at that point would leave `git clone` a non-empty target and abort the sandbox
+start, so the setup script **skips while the workspace is empty** and reports
+`workspace is empty (clone pending, or nothing there yet); skipping until next
+start`.
+
+Startup commands re-run on every container start, so the store and hooks appear
+on the next one. There is no `sbx start`; stop-then-run is the supported restart
+cycle:
+
+```console
+sbx stop <sandbox-name>
+sbx run --name <sandbox-name>
+```
+
+In direct-mount mode (the default) the workspace is already populated on the
+first start, so this does not apply — unless the directory you mounted is
+genuinely empty, which takes the same path for the same reason.
+
+## Agent support
+
+No `requires.agent` affinity is declared. The `rgt` CLI is agent-agnostic —
+`log`, `blame`, and `show` work regardless of which agent produced the history —
+so pinning the mixin to one agent would block legitimate use. Only hook wiring
+is agent-specific, and the `hooks` argument selects that.
+
+Upstream also supports Codex (`.codex/config.toml`), OpenCode (an npm plugin),
+and Pi (a git-sourced extension). This kit implements Claude Code only: the
+other two pull from `registry.npmjs.org` and `github.com` at wiring time, which
+would widen the kit's network contract for agents it isn't otherwise set up
+for. `hooks` is an enum so those can be added later without changing its shape.
+
+## What lands in your repository
+
+With the defaults plus `hooks=claude`, inside the workspace:
+
+- `.regent/` — the object store, SQLite index, and refs. Added to
+  `.git/info/exclude` by the kit, so it stays out of `git status` and out of
+  your commits without touching a tracked file.
+- `.claude/settings.json` — merged, not replaced.
+- `.git/info/exclude` — an appended `.regent/` line, plus
+  `.claude/settings.json.re-gent-backup` if a backup was ever taken. Not
+  committed.
+
+`.regent/` holds your prompts and the assistant's replies as plain data on
+disk. The exclude entry is local to the clone, so if you copy the working tree
+somewhere it doesn't follow, treat `.regent/` as session data.
+
+## Cleanup
+
+Nothing is created on the host outside the workspace, and the kit installs no
+host-side state. To undo it inside a workspace:
+
+```console
+rm -rf .regent
+```
+
+then remove the three `rgt` entries from `.claude/settings.json` (or restore
+`.claude/settings.json.re-gent-backup` if the kit made one), and drop the
+`.regent/` line from `.git/info/exclude`.
+
+**Removing the hooks is a manual step on purpose.** The kit never unwires
+hooks, not even when `hooks=none` — and since `none` is the default, doing so
+would mean every sandbox that merely installs the CLI strips hooks a user
+deliberately configured with `rgt init`. The cost of that choice is that hooks
+left in a committed `.claude/settings.json` will fail on any machine where
+`rgt` isn't installed, including your host. Remove them when you're done, or
+keep them out of the commit.
+
+## Upstream status
+
+re_gent is Apache-2.0, real and working, but early: v1.1.0 is the current
+release and the public repository has been quiet since mid-2026. The kit pins a
+specific release precisely so upstream's pace doesn't change what a sandbox
+gets. `rgt rewind`, `rgt fork`, and `rgt diff` appear in upstream's roadmap and
+skill files but are **not** implemented in v1.1.0.
+
+Note that upstream's Go module path is still `github.com/regent-vcs/regent`
+even though the repository is now `re_gent`, so `go install
+github.com/regent-vcs/re_gent/cmd/rgt@latest` fails. The kit installs a release
+binary and is unaffected.

--- a/re-gent/files/home/.local/share/re-gent/claude-hooks.jq
+++ b/re-gent/files/home/.local/share/re-gent/claude-hooks.jq
@@ -1,0 +1,100 @@
+# Mirror of re_gent's installClaudeHook merge, in jq.
+#
+# Upstream equivalents, for re-checking when RGT_VERSION is bumped:
+#   capture.IsRegentCommand  -> is_rgt_cmd
+#   normalizeHookGroups      -> norm_groups
+#   normalizeHookArray       -> norm_entries
+#   filterRegentHookCommands -> clean_group / keep_group
+#   hookGroup                -> new_group
+
+# Does this command string belong to re_gent? Mirrors IsRegentCommand: skip
+# leading VAR=value assignments, then match the basename of the first real
+# field against rgt/regent, or a `go run ... cmd/rgt` invocation.
+#
+# Matching upstream's breadth matters: a narrower rule (e.g. plain
+# `startswith("rgt ")`) misses `/usr/local/bin/rgt message-hook assistant`,
+# which `rgt init` itself can write, and the entry would then survive the
+# filter and get a duplicate appended on every container start.
+def is_rgt_cmd:
+  ((. | strings) // "") as $c
+  # \\s+, not [ \t]+: upstream uses strings.Fields, which splits on all
+  # whitespace, so a command carrying a newline must still be recognized.
+  | ($c | [splits("\\s+")] | map(select(length > 0))) as $fields
+  | ($fields
+     | until(length == 0
+             or ((.[0] | contains("=")) | not)
+             or (.[0] | startswith("="));
+             .[1:])) as $f
+  | if ($f | length) == 0 then false
+    else
+      (($f[0] | split("/") | last | ltrimstr("./")) as $first
+       | $first == "rgt"
+         or $first == "regent"
+         or (($f | length) >= 3
+             and $f[0] == "go"
+             and $f[1] == "run"
+             and ($f[2] | contains("cmd/rgt"))))
+    end;
+
+# A string becomes a single command group; a lone object becomes a
+# one-element list; an array passes through.
+def norm_groups:
+  if   type == "array"  then .
+  elif type == "string" then [{matcher: "", hooks: [{type: "command", command: .}]}]
+  elif type == "object" then [.]
+  elif . == null        then []
+  else [.] end;
+
+# A group's "hooks" may be a bare object rather than an array. null means the
+# key is absent, which the caller must distinguish from an empty list.
+def norm_entries:
+  if   type == "array"  then .
+  elif . == null        then null
+  elif type == "object" then [.]
+  else [.] end;
+
+# Drop rgt-owned entries from each group. A group with no "hooks" key is
+# passed through untouched, exactly as upstream does.
+def clean_group:
+  if type != "object" then .
+  else
+    (.hooks | norm_entries) as $entries
+    | if $entries == null then .
+      else .hooks = ($entries | map(select(
+             # Only objects can be rgt entries. Non-objects are passed
+             # through, as upstream does: `.command?` on a string yields
+             # `empty`, which would make `select` drop the entry entirely and
+             # silently delete it from the user's real settings.json.
+             if type == "object" then ((.command? | is_rgt_cmd) | not) else true end
+           )))
+      end
+  end;
+
+# A group that *had* a hooks array and is now empty is dropped; a group that
+# never had one is kept.
+def keep_group:
+  (type != "object") or ((.hooks | type) != "array") or ((.hooks | length) > 0);
+
+# hookGroup: upstream sets matcher to the empty string. Omitting it would make
+# settings.json flip between two shapes if the user ever also runs `rgt init`.
+def new_group($cmd):
+  {matcher: "", hooks: [{type: "command", command: $cmd}]};
+
+def merge_hook($event; $cmd):
+  # Bind the surviving groups BEFORE reassigning .hooks: inside a
+  # `(.hooks // {}) | ...` pipe the identity rebinds to the hooks object, so
+  # an inner `.hooks[$event]` would read the wrong level and silently drop
+  # the user's existing hooks for this event.
+  (((.hooks // {})[$event]) | norm_groups | map(clean_group) | map(select(keep_group))) as $kept
+  | .hooks = ((.hooks // {}) | .[$event] = ($kept + [new_group($cmd)]));
+
+# removeRegentHookCommands: strip rgt entries, delete the event if nothing left.
+def remove_hook($event):
+  (((.hooks // {})[$event]) | norm_groups | map(clean_group) | map(select(keep_group))) as $kept
+  | .hooks = ((.hooks // {}) | .[$event] = $kept)
+  | if ($kept | length) == 0 then (.hooks |= del(.[$event])) else . end;
+
+merge_hook("UserPromptSubmit"; "rgt message-hook user")
+| merge_hook("Stop"; "rgt message-hook assistant")
+| merge_hook("PostToolBatch"; "rgt tool-batch-hook")
+| remove_hook("PostToolUse")

--- a/re-gent/spec.yaml
+++ b/re-gent/spec.yaml
@@ -5,7 +5,8 @@ displayName: re_gent
 description: >-
   Installs the re_gent CLI (`rgt`), content-addressed version control for AI
   agent activity, from a pinned GitHub release. Creates the `.regent/` store
-  in the workspace and wires Claude Code capture hooks unconditionally.
+  in the workspace and wires capture hooks for the detected agent (Claude
+  Code or Codex).
 sourceURL: https://github.com/regent-vcs/re_gent
 licenses:
   - Apache-2.0
@@ -16,7 +17,7 @@ licenses:
 # displayName and throughout the docs.
 
 # This kit is deliberately opinionated rather than configurable: installing
-# it means you get init + Claude hook wiring, no flags. An earlier revision
+# it means you get init + capture wiring, no flags. An earlier revision
 # offered both as `args:`-gated options, but v2's `args:` block is not
 # supported by any shipped `sbx` release yet (confirmed: `sbx` v0.39.0 rejects
 # a spec.yaml with `args:` at load with "field args not found in type
@@ -24,15 +25,18 @@ licenses:
 # design is unusable today regardless of preference. Revisit once a stable
 # release supports `args:`.
 
-requires:
-  agent: claude
-
-# The `rgt` CLI itself is agent-agnostic — log/blame/show work regardless of
-# which agent produced the history — but hook wiring below is Claude-specific
-# (it writes .claude/settings.json) and, with no args to gate it, now always
-# runs. Composing this onto a non-Claude sandbox would silently create a
-# stray .claude/ directory there, so the affinity turns that into a
-# composition error instead.
+# No `requires.agent` affinity: the kit adapts to whatever agent it is layered
+# onto instead of pinning one. The setup script detects the agent at container
+# start and wires only that agent's hooks. That keeps this a single mixin
+# rather than one per agent, and keeps the `rgt` CLI — which is genuinely
+# agent-agnostic — usable everywhere, including on a base agent whose hook
+# format nothing here writes.
+#
+# There is no authoritative in-container signal for "which agent is this
+# sandbox", so detection is necessarily a probe. It is close to, but
+# deliberately stricter than, upstream's `rgt init --agent auto`: see the
+# detection block in the setup script for why a config directory alone is not
+# treated as evidence when an agent binary is present.
 
 agentInstructions:
   content: |
@@ -52,12 +56,18 @@ agentInstructions:
     | `rgt sessions` | List sessions (`--format json`) |
     | `rgt status` | Current repository state |
 
-    Two things worth knowing before you use it:
+    Three things worth knowing before you use it:
 
+    - **Capture is wired for the agent this sandbox runs.** The kit detects
+      the agent at start and wires Claude Code (`.claude/settings.json`) or
+      Codex (`.codex/config.toml`). On OpenCode or Pi it installs `rgt` and
+      creates the store but does **not** wire capture — `rgt log` stays empty
+      there, and that is expected, not a bug. `rgt status` tells you where
+      you stand.
     - **On a `--clone` sandbox, nothing is set up on the first start.** This
       kit's setup runs before the clone populates the workspace, so it skips
       that round and takes effect on the next container start. If there is no
-      `.regent/` at all, and no hooks in `.claude/settings.json`, that is why
+      `.regent/` at all, and no hooks in your agent's config, that is why
       — ask the user to restart the sandbox (`sbx stop <name>` then
       `sbx run --name <name>`) rather than trying to run `rgt init` yourself.
     - **`rgt init` needs a TTY and will not work from a tool call.** Its hook
@@ -97,9 +107,11 @@ permissions:
       - ports.ubuntu.com
       - download.docker.com
       # No runtime egress. re_gent is fully offline: the CLI imports no HTTP
-      # client at all and never contacts a server. `rgt init` can shell out to
-      # npm (OpenCode plugin) or git (Pi extension), but this kit never selects
-      # those agents, so neither host is declared here.
+      # client at all and never contacts a server. Wiring OpenCode would need
+      # registry.npmjs.org (its plugin is an npm package) and Pi would need a
+      # git fetch for its extension — the setup script detects both agents but
+      # deliberately does not wire them, precisely so neither host has to be
+      # declared here for every user of this kit.
 
 setup:
   install:
@@ -149,9 +161,10 @@ setup:
       description: Install re_gent CLI v1.1.0, version+digest pinned
 
     # SPEC-v2 §9.3: jq is not part of the tool floor, so a kit that needs it
-    # must install it. The hook merge needs it; nothing else here does. On the
-    # sandbox templates this kit targets jq is already present, so the guard
-    # makes the common path perform no package I/O at all.
+    # must install it. The Claude hook merge needs it; the Codex path is pure
+    # shell append and needs nothing. On the sandbox templates this kit targets
+    # jq is already present, so the guard makes the common path perform no
+    # package I/O at all.
     #
     # git is also outside the floor and deliberately NOT installed: it is used
     # only to add .regent/ to the repository's exclude file, and a workspace
@@ -166,7 +179,7 @@ setup:
         apt-get install -y --no-install-recommends jq
         jq --version
       user: "0"
-      description: Ensure jq is available for hook merging (no-op when jq is already present)
+      description: Ensure jq is available for Claude hook merging (no-op when jq is already present)
 
   files:
     # The workspace path is only available as ${WORKDIR} inside setup.files
@@ -261,42 +274,172 @@ setup:
           exit 0
         fi
 
-        if ! command -v jq >/dev/null 2>&1 || [ ! -f "$JQ_FILTER" ]; then
-          note "jq or the hook filter is unavailable; not wiring hooks"
-          exit 0
+        # Claude Code: merge the three hook events into .claude/settings.json.
+        wire_claude() {
+          if ! command -v jq >/dev/null 2>&1 || [ ! -f "$JQ_FILTER" ]; then
+            note "claude detected but jq or the hook filter is unavailable; not wiring"
+            return 1
+          fi
+
+          settings="$WORKSPACE/.claude/settings.json"
+          mkdir -p "$WORKSPACE/.claude"
+
+          # An absent or blank settings file is just an empty object, not a
+          # parse failure — upstream treats it the same way and makes no backup.
+          if [ ! -s "$settings" ] || [ -z "$(tr -d '[:space:]' < "$settings")" ]; then
+            echo '{}' > "$settings"
+          # `jq empty` reports whether the input PARSES. `jq -e .` would report
+          # the truthiness of the parsed value instead, so a settings file
+          # holding `null` or `false` would be misfiled as corrupt and
+          # needlessly backed up.
+          elif ! jq empty "$settings" >/dev/null 2>&1; then
+            cp "$settings" "$settings.re-gent-backup"
+            # The backup lands in the user's repository, so keep it out of git
+            # for the same reason .regent/ is kept out.
+            git_exclude '.claude/settings.json.re-gent-backup'
+            note "existing settings.json was invalid JSON; backed up to $settings.re-gent-backup"
+            echo '{}' > "$settings"
+          fi
+
+          tmp="$settings.re-gent-tmp"
+          if jq -f "$JQ_FILTER" "$settings" > "$tmp" 2>/dev/null && [ -s "$tmp" ]; then
+            mv "$tmp" "$settings"
+            note "Claude Code capture hooks wired in $settings"
+            return 0
+          fi
+          rm -f "$tmp"
+          note "failed to merge hooks into $settings; left unchanged"
+          return 1
+        }
+
+        # Codex: .codex/config.toml needs `[features] hooks = true` plus four
+        # events pointing at `rgt codex-hook`.
+        #
+        # Deliberately append-only, with no TOML parser. There is no jq for
+        # TOML, and python3's tomllib is parse-only (no stdlib writer), so a
+        # read-modify-write would mean hand-rolling an emitter and re-emitting
+        # the user's whole config from a parsed model — which silently drops
+        # their comments and formatting and can mangle exotic values. Appending
+        # new top-level tables to a valid TOML file is safe (a `[table]` header
+        # ends the previous one) and touches nothing that was already there.
+        #
+        # The cost is that this cannot MERGE into a config that already has a
+        # [hooks] or [features] table — appending a second one is a duplicate-
+        # table error. That case refuses loudly instead of guessing, and points
+        # at `rgt init`, which does a real parse-and-merge.
+        wire_codex() {
+          config="$WORKSPACE/.codex/config.toml"
+
+          # Idempotency first: our own block makes the conflict patterns below
+          # match, so re-running would otherwise refuse on every restart.
+          if [ -f "$config" ] && grep -q 'rgt codex-hook' "$config"; then
+            return 0
+          fi
+
+          # Deliberately broad. Catches table headers in every spelling TOML
+          # allows — [hooks], [ features ], [hooks.Stop], [[hooks]] (array of
+          # tables), ["hooks"] (quoted key) — and key forms including dotted
+          # keys (features.hooks = true, hooks.SessionStart = [...]). Any of
+          # them would collide with the tables appended below, and a duplicate
+          # definition invalidates the user's whole config; over-refusing costs
+          # nothing but a message, under-refusing corrupts the file while
+          # reporting success.
+          if [ -s "$config" ] && grep -qE '^[[:space:]]*\[{1,2}[[:space:]]*"?(hooks|features)("?[][:space:].]|"?$)|^[[:space:]]*(hooks|features)[[:space:]]*[.=]' "$config"; then
+            note "codex config already defines [hooks] or [features]; not merging — run 'rgt init' in a terminal to wire it"
+            return 1
+          fi
+
+          # Created only now, once the refusals above have passed: a refusal
+          # must not leave a stray .codex/ behind in a workspace whose agent
+          # isn't Codex.
+          if ! mkdir -p "$WORKSPACE/.codex"; then
+            note "could not create $WORKSPACE/.codex; not wiring codex hooks"
+            return 1
+          fi
+
+          # Same trailing-newline hazard as the git exclude file: without this
+          # the [features] header would splice onto the user's last line.
+          if [ -s "$config" ] && [ -n "$(tail -c 1 "$config")" ]; then
+            printf '\n' >> "$config"
+          fi
+
+          # The write is checked rather than assumed — an unwritable path would
+          # otherwise print "wired" having appended nothing.
+          if ! {
+            printf '\n# Added by the re-gent sandbox kit.\n'
+            printf '[features]\nhooks = true\n\n'
+            printf '[hooks]\n'
+            for event in SessionStart UserPromptSubmit PostToolUse Stop; do
+              printf '%s = [{ matcher = "", hooks = [{ type = "command", command = "rgt codex-hook" }] }]\n' "$event"
+            done
+          } >> "$config"; then
+            note "failed to write $config; codex hooks not wired"
+            return 1
+          fi
+          note "Codex capture hooks wired in $config"
+          return 0
+        }
+
+        # Which agent is this sandbox running?
+        #
+        # The binary on PATH is the authoritative signal: a sandbox template
+        # installs the agent it is for, so if any agent binary is present, that
+        # is the answer and directory probes are ignored entirely.
+        #
+        # That ordering matters. Upstream's `rgt init --agent auto` treats a
+        # project-level `.claude/` (or `.codex/`, ...) directory as equal
+        # evidence, but plenty of repositories commit a `.claude/` directory
+        # while being worked on from a Codex sandbox — this repository is one.
+        # Treating that as "Claude is the agent" would merge rgt hooks into a
+        # tracked settings.json that the running agent never reads. So the
+        # directory probe is only a fallback for an image where no agent binary
+        # is on PATH under its own name.
+        agents=""
+        for candidate in claude codex opencode pi; do
+          if command -v "$candidate" >/dev/null 2>&1; then
+            agents="$agents $candidate"
+          fi
+        done
+        if [ -z "$agents" ]; then
+          for candidate in claude codex opencode pi; do
+            # ${HOME:-} rather than $HOME: `set -u` turns an unset HOME into
+            # an abort, which would break this script's fail-soft contract.
+            if [ -d "$WORKSPACE/.$candidate" ] || { [ -n "${HOME:-}" ] && [ -d "$HOME/.$candidate" ]; }; then
+              agents="$agents $candidate"
+            fi
+          done
         fi
 
-        SETTINGS="$WORKSPACE/.claude/settings.json"
-        mkdir -p "$WORKSPACE/.claude"
+        wired=0
+        detected=0
 
-        # An absent or blank settings file is just an empty object, not a
-        # parse failure — upstream treats it the same way and makes no backup.
-        if [ ! -s "$SETTINGS" ] || [ -z "$(tr -d '[:space:]' < "$SETTINGS")" ]; then
-          echo '{}' > "$SETTINGS"
-        # `jq empty` reports whether the input PARSES. `jq -e .` would report
-        # the truthiness of the parsed value instead, so a settings file
-        # holding `null` or `false` would be misfiled as corrupt and needlessly
-        # backed up.
-        elif ! jq empty "$SETTINGS" >/dev/null 2>&1; then
-          cp "$SETTINGS" "$SETTINGS.re-gent-backup"
-          # The backup lands in the user's repository, so keep it out of git
-          # for the same reason .regent/ is kept out.
-          git_exclude '.claude/settings.json.re-gent-backup'
-          note "existing settings.json was invalid JSON; backed up to $SETTINGS.re-gent-backup"
-          echo '{}' > "$SETTINGS"
-        fi
+        for agent in $agents; do
+          detected=1
+          case "$agent" in
+            claude) wire_claude && wired=1 ;;
+            codex)  wire_codex  && wired=1 ;;
+            # OpenCode and Pi are detected but deliberately not wired. Both
+            # need network at wiring time — an npm plugin install and a
+            # git-sourced `pi install` respectively — which would widen this
+            # kit's declared egress for every user including those who never
+            # touch either agent, and both shell out to tooling whose failure
+            # modes are outside this script. Say so rather than silently
+            # doing nothing.
+            *) note "$agent detected, but this kit does not wire its capture hooks — run 'rgt init' in a terminal to set it up" ;;
+          esac
+        done
 
-        TMP="$SETTINGS.re-gent-tmp"
-        if jq -f "$JQ_FILTER" "$SETTINGS" > "$TMP" 2>/dev/null && [ -s "$TMP" ]; then
-          mv "$TMP" "$SETTINGS"
-          note "Claude Code capture hooks wired in $SETTINGS"
-        else
-          rm -f "$TMP"
-          note "failed to merge hooks into $SETTINGS; left unchanged"
+        # Distinguish "found nothing" from "found something and could not wire
+        # it": the second already printed its own reason above, and claiming
+        # nothing was detected would contradict it.
+        if [ "$wired" -eq 0 ] && [ "$detected" -eq 0 ]; then
+          note "no supported agent detected; rgt is installed and the store is ready, but nothing is capturing"
+        elif [ "$wired" -eq 0 ]; then
+          note "capture is not wired (see above); rgt is installed and the store is ready"
         fi
       description: re_gent setup wrapper, with the workspace path baked in at sandbox start
 
   startup:
     - command: ["/home/agent/.local/bin/re-gent-setup.sh"]
       user: "1000"
-      description: Initialize the .regent store and wire Claude Code capture hooks
+      description: Initialize the .regent store and wire capture hooks for the detected agent

--- a/re-gent/spec.yaml
+++ b/re-gent/spec.yaml
@@ -4,9 +4,8 @@ name: re-gent
 displayName: re_gent
 description: >-
   Installs the re_gent CLI (`rgt`), content-addressed version control for AI
-  agent activity, from a pinned GitHub release. Optionally creates the
-  `.regent/` store in the workspace and wires Claude Code capture hooks, both
-  controlled by kit arguments.
+  agent activity, from a pinned GitHub release. Creates the `.regent/` store
+  in the workspace and wires Claude Code capture hooks unconditionally.
 sourceURL: https://github.com/regent-vcs/re_gent
 licenses:
   - Apache-2.0
@@ -16,32 +15,24 @@ licenses:
 # underscores. The upstream project's own spelling is preserved in
 # displayName and throughout the docs.
 
-args:
-  init:
-    default: "true"
-    enum: ["true", "false"]
-    description: >-
-      Create the .regent/ store in the workspace on container start when it is
-      absent, and exclude it from git locally. Local-only and no network, so it
-      is on by default.
-  hooks:
-    default: "none"
-    enum: ["none", "claude"]
-    description: >-
-      Wire re_gent capture hooks into the workspace agent config. Off by
-      default because it edits a file that is normally committed to the user's
-      repository and changes agent behaviour on every turn. Set to `claude` to
-      capture Claude Code sessions. Requires a store, so `claude` together with
-      `init: "false"` wires nothing unless a .regent/ already exists.
+# This kit is deliberately opinionated rather than configurable: installing
+# it means you get init + Claude hook wiring, no flags. An earlier revision
+# offered both as `args:`-gated options, but v2's `args:` block is not
+# supported by any shipped `sbx` release yet (confirmed: `sbx` v0.39.0 rejects
+# a spec.yaml with `args:` at load with "field args not found in type
+# spec.specFileV2"; only the rolling nightly build parses it) — an args-based
+# design is unusable today regardless of preference. Revisit once a stable
+# release supports `args:`.
 
-# No `requires.agent` affinity is declared, for two reasons. The `rgt` CLI is
-# agent-agnostic — log/blame/show work regardless of which agent produced the
-# history — so an affinity would block legitimate use. And a
-# `${{ kit.args.* }}` placeholder cannot be used there anyway: argument
-# substitution happens in the consumer, while `requires.agent` is pattern-
-# validated against the raw spec.yaml, so the placeholder itself fails
-# validation. The agent-specific part of this kit is hook wiring, and the
-# `hooks` argument is what selects it.
+requires:
+  agent: claude
+
+# The `rgt` CLI itself is agent-agnostic — log/blame/show work regardless of
+# which agent produced the history — but hook wiring below is Claude-specific
+# (it writes .claude/settings.json) and, with no args to gate it, now always
+# runs. Composing this onto a non-Claude sandbox would silently create a
+# stray .claude/ directory there, so the affinity turns that into a
+# composition error instead.
 
 agentInstructions:
   content: |
@@ -61,25 +52,21 @@ agentInstructions:
     | `rgt sessions` | List sessions (`--format json`) |
     | `rgt status` | Current repository state |
 
-    Three things worth knowing before you use it:
+    Two things worth knowing before you use it:
 
-    - **Capture only happens if hooks are wired.** They are wired only when
-      this kit was created with `--kit-arg re-gent.hooks=claude`. Without
-      that, `.regent/` exists but stays empty and `rgt log` shows nothing —
-      that is expected, not a bug. Check with `rgt status`.
     - **On a `--clone` sandbox, nothing is set up on the first start.** This
       kit's setup runs before the clone populates the workspace, so it skips
       that round and takes effect on the next container start. If there is no
-      `.regent/` at all, that is why — ask the user to restart the sandbox
-      (`sbx stop <name>` then `sbx run --name <name>`) rather than trying to
-      run `rgt init` yourself.
+      `.regent/` at all, and no hooks in `.claude/settings.json`, that is why
+      — ask the user to restart the sandbox (`sbx stop <name>` then
+      `sbx run --name <name>`) rather than trying to run `rgt init` yourself.
     - **`rgt init` needs a TTY and will not work from a tool call.** Its hook
-      configuration step always opens an interactive multi-select, even with
-      `--agent` given, and it exits 0 after printing a warning when there is
-      no TTY. So running it non-interactively appears to succeed while
-      configuring nothing. If hooks need setting up, ask the user to run
-      `rgt init` in a terminal, or recreate the sandbox with
-      `--kit-arg re-gent.hooks=claude`.
+      configuration step always opens an interactive multi-select and exits 0
+      after printing a warning when there is no TTY, without configuring
+      anything. This kit already wires hooks another way, so you should never
+      need to run `rgt init` yourself — if `.regent/` or the hooks are ever
+      missing outside the `--clone` case above, that is a bug in this kit, not
+      something to fix by running `rgt init`.
 
     `.regent/` holds your prompts and the assistant's replies in plain form on
     disk. re_gent does **not** gitignore it — the `.gitignore` it writes lives
@@ -166,14 +153,6 @@ setup:
     # sandbox templates this kit targets jq is already present, so the guard
     # makes the common path perform no package I/O at all.
     #
-    # Deliberately NOT also gated on `hooks != none`: a `${{ kit.args.* }}`
-    # placeholder is substituted by the consumer, not by the spec library, so
-    # in any context that runs the raw spec.yaml — the TCK, which gates CI —
-    # the literal `${{ ... }}` reaches `sh -c` and dies with "Bad
-    # substitution". Placeholders belong in setup.files content, which is
-    # written rather than executed. The cost is installing jq on a jq-less
-    # image even when hooks=none, which is cheap and harmless.
-    #
     # git is also outside the floor and deliberately NOT installed: it is used
     # only to add .regent/ to the repository's exclude file, and a workspace
     # with no git is a workspace with no repository to keep the store out of.
@@ -192,10 +171,9 @@ setup:
   files:
     # The workspace path is only available as ${WORKDIR} inside setup.files
     # content — it is not substituted in `path`, and not available to startup
-    # commands at all. So the argument values and the workspace path are baked
-    # into a wrapper script here (under the agent home, never under the
-    # workspace, which setup.files may not target), and the startup command
-    # below just runs it.
+    # commands at all. So it is baked into a wrapper script here (under the
+    # agent home, never under the workspace, which setup.files may not
+    # target), and the startup command below just runs it.
     - path: /home/agent/.local/bin/re-gent-setup.sh
       mode: "0755"
       content: |
@@ -206,8 +184,6 @@ setup:
         set -u
 
         WORKSPACE="${WORKDIR}"
-        DO_INIT="${{ kit.args.init }}"
-        HOOKS="${{ kit.args.hooks }}"
         JQ_FILTER=/home/agent/.local/share/re-gent/claude-hooks.jq
 
         note() { echo "re_gent: $1"; }
@@ -236,8 +212,6 @@ setup:
           note "excluded $1 from git via $exclude"
         }
 
-        [ "$DO_INIT" = "true" ] || [ "$HOOKS" != "none" ] || exit 0
-
         if ! command -v rgt >/dev/null 2>&1; then
           note "rgt is not on PATH; skipping setup"
           exit 0
@@ -256,7 +230,7 @@ setup:
           exit 0
         fi
 
-        if [ "$DO_INIT" = "true" ] && [ ! -d "$WORKSPACE/.regent" ]; then
+        if [ ! -d "$WORKSPACE/.regent" ]; then
           # --skip-hook --skip-skills is what makes this non-interactive:
           # both of the steps it skips prompt on a TTY that does not exist
           # here. Hook wiring is done below instead.
@@ -277,12 +251,12 @@ setup:
           git_exclude '.regent/'
         fi
 
-        [ "$HOOKS" = "claude" ] || exit 0
-
         # Wiring hooks without a store would make every agent turn invoke rgt
-        # against a repository that does not exist.
+        # against a repository that does not exist. Reachable only if the
+        # `rgt init` call above failed after creating the directory partway,
+        # or was interrupted — the normal path always has a store here.
         if [ ! -d "$WORKSPACE/.regent" ]; then
-          note "no .regent store; not wiring hooks (re-create with re-gent.init=true)"
+          note "no .regent store; not wiring hooks"
           exit 0
         fi
 
@@ -319,9 +293,9 @@ setup:
           rm -f "$TMP"
           note "failed to merge hooks into $SETTINGS; left unchanged"
         fi
-      description: re_gent setup wrapper, with the workspace path and kit arguments baked in at sandbox start
+      description: re_gent setup wrapper, with the workspace path baked in at sandbox start
 
   startup:
     - command: ["/home/agent/.local/bin/re-gent-setup.sh"]
       user: "1000"
-      description: Initialize the .regent store and wire capture hooks, per the kit's arguments
+      description: Initialize the .regent store and wire Claude Code capture hooks

--- a/re-gent/spec.yaml
+++ b/re-gent/spec.yaml
@@ -1,0 +1,327 @@
+schemaVersion: "2"
+kind: mixin
+name: re-gent
+displayName: re_gent
+description: >-
+  Installs the re_gent CLI (`rgt`), content-addressed version control for AI
+  agent activity, from a pinned GitHub release. Optionally creates the
+  `.regent/` store in the workspace and wires Claude Code capture hooks, both
+  controlled by kit arguments.
+sourceURL: https://github.com/regent-vcs/re_gent
+licenses:
+  - Apache-2.0
+
+# The kit name is `re-gent`, not `re_gent`: kit names are constrained to
+# ^[a-z0-9]([a-z0-9-]{0,62}[a-z0-9])?$, which admits hyphens but not
+# underscores. The upstream project's own spelling is preserved in
+# displayName and throughout the docs.
+
+args:
+  init:
+    default: "true"
+    enum: ["true", "false"]
+    description: >-
+      Create the .regent/ store in the workspace on container start when it is
+      absent, and exclude it from git locally. Local-only and no network, so it
+      is on by default.
+  hooks:
+    default: "none"
+    enum: ["none", "claude"]
+    description: >-
+      Wire re_gent capture hooks into the workspace agent config. Off by
+      default because it edits a file that is normally committed to the user's
+      repository and changes agent behaviour on every turn. Set to `claude` to
+      capture Claude Code sessions. Requires a store, so `claude` together with
+      `init: "false"` wires nothing unless a .regent/ already exists.
+
+# No `requires.agent` affinity is declared, for two reasons. The `rgt` CLI is
+# agent-agnostic — log/blame/show work regardless of which agent produced the
+# history — so an affinity would block legitimate use. And a
+# `${{ kit.args.* }}` placeholder cannot be used there anyway: argument
+# substitution happens in the consumer, while `requires.agent` is pattern-
+# validated against the raw spec.yaml, so the placeholder itself fails
+# validation. The agent-specific part of this kit is hook wiring, and the
+# `hooks` argument is what selects it.
+
+agentInstructions:
+  content: |
+    ## re_gent — version control for agent activity
+
+    The `rgt` CLI is installed and on `PATH`. re_gent records *your* activity
+    as a chain of content-addressed steps in `.regent/`, alongside git rather
+    than instead of it: git tracks human intent, re_gent tracks agent actions.
+
+    Query it with:
+
+    | Command | Purpose |
+    | --- | --- |
+    | `rgt log` | Step history. `--session`, `-n`, `--json`, `--graph` |
+    | `rgt blame <path>[:<line>]` | Which prompt and step produced a line |
+    | `rgt show <step-hash>` | Full step: diff, tool call, conversation |
+    | `rgt sessions` | List sessions (`--format json`) |
+    | `rgt status` | Current repository state |
+
+    Three things worth knowing before you use it:
+
+    - **Capture only happens if hooks are wired.** They are wired only when
+      this kit was created with `--kit-arg re-gent.hooks=claude`. Without
+      that, `.regent/` exists but stays empty and `rgt log` shows nothing —
+      that is expected, not a bug. Check with `rgt status`.
+    - **On a `--clone` sandbox, nothing is set up on the first start.** This
+      kit's setup runs before the clone populates the workspace, so it skips
+      that round and takes effect on the next container start. If there is no
+      `.regent/` at all, that is why — ask the user to restart the sandbox
+      (`sbx stop <name>` then `sbx run --name <name>`) rather than trying to
+      run `rgt init` yourself.
+    - **`rgt init` needs a TTY and will not work from a tool call.** Its hook
+      configuration step always opens an interactive multi-select, even with
+      `--agent` given, and it exits 0 after printing a warning when there is
+      no TTY. So running it non-interactively appears to succeed while
+      configuring nothing. If hooks need setting up, ask the user to run
+      `rgt init` in a terminal, or recreate the sandbox with
+      `--kit-arg re-gent.hooks=claude`.
+
+    `.regent/` holds your prompts and the assistant's replies in plain form on
+    disk. re_gent does **not** gitignore it — the `.gitignore` it writes lives
+    *inside* `.regent/` and only covers `*.backup` and `log/` — so this kit
+    adds `.regent/` to the repository's `.git/info/exclude` instead. That is
+    local to the clone and is never committed. If you copy the working tree
+    somewhere that exclude file doesn't follow, treat `.regent/` as session
+    data and don't commit it.
+
+permissions:
+  network:
+    allow:
+      # Release tarball download (install time, one-shot).
+      # github.com 302-redirects to objects.githubusercontent.com for binary
+      # downloads; release-assets.githubusercontent.com is kept alongside it
+      # since that isn't guaranteed to be the same host for every repo/asset.
+      - github.com
+      - objects.githubusercontent.com
+      - release-assets.githubusercontent.com
+      # Reached only by the conditional jq install above, and only on an image
+      # that does not already ship jq — which the sandbox templates this kit
+      # targets do, so in practice these stay unused. Ubuntu serves
+      # amd64 from archive/security and arm64 from ports, and `apt-get update`
+      # refreshes every configured source, so download.docker.com (added by the
+      # *-docker templates) has to be here too or the update exits non-zero.
+      - archive.ubuntu.com
+      - security.ubuntu.com
+      - ports.ubuntu.com
+      - download.docker.com
+      # No runtime egress. re_gent is fully offline: the CLI imports no HTTP
+      # client at all and never contacts a server. `rgt init` can shell out to
+      # npm (OpenCode plugin) or git (Pi extension), but this kit never selects
+      # those agents, so neither host is declared here.
+
+setup:
+  install:
+    # Install `rgt` from a pinned, SHA256-verified GitHub release. We
+    # deliberately do NOT query api.github.com for `releases/latest`:
+    # unauthenticated API calls from shared CI runner IPs hit the 60-req/hr
+    # rate limit and 403, making installs flaky. Pinning by version + SHA256
+    # (in the kit, in git) is also the safer supply chain. To bump: change
+    # RGT_VERSION plus the per-arch SHA256 below, sourced from the release's
+    # checksums.txt.
+    #
+    # The guard is presence-only rather than version-aware because the shipped
+    # v1.1.0 binary reports `re_gent version dev (commit: unknown)` — the
+    # ldflags fix landed after the tag was cut, so the binary cannot report
+    # which release it came from. The pinned tarball digest is what actually
+    # establishes the version; the `rgt version` call at the end is a liveness
+    # check, since "Install commands completed" only means exit 0.
+    - command: |
+        set -euo pipefail
+        if command -v rgt >/dev/null 2>&1; then
+          echo "rgt already present at $(command -v rgt); skipping install"
+          exit 0
+        fi
+        RGT_VERSION=1.1.0
+        ARCH=$(dpkg --print-architecture)
+        case "$ARCH" in
+          amd64)
+            TARBALL="re_gent_${RGT_VERSION}_linux_amd64.tar.gz"
+            SHA256="88a44730756db0055617dacdce47922e06aadfb768d599868938eb6b6df0b254"
+            ;;
+          arm64)
+            TARBALL="re_gent_${RGT_VERSION}_linux_arm64.tar.gz"
+            SHA256="2dd718d85dc7934824f3a5496e259cb84a0fb53a66def28ecd507728ae658def"
+            ;;
+          *)
+            echo "unsupported sandbox arch: $ARCH (expected amd64 or arm64)" >&2
+            exit 1
+            ;;
+        esac
+        URL="https://github.com/regent-vcs/re_gent/releases/download/v${RGT_VERSION}/${TARBALL}"
+        curl --proto '=https' --tlsv1.2 -fsSL -o /tmp/rgt.tgz "$URL"
+        echo "${SHA256}  /tmp/rgt.tgz" | sha256sum -c -
+        tar -C /usr/local/bin -xzf /tmp/rgt.tgz rgt
+        rm /tmp/rgt.tgz
+        rgt version
+      user: "0"
+      description: Install re_gent CLI v1.1.0, version+digest pinned
+
+    # SPEC-v2 §9.3: jq is not part of the tool floor, so a kit that needs it
+    # must install it. The hook merge needs it; nothing else here does. On the
+    # sandbox templates this kit targets jq is already present, so the guard
+    # makes the common path perform no package I/O at all.
+    #
+    # Deliberately NOT also gated on `hooks != none`: a `${{ kit.args.* }}`
+    # placeholder is substituted by the consumer, not by the spec library, so
+    # in any context that runs the raw spec.yaml — the TCK, which gates CI —
+    # the literal `${{ ... }}` reaches `sh -c` and dies with "Bad
+    # substitution". Placeholders belong in setup.files content, which is
+    # written rather than executed. The cost is installing jq on a jq-less
+    # image even when hooks=none, which is cheap and harmless.
+    #
+    # git is also outside the floor and deliberately NOT installed: it is used
+    # only to add .regent/ to the repository's exclude file, and a workspace
+    # with no git is a workspace with no repository to keep the store out of.
+    - command: |
+        set -euo pipefail
+        if command -v jq >/dev/null 2>&1; then
+          exit 0
+        fi
+        echo "jq is required to merge Claude Code hooks and is missing; installing"
+        apt-get update -qq
+        apt-get install -y --no-install-recommends jq
+        jq --version
+      user: "0"
+      description: Ensure jq is available for hook merging (no-op when jq is already present)
+
+  files:
+    # The workspace path is only available as ${WORKDIR} inside setup.files
+    # content — it is not substituted in `path`, and not available to startup
+    # commands at all. So the argument values and the workspace path are baked
+    # into a wrapper script here (under the agent home, never under the
+    # workspace, which setup.files may not target), and the startup command
+    # below just runs it.
+    - path: /home/agent/.local/bin/re-gent-setup.sh
+      mode: "0755"
+      content: |
+        #!/bin/sh
+        # Runs on EVERY container start, so every step below is idempotent.
+        # Fails soft: a broken re_gent setup must never stop the sandbox from
+        # starting, so problems are reported and the script still exits 0.
+        set -u
+
+        WORKSPACE="${WORKDIR}"
+        DO_INIT="${{ kit.args.init }}"
+        HOOKS="${{ kit.args.hooks }}"
+        JQ_FILTER=/home/agent/.local/share/re-gent/claude-hooks.jq
+
+        note() { echo "re_gent: $1"; }
+
+        # Append a pattern to the repository's exclude file, once. Uses
+        # --git-common-dir, not --absolute-git-dir: in a linked worktree the
+        # latter points at .git/worktrees/<name>/, which git does NOT read
+        # excludes from, so the pattern would have no effect while the grep
+        # guard kept matching the wrong file and never self-corrected.
+        git_exclude() {
+          command -v git >/dev/null 2>&1 || return 0
+          gitdir=$(cd "$WORKSPACE" && git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 0
+          [ -n "$gitdir" ] || return 0
+          exclude="$gitdir/info/exclude"
+          if [ -f "$exclude" ] && grep -qxF "$1" "$exclude"; then
+            return 0
+          fi
+          mkdir -p "$gitdir/info"
+          # An exclude file not ending in a newline would otherwise splice our
+          # entry onto the user's last rule ("*.log" + ".regent/" becomes
+          # "*.log.regent/"), breaking both.
+          if [ -s "$exclude" ] && [ -n "$(tail -c 1 "$exclude")" ]; then
+            printf '\n' >> "$exclude"
+          fi
+          printf '%s\n' "$1" >> "$exclude"
+          note "excluded $1 from git via $exclude"
+        }
+
+        [ "$DO_INIT" = "true" ] || [ "$HOOKS" != "none" ] || exit 0
+
+        if ! command -v rgt >/dev/null 2>&1; then
+          note "rgt is not on PATH; skipping setup"
+          exit 0
+        fi
+
+        # Startup commands run BEFORE the workspace is populated in --clone
+        # mode (the git clone is a later, system-level startup command). An
+        # empty workspace therefore means "clone still pending", and writing
+        # .regent/ into it now would leave git clone a non-empty target and
+        # abort the start. Skip; the next container start finds it populated.
+        if [ ! -d "$WORKSPACE" ] || [ -z "$(ls -A "$WORKSPACE" 2>/dev/null)" ]; then
+          # Also reached by a genuinely empty direct-mount workspace, where
+          # there is simply nothing to record yet — same handling, and the next
+          # start picks it up once the directory has content.
+          note "workspace is empty (clone pending, or nothing there yet); skipping until next start"
+          exit 0
+        fi
+
+        if [ "$DO_INIT" = "true" ] && [ ! -d "$WORKSPACE/.regent" ]; then
+          # --skip-hook --skip-skills is what makes this non-interactive:
+          # both of the steps it skips prompt on a TTY that does not exist
+          # here. Hook wiring is done below instead.
+          if (cd "$WORKSPACE" && rgt init --skip-hook --skip-skills) >/dev/null 2>&1; then
+            note "initialized $WORKSPACE/.regent"
+          else
+            note "rgt init failed; run it yourself in a terminal"
+            exit 0
+          fi
+        fi
+
+        # rgt writes a .gitignore INSIDE .regent/ that only covers *.backup
+        # and log/ — it does not ignore .regent/ itself, so `git add -A` would
+        # commit the prompt and conversation history. Exclude it through
+        # .git/info/exclude, which is per-clone and never committed, rather
+        # than editing the repository's tracked .gitignore.
+        if [ -d "$WORKSPACE/.regent" ]; then
+          git_exclude '.regent/'
+        fi
+
+        [ "$HOOKS" = "claude" ] || exit 0
+
+        # Wiring hooks without a store would make every agent turn invoke rgt
+        # against a repository that does not exist.
+        if [ ! -d "$WORKSPACE/.regent" ]; then
+          note "no .regent store; not wiring hooks (re-create with re-gent.init=true)"
+          exit 0
+        fi
+
+        if ! command -v jq >/dev/null 2>&1 || [ ! -f "$JQ_FILTER" ]; then
+          note "jq or the hook filter is unavailable; not wiring hooks"
+          exit 0
+        fi
+
+        SETTINGS="$WORKSPACE/.claude/settings.json"
+        mkdir -p "$WORKSPACE/.claude"
+
+        # An absent or blank settings file is just an empty object, not a
+        # parse failure — upstream treats it the same way and makes no backup.
+        if [ ! -s "$SETTINGS" ] || [ -z "$(tr -d '[:space:]' < "$SETTINGS")" ]; then
+          echo '{}' > "$SETTINGS"
+        # `jq empty` reports whether the input PARSES. `jq -e .` would report
+        # the truthiness of the parsed value instead, so a settings file
+        # holding `null` or `false` would be misfiled as corrupt and needlessly
+        # backed up.
+        elif ! jq empty "$SETTINGS" >/dev/null 2>&1; then
+          cp "$SETTINGS" "$SETTINGS.re-gent-backup"
+          # The backup lands in the user's repository, so keep it out of git
+          # for the same reason .regent/ is kept out.
+          git_exclude '.claude/settings.json.re-gent-backup'
+          note "existing settings.json was invalid JSON; backed up to $SETTINGS.re-gent-backup"
+          echo '{}' > "$SETTINGS"
+        fi
+
+        TMP="$SETTINGS.re-gent-tmp"
+        if jq -f "$JQ_FILTER" "$SETTINGS" > "$TMP" 2>/dev/null && [ -s "$TMP" ]; then
+          mv "$TMP" "$SETTINGS"
+          note "Claude Code capture hooks wired in $SETTINGS"
+        else
+          rm -f "$TMP"
+          note "failed to merge hooks into $SETTINGS; left unchanged"
+        fi
+      description: re_gent setup wrapper, with the workspace path and kit arguments baked in at sandbox start
+
+  startup:
+    - command: ["/home/agent/.local/bin/re-gent-setup.sh"]
+      user: "1000"
+      description: Initialize the .regent store and wire capture hooks, per the kit's arguments

--- a/re-gent/spec.yaml
+++ b/re-gent/spec.yaml
@@ -252,9 +252,10 @@ setup:
         fi
 
         # Wiring hooks without a store would make every agent turn invoke rgt
-        # against a repository that does not exist. Reachable only if the
-        # `rgt init` call above failed after creating the directory partway,
-        # or was interrupted — the normal path always has a store here.
+        # against a repository that does not exist. Every path above either
+        # already exits (rgt init failed) or leaves .regent/ in place, so this
+        # never actually trips today — kept as a guard against that invariant
+        # breaking under a future edit, not because it's reachable now.
         if [ ! -d "$WORKSPACE/.regent" ]; then
           note "no .regent store; not wiring hooks"
           exit 0

--- a/re-gent/spec.yaml
+++ b/re-gent/spec.yaml
@@ -402,9 +402,16 @@ setup:
         done
         if [ -z "$agents" ]; then
           for candidate in claude codex opencode pi; do
-            # ${HOME:-} rather than $HOME: `set -u` turns an unset HOME into
+            # The agent home is spelled literally rather than read from the
+            # HOME variable, for two reasons. Under `set -u` an unset HOME is
             # an abort, which would break this script's fail-soft contract.
-            if [ -d "$WORKSPACE/.$candidate" ] || { [ -n "${HOME:-}" ] && [ -d "$HOME/.$candidate" ]; }; then
+            # And the usual brace-with-default guard for that is unavailable
+            # here: sbx rejects every placeholder except WORKDIR in
+            # setup.files content, and it scans the text rather than parsing
+            # shell, so even naming one inside a comment fails kit resolution.
+            # SPEC-v2 §9.1 guarantees the agent user's home is /home/agent, so
+            # the literal is both safe and more portable than the variable.
+            if [ -d "$WORKSPACE/.$candidate" ] || [ -d "/home/agent/.$candidate" ]; then
               agents="$agents $candidate"
             fi
           done


### PR DESCRIPTION
## Summary

Adds a `re-gent` mixin for [re_gent](https://github.com/regent-vcs/re_gent) — content-addressed version control for **AI agent activity**. It runs alongside git rather than instead of it: git records human intent, re_gent records what the agent did, so you can ask `rgt blame src/server.go:42` which prompt produced a line, or `rgt show <hash>` for the conversation behind a change.

The kit installs the `rgt` CLI from a pinned, SHA256-verified v1.1.0 release. It's deliberately opinionated: installing it always creates the `.regent/` store and wires capture hooks for whichever agent the sandbox runs — no flags.

It's **one mixin, not one per agent**. Rather than pinning to a single agent, the setup script detects the agent at container start and wires it:

| Agent | Capture wiring | Written to |
| --- | --- | --- |
| Claude Code | yes | `.claude/settings.json` |
| Codex | yes | `.codex/config.toml` |
| OpenCode | no — detected, reported | — |
| Pi | no — detected, reported | — |

```console
sbx run claude --kit ./re-gent/ .
```

**Revision note**: this PR originally shipped `init`/`hooks` as `args:`-gated options. CI caught that `sbx` v0.39.0 (the current stable release) rejects a spec.yaml declaring `args:` outright — `field args not found in type spec.specFileV2` — while the rolling nightly (813 commits ahead) parses it fine. `args:` hasn't shipped to any stable release, so that design was unusable for every real user. Dropped `args:` entirely; the kit is now unconditional by design rather than by fallback.

## Spec choices worth flagging for review

**The kit merges Claude Code hooks itself instead of calling `rgt init`.** `rgt init` has no unattended path: its hook step always opens an interactive `huh` multi-select, even with `--agent claude` (the flag only narrows the option list), and without a TTY it prints a warning, **exits 0, and configures nothing**. So the hook merge is a jq filter in `files/home/.local/share/re-gent/claude-hooks.jq` mirroring upstream `installClaudeHook` case for case — additive, idempotent, preserves the user's own hooks.

**Agent detection is deliberately stricter than upstream's.** `rgt init --agent auto` weighs a project-level `.claude/` directory as equal evidence to the binary. Plenty of repos commit a `.claude/` directory while being driven from a Codex sandbox — this one does — so the kit treats the **binary on `PATH` as authoritative** and consults config directories only as a fallback when no agent binary is found. Otherwise it would merge rgt hooks into a tracked `settings.json` the running agent never reads.

**Codex wiring appends TOML rather than rewriting it.** There is no `jq` for TOML and Python's `tomllib` is parse-only, so a read-modify-write would mean hand-rolling an emitter and re-emitting the user's config from a parsed model — dropping their comments and formatting. Appending new `[table]` headers is safe and touches nothing already there. The trade-off: it cannot *merge* into a config that already declares `[hooks]` or `[features]` (a duplicate table invalidates the file), so that case refuses loudly and leaves the file untouched. The conflict check covers every TOML spelling — `[hooks]`, `[[hooks]]`, `["hooks"]`, `[hooks.Stop]`, and dotted keys like `features.hooks = true`.

**OpenCode and Pi are detected but not wired.** Both need network *at wiring time* (an npm plugin install; a git-sourced `pi install`), which would add `registry.npmjs.org` to this kit's declared egress for every user including the majority who never touch either. The kit reports this at startup rather than silently doing nothing.

**No opt-out for init or hook wiring.** Discussed and confirmed as the intended design — see the revision note above for why `args:`-based configurability isn't available today.

**`.regent/` is not gitignored by upstream** — the `.gitignore` `rgt init` writes lives *inside* `.regent/` and only covers `*.backup` and `log/`, so a fresh init leaves `?? .regent/` and `git add -A` would commit prompt and conversation history. The kit adds `.regent/` (and any settings backup it takes) to `.git/info/exclude` via `--git-common-dir`, so it works from a linked worktree and never touches a tracked file.

**Only Claude Code is implemented.** Upstream also supports Codex, OpenCode, and Pi; the latter two shell out to npm and git at wiring time, which would widen the kit's network contract for agents it isn't otherwise set up for.

## Test plan

- `./scripts/test-kit.sh re-gent` passes.
- The jq filter was tested against empty/absent settings, existing user hooks, groups without a `hooks` key, non-object hook entries, string-form hooks, `null`/`false`/array/truncated JSON, and `rgt` / `./rgt` / `/usr/local/bin/rgt` / `FOO=1 rgt` / `go run ./cmd/rgt` command spellings. Idempotent across repeated runs; a `rgtool sync` lookalike is correctly left alone.
- The install and startup scripts were run end to end in `docker/sandbox-templates:claude-code-docker` on arm64: real release download and digest check, `.regent/` creation, git exclude, hook merge, and stability across repeated container starts. Also covered: a linked git worktree, an exclude file with no trailing newline, a non-git workspace, and the empty-workspace/`--clone` guard.
- Agent dispatch was exercised per path: Claude-only, Codex-only, a Codex sandbox on a repo with a committed `.claude/` (must not touch it), OpenCode (detected, reported, unwired), no agent at all, and the directory-fallback probe. The generated Codex TOML was verified to parse with `tomllib` and to preserve pre-existing `model`/`[profile]` keys verbatim. Conflict refusal was checked against every `[hooks]`/`[features]` spelling, and `HOME` being unset was confirmed not to break the script's fail-soft contract.
- **e2e now runs and passes** on this PR (`e2e-nightly`) once the branch picked up #258's Docker Hub credential fix. `e2e-release` failed once on the `args:` incompatibility above — that's what prompted this revision.

## Origin

Written from scratch for this repo after reading the upstream source, prompted by wanting agent-activity history inside sandboxes. No affiliation with the re_gent project.
