### PR TITLE
docs: update stale DOCKERHUB_USERNAME/DOCKERHUB_TOKEN references

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 Thanks for contributing to sbx-kits-contrib!
 
 PRs from forks have CI's `test-kit-e2e` job SKIPPED because GitHub does not
-expose `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` to fork-triggered workflows.
+expose `DOCKERPUBLICBOT_USERNAME` / `DOCKERPUBLICBOT_WRITE_PAT` to fork-triggered workflows.
 The e2e assertions will not run on your PR — your laptop is the only place
 they run before merge. See the checklist below.
 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ cd my-kit && ../scripts/test-kit.sh
 sbx run --kit . <agent>              # quick manual smoke
 ```
 
-The first two are what CI runs on every PR. **The third is not run on CI for PRs opened from a fork** — the CI e2e legs (`e2e-release`, which gates the PR, and the informational `e2e-nightly`) need `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN`, and GitHub doesn't expose secrets to fork-triggered workflows, so they are skipped silently and the reviewer sees a green check that does **not** include the e2e assertions. If you're contributing from a fork (the common case), your laptop is the only place those assertions ever run before merge.
+The first two are what CI runs on every PR. **The third is not run on CI for PRs opened from a fork** — the CI e2e legs (`e2e-release`, which gates the PR, and the informational `e2e-nightly`) need `DOCKERPUBLICBOT_USERNAME`/`DOCKERPUBLICBOT_WRITE_PAT`, and GitHub doesn't expose secrets to fork-triggered workflows, so they are skipped silently and the reviewer sees a green check that does **not** include the e2e assertions. If you're contributing from a fork (the common case), your laptop is the only place those assertions ever run before merge.
 
 `scripts/test-kit.sh` resolves the kit directory (default: `$PWD`), sets `KIT` to its absolute path, and runs `go test -run TestKitTCK ./tck/...` against the repo-root `tck` package. Forwards extra flags to `go test`, so `../scripts/test-kit.sh -v -run TestKitTCK/my-kit/validation` works.
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ The default TCK runs every kit assertion against a fabricated `testcontainers-go
   ```bash
   sbx --app-name sbx-kits-contrib-tck login
   ```
-  Non-interactive (matches CI):
+  Non-interactive (using your own Docker Hub username and access token):
   ```bash
   printf '%s' "$DOCKERHUB_TOKEN" | sbx --app-name sbx-kits-contrib-tck login --username "$DOCKERHUB_USERNAME" --password-stdin
   ```
@@ -270,7 +270,7 @@ Each subtest (`env`, `files/<path>`, `tmpfs/<path>`, `memory`) reports independe
 
 ### Running in CI
 
-The e2e legs in [`.github/workflows/tck.yml`](.github/workflows/tck.yml) run alongside the default `test-kit` job, via the reusable [`.github/workflows/e2e.yml`](.github/workflows/e2e.yml). Each signs in to Docker Hub using `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` repo secrets, then runs the e2e test once per detected kit — against two `sbx` channels:
+The e2e legs in [`.github/workflows/tck.yml`](.github/workflows/tck.yml) run alongside the default `test-kit` job, via the reusable [`.github/workflows/e2e.yml`](.github/workflows/e2e.yml). Each signs in to Docker Hub using `DOCKERPUBLICBOT_USERNAME` / `DOCKERPUBLICBOT_WRITE_PAT` repo secrets, then runs the e2e test once per detected kit — against two `sbx` channels:
 
 - **`e2e-release`** downloads the latest tagged `sbx` release. This is the channel users have today, so it **gates the PR** through the stable `e2e` job (the required status check).
 - **`e2e-nightly`** downloads the rolling `nightly` build, so kits are also exercised against what `sbx` will ship next. It is **informational only** — a broken nightly shows a red check but never blocks merge. The `e2e-nightly-report` job echoes its outcome to the run log and the job summary.


### PR DESCRIPTION
## Summary

#258 switched `e2e.yml`'s `sbx login` step from `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` to the `dockerpublicbot` org-bot credential (`DOCKERPUBLICBOT_USERNAME`/`DOCKERPUBLICBOT_WRITE_PAT`), because Docker Hub had started rejecting the old pair outright. The old secrets have since been deleted from the repo — nothing in `.github/workflows/` references them anymore.

Three docs still named the deleted pair:

- `README.md` — the "Running in CI" section stated the wrong secret names outright; fixed to name the ones `e2e.yml` actually uses now.
- `README.md` — the "Prerequisites" section's local, non-interactive login example is unaffected (a contributor uses their own Docker Hub account there, not the org bot), but its `(matches CI)` label is no longer true now that CI authenticates as a different identity, so it's reworded rather than the example itself changed.
- `CONTRIBUTING.md` and `.github/pull_request_template.md` — both explained why fork PRs skip e2e by naming the (now-deleted) secrets; updated to the current ones.

## Test plan

Documentation-only change, no CI behavior to verify — reading the diff is the review.
