### PR TITLE
fix(ci): use dockerpublicbot credential for e2e sbx login

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -93,19 +93,19 @@ jobs:
 
       - name: Sign in to Docker Hub via sbx
         env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          USERNAME: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
+          TOKEN: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
         run: |
-          if [ -z "${DOCKERHUB_USERNAME}" ] || [ -z "${DOCKERHUB_TOKEN}" ]; then
-            echo "DOCKERHUB_USERNAME / DOCKERHUB_TOKEN not configured; cannot run e2e."
+          if [ -z "${USERNAME}" ] || [ -z "${TOKEN}" ]; then
+            echo "DOCKERPUBLICBOT_USERNAME / DOCKERPUBLICBOT_WRITE_PAT not configured; cannot run e2e."
             exit 1
           fi
           # Defensive trim: GH preserves any whitespace pasted into the
           # secret editor, and sbx's readPasswordStdin only strips trailing
           # \r\n. Hub usernames and PATs are alphanumeric + hyphens, so
           # stripping all whitespace can't corrupt a legitimate value.
-          USER_CLEAN=$(printf '%s' "$DOCKERHUB_USERNAME" | tr -d '[:space:]')
-          TOKEN_CLEAN=$(printf '%s' "$DOCKERHUB_TOKEN"    | tr -d '[:space:]')
+          USER_CLEAN=$(printf '%s' "$USERNAME" | tr -d '[:space:]')
+          TOKEN_CLEAN=$(printf '%s' "$TOKEN" | tr -d '[:space:]')
           printf '%s' "$TOKEN_CLEAN" | sbx --app-name "$APP_NAME" login --username "$USER_CLEAN" --password-stdin
 
       - name: Run e2e TCK for ${{ matrix.kit }}


### PR DESCRIPTION
## Summary

- The e2e workflow's "Sign in to Docker Hub via sbx" step now authenticates with `vars.DOCKERPUBLICBOT_USERNAME` / `secrets.DOCKERPUBLICBOT_WRITE_PAT` instead of `secrets.DOCKERHUB_USERNAME` / `secrets.DOCKERHUB_TOKEN`, matching the credential and reference style already used by the equivalent `sbx login` step in `publish-artifact.yml`.
- `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` started failing `sbx login` with `invalid Docker credentials` in CI starting 2026-08-30. That error is only ever returned on a genuine 401/403 from Docker Hub's own auth endpoint — never on a timeout, rate limit, or transient outage — so Docker Hub itself is rejecting this credential pair now.
- The same credential pair worked as recently as 2026-08-28 (PR #254's `e2e-release` job logged `Signed in as ***`), and the `DOCKERHUB_TOKEN`/`DOCKERHUB_USERNAME` GitHub Actions secrets were last edited back in May — nothing in this repo's secret store changed, so the credential died on Docker Hub's side (most likely an expiring PAT that has now lapsed).
- `publish-artifact.yml` already maintains a static `dockerpublicbot` credential specifically because an OIDC-exchanged token is rejected by `sbx login` (a different error, "docker token is invalid"). That credential is this repo's blessed, actively-maintained identity for `sbx login`, so this PR reuses it instead of keeping a second, unmaintained credential around for the same purpose.
- Also updated the guard/precondition message and comment references in `e2e.yml` so nothing in the file still names the old `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` secrets.

## Spec choices worth flagging for review

- I could not verify this fix by actually running `sbx login` — there's no `sbx` binary or live GitHub Actions secrets available in the environment I used to make this change. The fix is a targeted like-for-like credential swap, informed by the fact that `publish-artifact.yml`'s equivalent `sbx login` step is this repo's known-working precedent for the same command.
- Please confirm `DOCKERPUBLICBOT_WRITE_PAT` is scoped appropriately for what `sbx login` needs here — it should be, since it's the exact same scope `publish-artifact.yml` already relies on for its own `sbx login` step, but worth a second look since this PR adds a second consumer of that secret.

## Test plan

- This cannot be exercised outside GitHub Actions with live secrets, so there is no local reproduction of the login itself.
- The only real proof is CI: a re-run of the `e2e-release` / `e2e-nightly` jobs on this PR actually completing the "Sign in to Docker Hub via sbx" step and going on to run the kit e2e suite.
- Locally validated only that `.github/workflows/e2e.yml` is still well-formed YAML after the edit, and manually diffed old vs. new to confirm every reference to the old secret names was updated consistently and nothing else in the file changed.