### PR TITLE
Add codex kit

### DIFF
--- a/codex/.dockerignore
+++ b/codex/.dockerignore
@@ -1,0 +1,13 @@
+# The build context is the kit directory, which also holds kit metadata that the
+# image has no use for. Excluding it keeps the context small and keeps README or
+# testdata edits from touching the image build at all.
+#
+# Listed by exclusion rather than as an allowlist (`*` plus a `!` re-include per
+# wanted file) so that adding a COPY for a new file later does not silently fail
+# against a stale ignore rule. This Dockerfile currently COPYs nothing at all,
+# which makes that failure mode especially easy to miss.
+README.md
+README.image.md
+spec.yaml
+testdata/
+.dockerignore

--- a/codex/Dockerfile
+++ b/codex/Dockerfile
@@ -1,0 +1,94 @@
+# syntax=docker/dockerfile:1
+
+# Base image for the `codex` sandbox kit.
+#
+# One image, no flavour suffix: the kit picks its own image, so the
+# Docker-in-Docker detail never reaches the user. There is no dockerless variant
+# either — a kind:sandbox kit names a single sandbox.image, so a second image
+# would be unreachable without a second kit to consume it.
+#
+# The base is a floating tag, which is why CI also rebuilds on a schedule.
+ARG BASE_IMAGE=docker/sandbox-templates:shell-docker
+FROM ${BASE_IMAGE}
+
+# Re-declared inside the stage: an ARG defined before the first FROM is a global
+# build arg, visible only to FROM lines. Without this, the LABEL below would
+# expand to an empty string.
+ARG BASE_IMAGE
+
+# CODEX_HOME. Created here rather than only in the kit's install hook so the
+# directory exists — and is owned by `agent`, the USER inherited from the base —
+# before anything else in the container start sequence can create it as root.
+# The install hook still does its own `mkdir -p`, which makes this belt and
+# braces rather than the only guarantee.
+RUN mkdir -p /home/agent/.codex
+
+# Codex's npm package is ~370 MB, so the default fetch timeout is not enough on
+# a slow or proxied network: raise it and retry rather than failing the whole
+# image build on one stalled request.
+#
+# --include=optional is load-bearing, not hygiene. The platform-specific native
+# binary (@openai/codex-linux-x64 and friends) ships as an optional dependency,
+# so omitting the flag produces an install that exits 0 and leaves no working
+# binary behind.
+#
+# Plain `npm`, deliberately. The built-in agent's image drives this install
+# through `corepack npm` and then tries to `corepack disable npm`; both halves
+# are worth dropping here:
+#
+#   * `corepack npm` downloads an unpinned npm over the network on every build
+#     and then warns that that npm does not support this image's Node — a
+#     warning today, a hard failure whenever npm decides to enforce it.
+#   * `corepack disable npm` cannot succeed anyway. This layer runs as the
+#     non-root `agent` user inherited from the base, so unlinking the
+#     root-owned /usr/bin/npm fails EACCES; the `|| echo` fallback next to it
+#     is what keeps the build green. It has nothing to remove either, because
+#     nothing in this image ever ran `corepack enable`.
+#
+# The end state that actually matters is unchanged and verified below: the real
+# apt-installed /usr/bin/npm is the npm on PATH at runtime, which is what Codex
+# needs — its self-updater spawns `npm` directly and dies with ENOENT against a
+# corepack shim.
+#
+# `codex --version` last, deliberately: an install command's exit code says
+# only that npm exited 0, not that a usable binary landed. This asserts the
+# outcome instead of trusting the exit code.
+RUN npm install -g @openai/codex@latest \
+      --include=optional \
+      --fetch-timeout=300000 \
+      --fetch-retries=3 \
+      --fetch-retry-mintimeout=60000 \
+ && codex --version \
+ && command -v npm
+
+# Inherited from the base image, but re-declared deliberately so the value is
+# owned here rather than depending on inheritance from an image this repository
+# does not own.
+#
+# This is a *request* to the runtime, not a description of the image: setting it
+# over a base with no Docker engine yields a sandbox started in Docker mode with
+# nothing to run. Since BASE_IMAGE is overridable, CI asserts the engine is
+# really present rather than trusting this label.
+LABEL com.docker.sandboxes.start-docker="true"
+
+# Both of the labels below OVERRIDE values inherited from the base image, which
+# describe the base rather than this image. Overriding is not optional for
+# `flavor`: left inherited it would read "shell-docker", and sbx would report
+# this image's agent as "shell-docker".
+#
+# sbx reads `flavor` and treats it as an agent identifier — it surfaces the value
+# as an image's `Agent` in the API, and separately uses it (with any `-docker`
+# suffix trimmed) to warn when a template looks built for a different agent than
+# the one being run. So it must be the kit's own name: `codex`.
+LABEL com.docker.sandboxes.flavor="codex"
+
+# Informational only — nothing in sbx reads this. Worth setting because the base
+# is a floating tag rebuilt nightly, so this is the one place the produced image
+# records what it was actually built on.
+LABEL com.docker.sandboxes.base="${BASE_IMAGE}"
+
+# Note: `com.docker.sandboxes=templates` also appears on this image. It is
+# inherited from the base and is not set here — nothing reads it, and this image
+# is not part of that template family, so it is left alone rather than asserted.
+
+CMD [ "codex" ]

--- a/codex/Dockerfile
+++ b/codex/Dockerfile
@@ -23,6 +23,35 @@ ARG BASE_IMAGE
 # braces rather than the only guarantee.
 RUN mkdir -p /home/agent/.codex
 
+# xdg-utils, for the `xdg-open` that this kit's BROWSER variable names.
+#
+# The base image ships neither xdg-open nor xdg-settings, so without this layer
+# BROWSER points at a binary that does not exist and every "open this link for
+# you" attempt dies with a command-not-found. This kit builds its own image
+# precisely so it can install what the agent needs, so it installs it.
+#
+# --no-install-recommends is load-bearing rather than habitual here: the
+# recommends are the desktop-integration half of the package
+# (libfile-mimeinfo-perl, libnet-dbus-perl, libx11-protocol-perl, x11-utils,
+# x11-xserver-utils) and pull in an X11 dependency tree a headless sandbox has
+# no use for. Skipping them leaves xdg-utils with no dependencies at all: one
+# architecture-independent package of shell scripts, well under a megabyte.
+#
+# BROWSER=xdg-open does not make xdg-open re-invoke itself: Debian and Ubuntu
+# patch the script to strip its own name out of $BROWSER before consulting it,
+# so it falls through to the browser list instead of recursing.
+#
+# Deliberately placed above the npm layer below. That layer floats on
+# `@openai/codex@latest` and re-runs on every nightly rebuild; this one has
+# nothing to do with which Codex version is installed, and above it stays a
+# cache hit.
+USER root
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends xdg-utils && \
+    rm -rf /var/lib/apt/lists/* && \
+    command -v xdg-open
+USER agent
+
 # Codex's npm package is ~370 MB, so the default fetch timeout is not enough on
 # a slow or proxied network: raise it and retry rather than failing the whole
 # image build on one stalled request.

--- a/codex/README.image.md
+++ b/codex/README.image.md
@@ -1,0 +1,19 @@
+# sbx/codex-image
+
+Base image for the Codex agent kit for
+[Docker Sandboxes](https://docs.docker.com/ai/sandboxes/).
+
+## Contents
+
+Built on `docker/sandbox-templates:shell-docker`: the standard sandbox tool
+chain plus a Docker engine, requesting Docker-in-Docker via
+`com.docker.sandboxes.start-docker=true`. On top of that:
+
+- `@openai/codex`, OpenAI's Codex CLI, installed globally from npm with its
+  platform-specific native binary
+
+Runs as the non-root `agent` user, with `CMD ["codex"]`.
+
+## Kit
+
+[`docker.io/sbx/codex-kit`](https://hub.docker.com/r/sbx/codex-kit)

--- a/codex/README.image.md
+++ b/codex/README.image.md
@@ -11,6 +11,8 @@ chain plus a Docker engine, requesting Docker-in-Docker via
 
 - `@openai/codex`, OpenAI's Codex CLI, installed globally from npm with its
   platform-specific native binary
+- `xdg-utils`, so the `xdg-open` that the kit's `BROWSER` variable names exists
+  (installed without its recommends, which are the X11 half of the package)
 
 Runs as the non-root `agent` user, with `CMD ["codex"]`.
 

--- a/codex/README.md
+++ b/codex/README.md
@@ -1,0 +1,243 @@
+# codex
+
+A standalone sandbox kit (`kind: sandbox`, `schemaVersion: "2"`) for
+[Codex CLI](https://developers.openai.com/codex/cli), OpenAI's agentic coding
+CLI. The kit runs `codex` as the entrypoint with Codex's own approval gate and
+filesystem sandbox turned off — the container is the sandbox — and authenticates
+through a single `openai` credential that works from either an API key or a
+ChatGPT login.
+
+Codex was previously a built-in `sbx` agent, run as `sbx run codex`. This kit
+replaces that, and is backed by a base image built from the
+[`Dockerfile`](./Dockerfile) in this directory rather than by the
+`docker/sandbox-templates` release train.
+
+## Prerequisites
+
+Any one of these works — the kit adapts to what it finds:
+
+- `OPENAI_API_KEY` bound on your host. The proxy authenticates outbound
+  requests to `api.openai.com` for you.
+- A ChatGPT login stored as your host's `openai` credential. The kit points
+  Codex at a ChatGPT-backed model provider and the proxy spends the OAuth token
+  on your behalf.
+- Nothing at all. Codex starts unauthenticated and prompts you to log in on
+  first use, inside the sandbox.
+
+## Usage
+
+```console
+sbx run --kit "docker.io/sbx/codex-kit:latest" codex
+```
+
+Or from a git URL targeting this repo:
+
+```console
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=codex" codex
+```
+
+Or with a local clone of this repo:
+
+```console
+sbx run --kit ./codex/ codex
+```
+
+The trailing `codex` is required, not redundant: for `kind: sandbox` kits,
+`sbx` enforces that the agent name matches the kit's own `name`.
+
+## Passing arguments
+
+The entrypoint is `codex --dangerously-bypass-approvals-and-sandbox`, so
+anything you pass is appended after that flag. The flag is not optional
+housekeeping: an approval prompt in a headless sandbox has nobody to answer it,
+and the isolation Codex would otherwise provide for itself is already provided
+from the outside by the container.
+
+The same intent is written into `~/.codex/config.toml` as
+`approval_policy = "never"` and `sandbox_mode = "danger-full-access"`, so the
+behaviour survives a session started by something other than the entrypoint —
+`sbx exec`, or one of the mixins below.
+
+## How auth works
+
+The kit declares one credential, `openai`, carrying both an `apiKey` and an
+`oauth` block. Which one is live is decided on the host, and the kit is told the
+outcome through `SBX_CRED_OPENAI_MODE` — one of `apikey`, `oauth`, or `none`
+(a host with both collapses to `oauth`). The install hook branches on it and
+writes `~/.codex/config.toml` and `~/.codex/auth.json` accordingly:
+
+| Mode | `config.toml` | `auth.json` |
+| --- | --- | --- |
+| `apikey` | forced API-key login | proxy-managed placeholder |
+| `oauth` | forced API-key login **and** a ChatGPT-backed `model_provider` whose bearer is the access-token sentinel | proxy-managed placeholder |
+| `none` | neither | **removed** |
+
+Three things about that table are deliberate:
+
+- **`forced_login_method = "api"` in both managed modes.** The placeholder in
+  `auth.json` is the entire auth story there, so a remote client must not be
+  able to replace it with a sandbox-local ChatGPT login. `none` mode
+  deliberately allows that login — it is the only way to authenticate at all.
+- **`auth.json` is removed, not blanked, in `none` mode.** A leftover
+  `proxy-managed` placeholder would be sent to OpenAI verbatim and come back
+  a 401, which is a much more confusing failure than "please log in".
+- **Both files are rewritten on every create and recreate.** Their content is a
+  pure function of the mode, which is what makes an unconditional rewrite
+  idempotent, and it means a credential change on the host is picked up by a
+  recreate instead of leaving stale config behind. The flip side, inherited
+  from the built-in agent this kit replaces: anything *Codex* wrote into
+  `config.toml` during a previous session — project trust decisions, a `/model`
+  choice — is discarded by a recreate. Only the truncating install hook does
+  this; an ordinary stop/start leaves the file alone.
+
+> [!IMPORTANT]
+> Unlike most `apiKey`-based kits in this repo, this one does **not** set
+> `apiKey.proxyManaged: true` on `OPENAI_API_KEY` — carried over as-is from the
+> built-in agent's spec. On the paths this kit configures Codex reads its key
+> from `auth.json`, where the kit already writes the `proxy-managed` sentinel
+> itself, so the environment variable is not the delivery path. The consequence
+> is still worth knowing: without `proxyManaged`, the real key is present in
+> the container environment rather than only inside the proxy. Turning it on
+> looks more correct and has **not** been verified against Codex's own
+> key-discovery order, which is why it was not changed here. See the PR
+> description.
+
+## MCP gateway
+
+When a sandbox has an MCP gateway reserved, a startup hook appends an
+`[mcp_servers.mcp-gateway]` table to `~/.codex/config.toml` pointing at it, with
+`Authorization: Bearer $MCP_SENTINEL_TOKEN_NAME`. The sentinel is a *name*, not
+a token — the proxy substitutes the real value per request, so nothing
+credential-shaped is ever written to disk.
+
+Three details worth knowing if you edit that hook:
+
+- The header table is **`http_headers`**, not `headers`. Codex ignores unknown
+  config keys silently, so a `headers` table is accepted, the server shows up
+  as registered and healthy, and every request through it goes out with no
+  `Authorization` at all. `headers` is the right spelling for the
+  JSON-configured agents in this repo (`copilot`, `kiro`); it does not carry
+  over to Codex's TOML. `codex mcp get mcp-gateway` is the quick check —
+  `http_headers: Authorization=*****` means it took.
+- It **appends**. `config.toml` is shared territory: the install hook writes the
+  yolo-mode and provider keys before launch, and Codex itself appends
+  per-project and TUI state during a session. Rewriting the file would clobber
+  both.
+- It is guarded by `grep` on the table header, because startup hooks run on
+  *every* container start — the initial create, every stop/start, and daemon
+  restarts. Without the guard you would collect a duplicate table per boot.
+
+With no gateway reserved, the hook exits 0 without touching anything.
+
+## Related mixins
+
+Two mixins in this repo declare `requires.agent: codex`, so they compose onto
+this kit and nothing else:
+
+- [`codex-acp`](../codex-acp/) — runs the Codex ACP adapter over stdio.
+- [`codex-app-server`](../codex-app-server/) — runs sshd so the Codex Mac GUI
+  can drive `codex app-server` in the sandbox over an SSH connection.
+
+```console
+sbx run --kit ./codex/ --kit ./codex-acp/ codex
+```
+
+Affinity matching is by exact name, which is one reason this kit's directory and
+`name:` are both plain `codex` rather than anything more descriptive.
+
+> [!NOTE]
+> `codex-app-server` shadows `codex` on `PATH` with a wrapper that execs the
+> binary at its npm global path. This kit installs Codex to exactly that path
+> (the base image sets npm's global prefix and the kit does not change it), so
+> the two stay compatible — but it is a coupling to keep in mind if the install
+> location ever moves.
+
+## Credential exposure worth reviewing
+
+The credential injects `Authorization: Bearer <key>` into `api.openai.com`
+**and** into the bare `openai.com` apex. The apex serves OpenAI's website, not
+the API — nothing observed from a live CLI needs a bearer token there — so any
+process in the sandbox that happens to fetch `openai.com` gets the real key
+attached on the way out. It is carried over from the built-in agent's spec
+unchanged, because a missing header is a silent 401 on whatever path did want
+it, and "no path wants it" is a negative this port cannot prove. There is a
+matching `TODO` on the entry in `spec.yaml`; it should be dropped once someone
+can rule the last path out.
+
+## Network policy
+
+`permissions.network.allow` covers every domain the credential injects into or
+authenticates against, the hosts Codex reaches during a session (uploads, npm
+self-upgrade, GitHub release checks and skill downloads), and the apt sources
+the base image ships with — the last of those because the startup hook runs
+`apt-get update`, which fails wholesale if any configured source is
+unreachable.
+
+Hosts are listed without a port qualifier. The built-in agent's spec pinned
+`:443` and `:80`; this kit does not, matching the other kits in this repo. On
+the apt mirrors in particular a hardcoded `:80` would break `apt-get update`
+the day the base image's sources switch to https, and which scheme those
+sources use is not something this kit owns.
+
+> [!IMPORTANT]
+> This list has not been verified end-to-end under `sbx policy init deny-all`
+> from this repo. The known suspect is the self-update flow: if Codex ever
+> fetches a compiled release *asset* rather than the repository archive
+> `codeload.github.com` serves, GitHub redirects that download to a
+> `*.githubusercontent.com` host which is **not** declared here. It was left
+> out rather than added on speculation. If something fails under deny-all,
+> inspect what was blocked and widen the list:
+>
+> ```console
+> $ sbx policy log
+> ```
+>
+> then add the reported hosts to `permissions.network.allow` in `spec.yaml`.
+
+## Base image
+
+Unlike most kits here — which are `kind: mixin` or `kind: agent` and layer onto
+an existing `docker/sandbox-templates` image — a `kind: sandbox` kit *is* the
+whole environment, so it names the image the sandbox boots from. This kit
+builds and publishes its own, from the `Dockerfile` in this directory.
+
+The image is **`docker.io/sbx/codex-image`**, built on
+`docker/sandbox-templates:shell-docker`, so it carries a Docker engine and
+requests Docker-in-Docker.
+
+The `-image` suffix distinguishes the base image from the kit itself: the kit
+is published as an OCI artifact at `docker.io/sbx/codex-kit` (see
+[Usage](#usage) above). The name is derived from the kit directory and enforced
+repo-wide — see [PUBLISHING.md](../PUBLISHING.md#naming).
+
+There is no flavour suffix and no dockerless variant. The sandbox templates
+distinguish `codex` from `codex-docker` because a user picks a template
+directly, but a kit picks its own image — so the Docker-in-Docker detail never
+reaches the user, just as `sbx run codex` already resolves to the Docker
+flavour today. And a `kind: sandbox` kit names exactly one `sandbox.image`, so
+a second image would be unreachable without a second kit to consume it.
+
+### Building and publishing
+
+How the image is named, tagged, verified and pushed is the same for every kit
+in this repo that builds its own image — see
+**[PUBLISHING.md](../PUBLISHING.md)** for the pipeline, the tagging scheme,
+the coordinates, and the Docker Hub OIDC setup. Only the codex-specific parts
+are below.
+
+### Building locally
+
+```console
+docker build -t docker.io/sbx/codex-image:latest codex
+```
+
+Expect this to take a while: Codex's npm package is around 370 MB. The install
+raises npm's fetch timeout and adds retries for exactly that reason, and passes
+`--include=optional` because the platform-specific native binary ships as an
+optional dependency — without the flag npm exits 0 and leaves no working
+binary. The build ends with `codex --version` so a broken install fails the
+image rather than shipping.
+
+`BASE_IMAGE` is a build arg, so the base can be re-pointed or digest-pinned
+without editing the `Dockerfile`: `--build-arg BASE_IMAGE=…` accepts a tag or a
+digest.

--- a/codex/README.md
+++ b/codex/README.md
@@ -58,6 +58,19 @@ The same intent is written into `~/.codex/config.toml` as
 behaviour survives a session started by something other than the entrypoint —
 `sbx exec`, or one of the mixins below.
 
+## Opening links
+
+`BROWSER` is set to `xdg-open`, and the image installs `xdg-utils` so that
+program is really there. A kit that builds its own image has no excuse for
+pointing `BROWSER` at something it never shipped, and the package costs
+roughly 400 KB with no dependencies once its X11 recommends are skipped.
+
+The sandbox still has no browser and no display, so a link does not literally
+open: `xdg-open` answers `no method available for opening ...`, exits non-zero,
+and Codex prints the URL for you to follow on your own machine. What changes is
+that the failure is a real answer from a real tool rather than a
+command-not-found from the kit's own configuration.
+
 ## How auth works
 
 The kit declares one credential, `openai`, carrying both an `apiKey` and an

--- a/codex/spec.yaml
+++ b/codex/spec.yaml
@@ -148,10 +148,16 @@ permissions:
 
 environment:
   variables:
-    # Carried over from the built-in spec. Nothing in this sandbox can open a
-    # browser and the base image does not ship xdg-utils, so the practical
-    # effect is that Codex's "open this URL for me" attempt fails fast and it
-    # falls back to printing the URL. Kept for parity; see the PR description.
+    # xdg-open is the conventional "open this for me" hook on Linux. The kit's
+    # Dockerfile installs xdg-utils, so this names a program that is really
+    # there rather than one the kit forgot to ship: a command-not-found from
+    # the kit's own configuration is not a failure mode worth documenting when
+    # the kit builds the image and can just install the package.
+    #
+    # There is still no browser and no display inside the sandbox, so a link
+    # does not literally open. xdg-open says so ("no method available for
+    # opening ...") and exits non-zero, which is a diagnosable answer, and
+    # Codex prints the URL for you to open on your own machine.
     BROWSER: xdg-open
     CODEX_HOME: /home/agent/.codex
     # git must never block on an interactive credential prompt in a headless

--- a/codex/spec.yaml
+++ b/codex/spec.yaml
@@ -1,0 +1,296 @@
+schemaVersion: "2"
+kind: sandbox
+name: codex
+# The KIT's version, not Codex's. It covers this spec, the network policy and
+# the hooks — the agent inside the image floats, so a newer Codex CLI does not
+# bump this and this does not track releases of the CLI.
+#
+# Published as the vnd.docker.sandbox.kit.version OCI annotation at pack time,
+# and `scripts/check-release-tag.sh` refuses a `codex/vX.Y.Z` tag that
+# disagrees with it. Bump here first, then tag.
+version: "1.0.0"
+displayName: Codex
+description: OpenAI Codex CLI, OpenAI's agentic coding CLI.
+sandbox:
+  # Built from the Dockerfile beside this spec and published by
+  # .github/workflows/build-and-publish-kits.yml. Carries a Docker engine and
+  # requests Docker-in-Docker, matching the built-in agent this kit replaces.
+  #
+  # This value is the source of truth for what CI builds and publishes: the
+  # workflow reads it from here rather than deriving a name, because spec.yaml
+  # is consumed literally (no env interpolation) and so cannot follow a
+  # variable. scripts/check-image-ref.sh asserts it stays inside the namespace
+  # CI can actually push to.
+  #
+  # The `-image` suffix distinguishes the base image from the kit artifact:
+  # when the kit itself is published as an OCI artifact it is
+  # `docker.io/sbx/codex-kit`.
+  image: "docker.io/sbx/codex-image:latest"
+  # Codex's own sandboxing and approval prompts are redundant here — the
+  # container *is* the sandbox, and an approval prompt nobody can answer just
+  # deadlocks a non-interactive session. The two config keys written by
+  # setup.install below say the same thing in config form; both are kept so
+  # neither surface has to be the only line of defence.
+  entrypoint: [codex, "--dangerously-bypass-approvals-and-sandbox"]
+
+credentials:
+  - service: openai
+    apiKey:
+      name: OPENAI_API_KEY
+      # NOTE: deliberately NOT `proxyManaged: true`, unlike most apiKey-based
+      # kits in this repo. Codex does not read this variable for model calls
+      # on the paths this kit configures — setup.install writes the literal
+      # `proxy-managed` sentinel into ~/.codex/auth.json instead, and the
+      # proxy swaps it on the domains below. Flipping this on would put a
+      # sentinel in the env var too, which is arguably tidier, but it has NOT
+      # been verified that Codex's own key-discovery order stays happy with
+      # a sentinel in both places. See the PR description.
+      inject:
+        - domain: api.openai.com
+          header: Authorization
+          format: Bearer %s
+        # TODO(codex-extraction): drop this entry once someone can rule out
+        # the last request path. The apex serves OpenAI's website, not the API:
+        # everything observed from a live 0.151.0 CLI goes to api.openai.com,
+        # chatgpt.com, auth.openai.com or files.openai.com. While it stands,
+        # any process in the sandbox that fetches openai.com gets the user's
+        # real key attached by the proxy, which is avoidable exposure.
+        # Carried over unchanged rather than narrowed unilaterally, because a
+        # missing header is a silent 401 on whatever path did need it and
+        # "no path needs it" is a negative this port cannot prove.
+        - domain: openai.com
+          header: Authorization
+          format: Bearer %s
+    # For a host whose stored openai credential is a ChatGPT login rather than
+    # an API key. The block is entirely declarative: the token endpoint, the
+    # hosts the bearer is actually spent on, and the sentinel values the proxy
+    # substitutes at request time. Nothing in the container implements any of
+    # it.
+    oauth:
+      tokenEndpoint:
+        host: auth.openai.com
+        path: /oauth/token
+      # In oauth mode setup.install points Codex at a ChatGPT-backed model
+      # provider, so the sentinel bearer travels on inference calls to
+      # chatgpt.com — not only on the token exchange. resourceHosts is what
+      # tells the proxy to substitute the real token there too.
+      resourceHosts:
+        - chatgpt.com
+      sentinels:
+        accessToken: oai-oat01-proxy-managed
+        refreshToken: oai-ort01-proxy-managed
+      # Carried over from the built-in spec for parity, but a no-op for a
+      # schemaVersion "2" credential like this one: resolution here is
+      # binding-driven, not host-env-driven, so a host env var alone (as
+      # opposed to a bound credential) does not gate this. Kept rather than
+      # dropped so a future diff against the built-in spec stays minimal.
+      skipIfEnv:
+        - OPENAI_API_KEY
+
+permissions:
+  network:
+    # Built-in agents ship no egress policy of their own: they inherit
+    # whatever the host policy is, which defaults to permissive. A community
+    # kit cannot rely on that — this repo's e2e runs every kit under
+    # `sbx policy init deny-all`, so the kit gets exactly the reachability it
+    # declares here and nothing more.
+    #
+    # Hosts are listed without a port qualifier, matching the other kits in
+    # this repo. Pinning `:80` on the apt mirrors in particular would break
+    # `apt-get update` outright the day the base image's sources switch to
+    # https, and which scheme those sources use is a base-image detail this
+    # kit does not own.
+    allow:
+      # Every domain the credential injects into or authenticates against —
+      # required here too, not just above: a domain absent from this list is
+      # unreachable regardless of what the credential block declares.
+      - api.openai.com
+      - openai.com
+      # The OAuth token endpoint.
+      - auth.openai.com
+      # Where the OAuth access token is spent in oauth mode — the model
+      # provider setup.install configures, and the credential's resourceHosts.
+      - chatgpt.com
+      # Hit during a session for attachments and uploads.
+      - files.openai.com
+      # `codex update` reinstalls the CLI from npm, and `codex plugin add`
+      # pulls from a marketplace snapshot. Same registry the image build uses,
+      # but these are the runtime paths, not the build one.
+      - registry.npmjs.org
+      # Codex's native binary checks GitHub releases for updates and pulls
+      # skills and plugins from repository archives. A distinct concern from
+      # the npm upgrade path above, which is why both are listed.
+      - api.github.com
+      - github.com
+      - codeload.github.com
+      # `apt-get update` (the startup hook below) refreshes metadata for every
+      # configured apt source and returns exit 100 if any one of them fails.
+      # The shell-docker base ships three sources, so all three must be
+      # reachable. Ubuntu serves amd64 from archive/security and arm64 from
+      # ports.ubuntu.com, so all three Ubuntu hosts are listed to keep the kit
+      # working cross-arch.
+      - archive.ubuntu.com        # Ubuntu archive (amd64 main)
+      - security.ubuntu.com       # Ubuntu security updates (amd64)
+      - ports.ubuntu.com          # Ubuntu archive/security (arm64)
+      - download.docker.com       # Docker's apt repo, pre-added by shell-docker
+      #
+      # TODO(codex-extraction): the domains above are the ones the built-in
+      # agent already declared; they have not been verified end-to-end under
+      # deny-all from this repo, and Codex may reach further hosts. The known
+      # suspect is the update flow: if it ever fetches a compiled release
+      # asset rather than the repository archive codeload.github.com serves,
+      # GitHub redirects asset downloads to a *.githubusercontent.com host
+      # that is not declared here. Deliberately not added on speculation —
+      # confirm or widen from a live run:
+      #
+      #   sbx run --kit ./codex codex   # then attempt a prompt
+      #   sbx policy log                # lists every blocked host + reason
+
+environment:
+  variables:
+    # Carried over from the built-in spec. Nothing in this sandbox can open a
+    # browser and the base image does not ship xdg-utils, so the practical
+    # effect is that Codex's "open this URL for me" attempt fails fast and it
+    # falls back to printing the URL. Kept for parity; see the PR description.
+    BROWSER: xdg-open
+    CODEX_HOME: /home/agent/.codex
+    # git must never block on an interactive credential prompt in a headless
+    # sandbox. Without this, a 401 from the credentials proxy (e.g. a bad or
+    # expired github secret) makes git open /dev/tty to ask for a username and
+    # hang, which freezes Codex's TUI. "0" makes git fail fast instead.
+    GIT_TERMINAL_PROMPT: "0"
+
+setup:
+  install:
+    # Seed ~/.codex/config.toml + ~/.codex/auth.json, branching on the auth
+    # mode the engine surfaces as SBX_CRED_OPENAI_MODE. Only three values
+    # reach a kit — oauth, apikey, none (a host with both collapses to
+    # oauth) — and the branches are:
+    #
+    #   oauth  -> config.toml WITH forced API-key login AND the ChatGPT-backed
+    #             model_provider block; auth.json holds the proxy-managed
+    #             placeholder.
+    #   apikey -> config.toml WITH forced API-key login, WITHOUT the provider
+    #             block; auth.json holds the proxy-managed placeholder.
+    #   none   -> config.toml WITHOUT either; auth.json REMOVED, so Codex
+    #             prompts for login on first use. Leaving a stale placeholder
+    #             behind would send the literal string to OpenAI and 401.
+    #
+    # Both files are kit-managed and rewritten unconditionally on every
+    # (re)create, so a mode change on recreate is picked up. The content is a
+    # pure function of the mode, which is what makes the unconditional rewrite
+    # idempotent — install hooks run again on every recreate.
+    #
+    # The MCP block is deliberately NOT written here. The runtime-gated
+    # registration in setup.startup is the single writer of it, and its grep
+    # guard supplies its own idempotency.
+    #
+    # Heredoc bodies sit at the outer indentation on purpose, including inside
+    # the case arms: an unquoted terminator has to start at column 0.
+    - command: |
+        set -e
+        # ~/.codex is CODEX_HOME; ~/.agents is where Codex looks for the
+        # cross-agent skills tree (~/.agents/skills). Both are created up
+        # front so nothing later has to create them as root.
+        mkdir -p /home/agent/.codex /home/agent/.agents
+        MODE="${SBX_CRED_OPENAI_MODE:-none}"
+        cat > /home/agent/.codex/config.toml << 'EOF'
+        # Codex configuration for a Docker sandbox.
+        # The container is the sandbox, so Codex's own approval gate and
+        # filesystem sandbox are turned off: there is nobody to answer a
+        # prompt, and the isolation is already provided from the outside.
+
+        approval_policy = "never"
+        sandbox_mode = "danger-full-access"
+        mcp_oauth_credentials_store = "file"
+        EOF
+        # In a managed mode the placeholder in auth.json is the whole auth
+        # story, so a remote client must not be able to replace it with a
+        # sandbox-local ChatGPT login. `none` mode deliberately permits that
+        # login — it is the only way to authenticate at all there.
+        case "$MODE" in
+          oauth|apikey)
+            cat >> /home/agent/.codex/config.toml << 'EOF'
+        forced_login_method = "api"
+        EOF
+            ;;
+        esac
+        if [ "$MODE" = oauth ]; then
+          cat >> /home/agent/.codex/config.toml << 'EOF'
+
+        model_provider = "sandboxd"
+
+        [model_providers.sandboxd]
+        name = "Sandbox Proxy"
+        base_url = "https://chatgpt.com/backend-api/codex"
+        experimental_bearer_token = "oai-oat01-proxy-managed"
+        requires_openai_auth = false
+        EOF
+        fi
+        case "$MODE" in
+          oauth|apikey)
+            cat > /home/agent/.codex/auth.json << 'EOF'
+        {
+          "OPENAI_API_KEY": "proxy-managed"
+        }
+        EOF
+            ;;
+          *)
+            rm -f /home/agent/.codex/auth.json
+            ;;
+        esac
+      user: "agent"
+      description: Seed Codex config/auth from SBX_CRED_OPENAI_MODE
+  startup:
+    # CODEX_HOME (~/.codex) is created agent-owned by the Dockerfile and
+    # re-ensured by the install hook above, which runs pre-launch as the agent
+    # user — so no root-owned mkdir/chown step is needed here.
+    - command: ["sh", "-c", "command -v apt-get > /dev/null 2>&1 && (apt-get update -qq -y > /dev/null 2>&1 || true) &"]
+      user: "root"
+      description: Update apt package cache in background
+    # Gateway-first MCP registration. The runtime injects MCP_GATEWAY_URL and
+    # MCP_SENTINEL_TOKEN_NAME into the container env when a gateway has been
+    # reserved. The sentinel name is not a credential — the proxy substitutes
+    # the real token at request time, keyed by that name. No-op when MCP is
+    # not enabled, which is what the guard is for.
+    #
+    # config.toml is shared territory: the install hook writes the yolo-mode
+    # and provider keys pre-launch, and Codex itself appends per-project and
+    # TUI state during a session. Append a new table rather than rewriting the
+    # file so none of that is clobbered, and grep first so re-running on every
+    # container start (which startup hooks do) stays a no-op.
+    #
+    # The header table is `http_headers`, NOT `headers`. This is the one place
+    # the port diverges from the built-in spec for correctness rather than
+    # policy: Codex spells the key `http_headers`, ignores unknown keys without
+    # complaint, and so accepts a `headers` table while sending no
+    # Authorization at all. That fails open — the gateway registers, looks
+    # healthy in `codex mcp get`, and every tool call through it is
+    # unauthenticated. Confirmed against 0.151.0: with `headers`,
+    # `codex mcp get mcp-gateway` reports `http_headers: -`; with
+    # `http_headers` it reports the header. The `headers` spelling is correct
+    # for the JSON-configured agents (copilot, kiro) and does not transliterate
+    # to Codex's TOML.
+    - command:
+        - sh
+        - -c
+        - |
+          set -e
+          [ -n "$MCP_GATEWAY_URL" ] || exit 0
+          mkdir -p "$HOME/.codex"
+          cfg="$HOME/.codex/config.toml"
+          touch "$cfg"
+          grep -q "^\[mcp_servers.mcp-gateway\]" "$cfg" && exit 0
+          cat >> "$cfg" <<EOF
+
+          [mcp_servers.mcp-gateway]
+          type = "http"
+          url = "$MCP_GATEWAY_URL"
+          [mcp_servers.mcp-gateway.http_headers]
+          Authorization = "Bearer $MCP_SENTINEL_TOKEN_NAME"
+          EOF
+      user: "agent"
+      description: Register the sandbox MCP gateway in ~/.codex/config.toml
+
+agentInstructions:
+  filename: AGENTS.md

--- a/codex/testdata/tck.yaml
+++ b/codex/testdata/tck.yaml
@@ -1,0 +1,42 @@
+# TCK configuration for the codex kit.
+#
+# codex is still a built-in agent in released sbx builds, and sbx refuses to
+# load a kit whose name collides with a built-in ("built-in agents cannot be
+# overridden by a kit"). This flag turns that one specific `sbx create` failure
+# into a skip, so the kit can land and be reviewed here before the built-in is
+# removed from sbx.
+#
+# Nothing needs re-enabling later: once a released sbx no longer registers the
+# built-in, `sbx create` succeeds, the full e2e runs, and the test logs a notice
+# that this line is obsolete and can be deleted.
+extractedFromBuiltin: true
+#
+# `promptArgs` is deliberately omitted for now, which skips the e2e `prompt`
+# subtest. Codex does have a non-interactive mode — `codex exec <prompt>` — so
+# unlike kiro this is not a permanent opt-out. What is missing is a credential:
+# every auth path this kit configures needs a real OpenAI credential on the
+# runner, and none is wired up here. The built-in agent's own e2e test does not
+# exercise a non-interactive prompt either, so there is no known-working recipe
+# to carry over. Wire `promptArgs: [exec]` once a credential exists on the
+# runner, rather than landing an invocation that can only fail or hang.
+#
+# The remaining subtests (env, files, tmpfs, agentContext) still run and are
+# what actually gate this kit.
+
+# Shape of the MCP-gateway registration written by the startup hook in
+# spec.yaml, checked by the TCK's mcp_registration subtest. The
+# format-independent parts (no-op guard, env-var indirection, no literal token,
+# non-root user) are asserted for every kit and need no configuration here.
+#
+# `transportKey` is deliberately NOT set. Codex's config file is TOML, where the
+# gateway URL is written as a bare `url = "…"` key, but the TCK asserts
+# `transportKey` as a *quoted JSON* key (`"url":`) — every other kit that
+# registers a gateway writes JSON. Declaring `url` here would fail against a
+# correct script. The URL still gets its coverage from the format-independent
+# assertion that $MCP_GATEWAY_URL appears outside the guard.
+#
+# `forbiddenKeys` is likewise left out: those assertions are quoted-JSON-key
+# searches too, so against a TOML script they can only ever trivially pass, and
+# a check that cannot fail is worse than no check — it reads as coverage.
+mcp:
+  configPath: $HOME/.codex/config.toml

--- a/codex/testdata/tck.yaml
+++ b/codex/testdata/tck.yaml
@@ -28,15 +28,30 @@ extractedFromBuiltin: true
 # format-independent parts (no-op guard, env-var indirection, no literal token,
 # non-root user) are asserted for every kit and need no configuration here.
 #
-# `transportKey` is deliberately NOT set. Codex's config file is TOML, where the
-# gateway URL is written as a bare `url = "…"` key, but the TCK asserts
-# `transportKey` as a *quoted JSON* key (`"url":`) — every other kit that
-# registers a gateway writes JSON. Declaring `url` here would fail against a
-# correct script. The URL still gets its coverage from the format-independent
-# assertion that $MCP_GATEWAY_URL appears outside the guard.
+# `configFormat: toml` is what makes the two key assertions below mean
+# anything. Codex is the first kit here whose MCP config is TOML rather than
+# JSON, so it is the first to need it: a TOML key is a bare word followed by
+# `=`, or the last segment of a `[table.header]`, and the TCK matches keys
+# accordingly. Kits that omit the field get JSON, which is what every kit
+# written before it expected.
 #
-# `forbiddenKeys` is likewise left out: those assertions are quoted-JSON-key
-# searches too, so against a TOML script they can only ever trivially pass, and
-# a check that cannot fail is worse than no check — it reads as coverage.
+# `forbiddenKeys` are the plausible-but-wrong spellings, and the first one is
+# not hypothetical:
+#
+#   * `headers` — the spelling every JSON-configured agent in this repo uses
+#     for the same concept, and the one this kit was originally ported with.
+#     Codex spells it `http_headers` and ignores unknown keys without
+#     complaining, so a `headers` table registers a gateway that looks healthy
+#     in `codex mcp get` and sends no Authorization header at all. That is a
+#     silent auth failure, which is exactly the class of bug this subtest is
+#     for. Note the check is segment-anchored, so the correct
+#     `[mcp_servers.mcp-gateway.http_headers]` does not read as the wrong one.
+#   * `httpUrl` — Gemini's spelling of `url`, the wrong answer nearest to hand
+#     when transliterating an MCP config from another agent.
 mcp:
   configPath: $HOME/.codex/config.toml
+  configFormat: toml
+  transportKey: url
+  forbiddenKeys:
+    - headers
+    - httpUrl

--- a/tck/mcp.go
+++ b/tck/mcp.go
@@ -1,6 +1,7 @@
 package tck
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -9,6 +10,20 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v3"
+)
+
+// Config formats an agent's MCP registration can be written in. The key
+// assertions below are the only part of this file that cares: everything else
+// about a registration (the guard, the env-var indirection, the absence of a
+// literal token, the user it runs as) is the same shell in any format.
+const (
+	// mcpFormatJSON is the default, and what every kit registering a gateway
+	// used before TOML turned up: a key is a quoted string followed by `:`.
+	mcpFormatJSON = "json"
+
+	// mcpFormatTOML: a key is a bare word followed by `=`, or the last
+	// segment of a `[table.header]`. No quotes, no colon.
+	mcpFormatTOML = "toml"
 )
 
 // mcpExpectations is the `mcp:` block of <kit>/testdata/tck.yaml. It records
@@ -24,13 +39,34 @@ type mcpExpectations struct {
 	// script (env vars unexpanded, e.g. "$HOME/.kiro/settings/mcp.json").
 	ConfigPath string `yaml:"configPath"`
 
-	// TransportKey is the JSON key carrying the gateway URL, without quotes
-	// (e.g. "url"). Asserted as a JSON key, so `url` matches `"url":`.
+	// ConfigFormat is the syntax of that file: "json" (the default) or
+	// "toml". It decides how TransportKey and ForbiddenKeys are matched.
+	//
+	// Explicit rather than inferred from ConfigPath's extension, for two
+	// reasons. ConfigPath is optional, so inference would have nothing to go
+	// on for a kit that omits it and would silently fall back to JSON — and
+	// silently falling back to JSON is exactly the failure this field exists
+	// to prevent, because JSON-shaped ForbiddenKeys assertions against a TOML
+	// script cannot fail, and a check that cannot fail reads as coverage
+	// while providing none. Stating the format also keeps the expectation
+	// legible to a reviewer who does not know which agent uses which syntax.
+	//
+	// Defaulting to "json" is what keeps every kit written before this field
+	// existed passing unchanged.
+	//
+	// The extension is still used, as a cross-check rather than as the
+	// source of truth: a ".toml" path declared as "json" (or the reverse) is
+	// rejected outright instead of quietly asserting the wrong syntax.
+	ConfigFormat string `yaml:"configFormat"`
+
+	// TransportKey is the key carrying the gateway URL, written bare (e.g.
+	// "url"). How it is matched follows ConfigFormat: `"url":` in JSON,
+	// `url =` in TOML.
 	TransportKey string `yaml:"transportKey"`
 
-	// ForbiddenKeys are JSON keys this agent must NOT use — the
+	// ForbiddenKeys are keys this agent must NOT use — the
 	// plausible-but-wrong spellings a neighbouring agent uses for the same
-	// concept. Also unquoted.
+	// concept. Also written bare, and also matched per ConfigFormat.
 	ForbiddenKeys []string `yaml:"forbiddenKeys"`
 }
 
@@ -43,6 +79,104 @@ const mcpGuard = `[ -n "$MCP_GATEWAY_URL" ]`
 // literalTokenPattern matches something shaped like a real bearer credential,
 // as opposed to the $MCP_SENTINEL_TOKEN_NAME reference that belongs here.
 var literalTokenPattern = regexp.MustCompile(`Bearer\s+[A-Za-z0-9_\-]{16,}`)
+
+// mcpT is the subset of *testing.T that assertMCPRegistration uses. Narrowing
+// it is what lets this package's own tests drive the assertions with a
+// recording T and prove that a wrong script really does fail them. An
+// assertion nobody has watched fail is not evidence of anything.
+type mcpT interface {
+	require.TestingT
+	Logf(format string, args ...any)
+}
+
+// format returns the declared config format, defaulted and normalised.
+func (m *mcpExpectations) format() string {
+	if m.ConfigFormat == "" {
+		return mcpFormatJSON
+	}
+	return strings.ToLower(m.ConfigFormat)
+}
+
+// validate rejects an mcp: block the assertions cannot honour: an unknown
+// format, or one that contradicts the extension of the file it describes.
+//
+// Both are silent-downgrade hazards rather than cosmetic complaints. An
+// unrecognised value would otherwise fall through to the JSON default, and a
+// ".toml" path left at the default would assert JSON syntax against a TOML
+// script — which passes the forbidden-key checks trivially and reports
+// coverage the kit does not have.
+func (m *mcpExpectations) validate() error {
+	format := m.format()
+	if format != mcpFormatJSON && format != mcpFormatTOML {
+		return fmt.Errorf("unknown configFormat %q: want %q or %q",
+			m.ConfigFormat, mcpFormatJSON, mcpFormatTOML)
+	}
+
+	// Only extensions this package knows how to match are cross-checked;
+	// anything else (no extension, ".jsonc", a bare "settings") is left to
+	// the declared value.
+	var implied string
+	switch strings.ToLower(filepath.Ext(m.ConfigPath)) {
+	case ".json":
+		implied = mcpFormatJSON
+	case ".toml":
+		implied = mcpFormatTOML
+	default:
+		return nil
+	}
+	if implied != format {
+		return fmt.Errorf("configPath %q is %s, but configFormat says %q",
+			m.ConfigPath, implied, format)
+	}
+	return nil
+}
+
+// mcpKeyPatterns returns the two regexps that decide whether a registration
+// script carries key as its transport key in the given format: present (used
+// as a key at all) and assigned (bound to $MCP_GATEWAY_URL).
+//
+// A JSON key carries its own delimiters — the quotes and the colon — so it is
+// unambiguous wherever it appears in the script. A TOML key is a bare word,
+// indistinguishable from prose except by position: it must start a line and be
+// followed by `=`. That is the one thing a TOML script needs that a JSON one
+// does not, and it has a consequence for scripts embedded in a spec: the
+// patterns are multi-line and tolerate leading whitespace, because a heredoc
+// body inside a YAML block scalar keeps whatever indentation the author gave
+// it relative to the scalar. Quoted TOML keys (`"url" = …`) are legal and
+// matched too, though nothing in this repo writes them.
+func mcpKeyPatterns(format, key string) (present, assigned *regexp.Regexp) {
+	k := regexp.QuoteMeta(key)
+	if format == mcpFormatTOML {
+		return regexp.MustCompile(`(?m)^[ \t]*"?` + k + `"?[ \t]*=`),
+			regexp.MustCompile(`(?m)^[ \t]*"?` + k + `"?[ \t]*=[ \t]*"\$MCP_GATEWAY_URL"`)
+	}
+	return regexp.MustCompile(`"` + k + `"\s*:`),
+		regexp.MustCompile(`"` + k + `"\s*:\s*"\$MCP_GATEWAY_URL"`)
+}
+
+// mcpForbiddenPattern matches key used as a key anywhere in a script of the
+// given format.
+//
+// Deliberately broader than mcpKeyPatterns' present: this is a negative
+// assertion, so being generous about what counts as "the agent used this key"
+// makes it stronger, not weaker. In JSON that means the quoted key with no
+// colon required. In TOML it means both ways a key can be named: a bare
+// assignment, and the final segment of a table header — the latter being the
+// form that actually matters, since a nested table is how a wrong key reaches
+// a TOML config in practice.
+//
+// The table form is segment-anchored so a longer key that merely ends in the
+// forbidden one does not trip it: `headers` must not match
+// `[mcp_servers.mcp-gateway.http_headers]`.
+func mcpForbiddenPattern(format, key string) *regexp.Regexp {
+	k := regexp.QuoteMeta(key)
+	if format == mcpFormatTOML {
+		return regexp.MustCompile(`(?m)^[ \t]*(?:` +
+			`"?` + k + `"?[ \t]*=` +
+			`|\[[ \t]*(?:[^]\n]*\.[ \t]*)?"?` + k + `"?[ \t]*\])`)
+	}
+	return regexp.MustCompile(`"` + k + `"`)
+}
 
 // RunMCPRegistrationTests verifies the kit's MCP-gateway registration, if it
 // declares one.
@@ -69,68 +203,75 @@ func (s *Suite) RunMCPRegistrationTests(t *testing.T) {
 	}
 
 	t.Run("mcp_registration", func(t *testing.T) {
-		// Without the guard, a sandbox with no gateway still gets a config
-		// written — one pointing at an empty URL, which the agent reports as a
-		// broken server rather than as no server at all.
-		require.Contains(t, script, mcpGuard,
-			"registration must no-op when MCP is not enabled")
-
-		// Deliberately checked against the script with the guard removed. The
-		// guard line contains $MCP_GATEWAY_URL itself, so asserting the env var
-		// against the whole script is implied by the assertion above and can
-		// never fail on its own — it would pass a script that guards on the
-		// env var and then writes a hardcoded URL into the config.
-		body := strings.Replace(script, mcpGuard, "", 1)
-		require.Contains(t, body, "$MCP_GATEWAY_URL",
-			"the gateway URL must be written into the config, not merely tested by the guard")
-
-		// Both values are injected into the container environment per sandbox.
-		// Baking either into the spec would pin one sandbox's value into an
-		// artifact every sandbox shares.
-		require.Contains(t, script, "$MCP_SENTINEL_TOKEN_NAME",
-			"the auth header must reference the sentinel name")
-
-		// The sentinel is a name; the proxy substitutes the real token per
-		// request. Anything token-shaped here is a credential in a public repo.
-		require.NotRegexp(t, literalTokenPattern, script,
-			"auth header must carry the sentinel name, never a literal token")
-
-		// The config lands under the agent user's $HOME. Writing it as root
-		// leaves a file the agent cannot rewrite later.
-		require.NotEmpty(t, user, "registration command must set an explicit user")
-		require.NotContains(t, []string{"root", "0"}, user,
-			"registration must run as the agent user, not root")
-
-		if want == nil {
-			t.Logf("%s registers an MCP gateway but declares no mcp: block in "+
-				"testdata/tck.yaml, so its config format is unverified", s.Artifact.Manifest.Name)
-			return
-		}
-
-		if want.ConfigPath != "" {
-			require.Contains(t, script, want.ConfigPath,
-				"registration must write %s", want.ConfigPath)
-		}
-		if want.TransportKey != "" {
-			key := `"` + want.TransportKey + `"`
-			require.Contains(t, script, key,
-				"the gateway URL must be carried by %s", key)
-
-			// Pair the key with the value. Asserting each separately passes a
-			// config whose transport key holds a literal URL while the env var
-			// appears only somewhere else in the script.
-			pair := regexp.MustCompile(
-				regexp.QuoteMeta(key) + `\s*:\s*"\$MCP_GATEWAY_URL"`)
-			require.Regexp(t, pair, script,
-				"%s must carry $MCP_GATEWAY_URL, not a literal address", key)
-		}
-		for _, forbidden := range want.ForbiddenKeys {
-			key := `"` + forbidden + `"`
-			require.NotContains(t, script, key,
-				"%s must not use %s — see the mcp: block in testdata/tck.yaml",
-				s.Artifact.Manifest.Name, key)
-		}
+		assertMCPRegistration(t, s.Artifact.Manifest.Name, script, user, want)
 	})
+}
+
+// assertMCPRegistration holds the whole body of the mcp_registration subtest.
+// Split out from RunMCPRegistrationTests so it can be driven with a script and
+// an expectation directly, without a kit directory on disk behind it.
+func assertMCPRegistration(t mcpT, kit, script, user string, want *mcpExpectations) {
+	// Without the guard, a sandbox with no gateway still gets a config
+	// written — one pointing at an empty URL, which the agent reports as a
+	// broken server rather than as no server at all.
+	require.Contains(t, script, mcpGuard,
+		"registration must no-op when MCP is not enabled")
+
+	// Deliberately checked against the script with the guard removed. The
+	// guard line contains $MCP_GATEWAY_URL itself, so asserting the env var
+	// against the whole script is implied by the assertion above and can
+	// never fail on its own — it would pass a script that guards on the
+	// env var and then writes a hardcoded URL into the config.
+	body := strings.Replace(script, mcpGuard, "", 1)
+	require.Contains(t, body, "$MCP_GATEWAY_URL",
+		"the gateway URL must be written into the config, not merely tested by the guard")
+
+	// Both values are injected into the container environment per sandbox.
+	// Baking either into the spec would pin one sandbox's value into an
+	// artifact every sandbox shares.
+	require.Contains(t, script, "$MCP_SENTINEL_TOKEN_NAME",
+		"the auth header must reference the sentinel name")
+
+	// The sentinel is a name; the proxy substitutes the real token per
+	// request. Anything token-shaped here is a credential in a public repo.
+	require.NotRegexp(t, literalTokenPattern, script,
+		"auth header must carry the sentinel name, never a literal token")
+
+	// The config lands under the agent user's $HOME. Writing it as root
+	// leaves a file the agent cannot rewrite later.
+	require.NotEmpty(t, user, "registration command must set an explicit user")
+	require.NotContains(t, []string{"root", "0"}, user,
+		"registration must run as the agent user, not root")
+
+	if want == nil {
+		t.Logf("%s registers an MCP gateway but declares no mcp: block in "+
+			"testdata/tck.yaml, so its config format is unverified", kit)
+		return
+	}
+
+	require.NoErrorf(t, want.validate(), "invalid mcp: block in %s/testdata/tck.yaml", kit)
+	format := want.format()
+
+	if want.ConfigPath != "" {
+		require.Contains(t, script, want.ConfigPath,
+			"registration must write %s", want.ConfigPath)
+	}
+	if want.TransportKey != "" {
+		present, assigned := mcpKeyPatterns(format, want.TransportKey)
+		require.Regexp(t, present, script,
+			"the gateway URL must be carried by a %s key %q", format, want.TransportKey)
+
+		// Pair the key with the value. Asserting each separately passes a
+		// config whose transport key holds a literal URL while the env var
+		// appears only somewhere else in the script.
+		require.Regexp(t, assigned, script,
+			"%q must carry $MCP_GATEWAY_URL, not a literal address", want.TransportKey)
+	}
+	for _, forbidden := range want.ForbiddenKeys {
+		require.NotRegexp(t, mcpForbiddenPattern(format, forbidden), script,
+			"%s must not use a %s key %q — see the mcp: block in testdata/tck.yaml",
+			kit, format, forbidden)
+	}
 }
 
 // mcpStartupCommand returns the script body and user of the kit's

--- a/tck/mcp_test.go
+++ b/tck/mcp_test.go
@@ -1,0 +1,370 @@
+package tck
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// recordingT is an mcpT that records failures instead of failing the
+// enclosing test. It is what lets the negative cases below assert that a
+// wrong script *does* trip an assertion — the point of the exercise, since a
+// check that cannot fail is worse than no check.
+type recordingT struct {
+	failed bool
+	msgs   []string
+}
+
+func (r *recordingT) Errorf(format string, args ...any) {
+	r.failed = true
+	r.msgs = append(r.msgs, fmt.Sprintf(format, args...))
+}
+
+// FailNow must not return: require.* relies on it to stop the assertion chain
+// after the first failure. runtime.Goexit unwinds the goroutine that
+// captureFailure runs the assertions on, which is the only way to honour that
+// contract outside a real *testing.T.
+func (r *recordingT) FailNow() { runtime.Goexit() }
+
+func (r *recordingT) Logf(string, ...any) {}
+
+// captureFailure runs fn against a recordingT and reports whether it failed,
+// along with everything it complained about.
+func captureFailure(fn func(t mcpT)) (failed bool, msg string) {
+	rec := &recordingT{}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fn(rec)
+	}()
+	<-done
+	return rec.failed, strings.Join(rec.msgs, "\n")
+}
+
+// The two scripts below are the shapes this repo actually ships, trimmed to
+// what the assertions look at: a JSON registration in the style of copilot and
+// kiro, and a TOML one in the style of codex. Both keep their heredoc bodies
+// indented, because that is how they read inside a YAML block scalar and it is
+// the case a line-anchored TOML pattern has to tolerate.
+const jsonScript = `set -e
+[ -n "$MCP_GATEWAY_URL" ] || exit 0
+mkdir -p "$HOME/.copilot"
+cat > "$HOME/.copilot/mcp-config.json" <<EOF
+{
+  "mcpServers": {
+    "mcp-gateway": {
+      "type": "http",
+      "url": "$MCP_GATEWAY_URL",
+      "headers": {
+        "Authorization": "Bearer $MCP_SENTINEL_TOKEN_NAME"
+      }
+    }
+  }
+}
+EOF
+`
+
+const tomlScript = `set -e
+[ -n "$MCP_GATEWAY_URL" ] || exit 0
+cfg="$HOME/.codex/config.toml"
+grep -q "^\[mcp_servers.mcp-gateway\]" "$cfg" && exit 0
+cat >> "$cfg" <<EOF
+
+  [mcp_servers.mcp-gateway]
+  type = "http"
+  url = "$MCP_GATEWAY_URL"
+  [mcp_servers.mcp-gateway.http_headers]
+  Authorization = "Bearer $MCP_SENTINEL_TOKEN_NAME"
+EOF
+`
+
+func TestMCPExpectationsValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		want    mcpExpectations
+		format  string
+		errText string
+	}{
+		{
+			name:   "empty_format_defaults_to_json",
+			want:   mcpExpectations{ConfigPath: "$HOME/.copilot/mcp-config.json"},
+			format: mcpFormatJSON,
+		},
+		{
+			name:   "explicit_toml",
+			want:   mcpExpectations{ConfigPath: "$HOME/.codex/config.toml", ConfigFormat: "toml"},
+			format: mcpFormatTOML,
+		},
+		{
+			name:   "format_is_case_insensitive",
+			want:   mcpExpectations{ConfigPath: "$HOME/.codex/config.toml", ConfigFormat: "TOML"},
+			format: mcpFormatTOML,
+		},
+		{
+			name:   "unknown_extension_trusts_declared_format",
+			want:   mcpExpectations{ConfigPath: "$HOME/.agent/settings", ConfigFormat: "toml"},
+			format: mcpFormatTOML,
+		},
+		{
+			name:   "no_config_path",
+			want:   mcpExpectations{ConfigFormat: "toml"},
+			format: mcpFormatTOML,
+		},
+		{
+			name:    "unknown_format_rejected",
+			want:    mcpExpectations{ConfigFormat: "yaml"},
+			format:  "yaml",
+			errText: `unknown configFormat "yaml"`,
+		},
+		{
+			// The silent-downgrade case the cross-check exists for: a TOML
+			// path left at the JSON default would assert JSON syntax against
+			// a TOML script, where the forbidden-key checks cannot fail.
+			name:    "toml_path_declared_json",
+			want:    mcpExpectations{ConfigPath: "$HOME/.codex/config.toml"},
+			format:  mcpFormatJSON,
+			errText: `is toml, but configFormat says "json"`,
+		},
+		{
+			name:    "json_path_declared_toml",
+			want:    mcpExpectations{ConfigPath: "$HOME/.kiro/settings/mcp.json", ConfigFormat: "toml"},
+			format:  mcpFormatTOML,
+			errText: `is json, but configFormat says "toml"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.format, tc.want.format())
+			err := tc.want.validate()
+			if tc.errText == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tc.errText)
+		})
+	}
+}
+
+func TestMCPKeyPatterns(t *testing.T) {
+	t.Run("json", func(t *testing.T) {
+		present, assigned := mcpKeyPatterns(mcpFormatJSON, "url")
+
+		require.Regexp(t, present, `"url": "$MCP_GATEWAY_URL"`)
+		require.Regexp(t, assigned, `"url": "$MCP_GATEWAY_URL"`)
+
+		// A TOML assignment is not a JSON key, and vice versa. This is the
+		// gap the format discriminator closes.
+		require.NotRegexp(t, present, `url = "$MCP_GATEWAY_URL"`)
+		require.NotRegexp(t, assigned, `"url": "https://gateway.example"`)
+
+		// The key must be a key, not a substring of a value.
+		require.NotRegexp(t, present, `"httpUrl": "$MCP_GATEWAY_URL"`)
+	})
+
+	t.Run("toml", func(t *testing.T) {
+		present, assigned := mcpKeyPatterns(mcpFormatTOML, "url")
+
+		require.Regexp(t, present, "url = \"$MCP_GATEWAY_URL\"")
+		require.Regexp(t, assigned, "url = \"$MCP_GATEWAY_URL\"")
+
+		// Indented, as a heredoc body inside a YAML block scalar can be.
+		require.Regexp(t, assigned, "  url   =  \"$MCP_GATEWAY_URL\"")
+		// Quoted keys are legal TOML.
+		require.Regexp(t, assigned, "\"url\" = \"$MCP_GATEWAY_URL\"")
+
+		// A literal address is not the env var.
+		require.NotRegexp(t, assigned, "url = \"https://gateway.example\"")
+		// A longer key that merely ends in the same word is a different key.
+		require.NotRegexp(t, present, "base_url = \"$MCP_GATEWAY_URL\"")
+		// Not anchored to a line start, so not a key.
+		require.NotRegexp(t, present, "echo url = nope")
+	})
+}
+
+func TestMCPForbiddenPattern(t *testing.T) {
+	t.Run("json", func(t *testing.T) {
+		re := mcpForbiddenPattern(mcpFormatJSON, "headers")
+		require.Regexp(t, re, `"headers": {}`)
+		require.NotRegexp(t, re, `"http_headers": {}`)
+		// A TOML table is invisible to a JSON pattern — the whole reason
+		// codex could not express these assertions before.
+		require.NotRegexp(t, re, "[mcp_servers.mcp-gateway.headers]")
+	})
+
+	t.Run("toml", func(t *testing.T) {
+		re := mcpForbiddenPattern(mcpFormatTOML, "headers")
+
+		// Both ways TOML can name a key.
+		require.Regexp(t, re, "headers = { Authorization = \"x\" }")
+		require.Regexp(t, re, "[mcp_servers.mcp-gateway.headers]")
+		require.Regexp(t, re, "  [headers]")
+		require.Regexp(t, re, `  "headers" = {}`)
+
+		// Segment-anchored: the correct key must not read as the wrong one.
+		require.NotRegexp(t, re, "[mcp_servers.mcp-gateway.http_headers]")
+		require.NotRegexp(t, re, "http_headers = {}")
+		// A value, not a key.
+		require.NotRegexp(t, re, `type = "headers"`)
+	})
+}
+
+func TestAssertMCPRegistration(t *testing.T) {
+	t.Run("json_kit_passes", func(t *testing.T) {
+		assertMCPRegistration(t, "copilot", jsonScript, "agent", &mcpExpectations{
+			ConfigPath:    "$HOME/.copilot/mcp-config.json",
+			TransportKey:  "url",
+			ForbiddenKeys: []string{"httpUrl", "transport"},
+		})
+	})
+
+	t.Run("toml_kit_passes", func(t *testing.T) {
+		assertMCPRegistration(t, "codex", tomlScript, "agent", &mcpExpectations{
+			ConfigPath:    "$HOME/.codex/config.toml",
+			ConfigFormat:  "toml",
+			TransportKey:  "url",
+			ForbiddenKeys: []string{"headers", "httpUrl"},
+		})
+	})
+
+	// Everything below asserts that a wrong script fails. Without these the
+	// TOML path would be indistinguishable from no path at all.
+	negatives := []struct {
+		name    string
+		kit     string
+		script  string
+		user    string
+		want    *mcpExpectations
+		errText string
+	}{
+		{
+			name:   "toml_wrong_transport_key",
+			kit:    "codex",
+			script: strings.ReplaceAll(tomlScript, "url = ", "endpoint = "),
+			user:   "agent",
+			want: &mcpExpectations{
+				ConfigPath:   "$HOME/.codex/config.toml",
+				ConfigFormat: "toml",
+				TransportKey: "url",
+			},
+			errText: "the gateway URL must be carried by a toml key",
+		},
+		{
+			// The env var is still in the script — just not in the key that
+			// matters. This is the case the paired assertion exists for: the
+			// format-independent "$MCP_GATEWAY_URL appears in the body" check
+			// is satisfied and the config still points somewhere fixed.
+			name: "toml_transport_key_holds_literal_address",
+			kit:  "codex",
+			script: strings.Replace(tomlScript,
+				`url = "$MCP_GATEWAY_URL"`,
+				"url = \"https://gateway.example\"\necho \"registering $MCP_GATEWAY_URL\"", 1),
+			user: "agent",
+			want: &mcpExpectations{
+				ConfigPath:   "$HOME/.codex/config.toml",
+				ConfigFormat: "toml",
+				TransportKey: "url",
+			},
+			errText: "must carry $MCP_GATEWAY_URL, not a literal address",
+		},
+		{
+			// The bug this kit's TCK entry exists to catch: Codex spells the
+			// header table `http_headers` and ignores unknown keys, so a
+			// `headers` table registers a gateway that sends no
+			// Authorization at all and still looks healthy.
+			name:   "toml_forbidden_key_as_table_header",
+			kit:    "codex",
+			script: strings.Replace(tomlScript, "http_headers]", "headers]", 1),
+			user:   "agent",
+			want: &mcpExpectations{
+				ConfigPath:    "$HOME/.codex/config.toml",
+				ConfigFormat:  "toml",
+				TransportKey:  "url",
+				ForbiddenKeys: []string{"headers"},
+			},
+			errText: `must not use a toml key "headers"`,
+		},
+		{
+			name:   "toml_forbidden_key_as_assignment",
+			kit:    "codex",
+			script: strings.Replace(tomlScript, "type = \"http\"", "httpUrl = \"x\"", 1),
+			user:   "agent",
+			want: &mcpExpectations{
+				ConfigPath:    "$HOME/.codex/config.toml",
+				ConfigFormat:  "toml",
+				TransportKey:  "url",
+				ForbiddenKeys: []string{"httpUrl"},
+			},
+			errText: `must not use a toml key "httpUrl"`,
+		},
+		{
+			name:   "json_wrong_transport_key",
+			kit:    "copilot",
+			script: strings.Replace(jsonScript, `"url":`, `"httpUrl":`, 1),
+			user:   "agent",
+			want: &mcpExpectations{
+				ConfigPath:   "$HOME/.copilot/mcp-config.json",
+				TransportKey: "url",
+			},
+			errText: "the gateway URL must be carried by a json key",
+		},
+		{
+			// A TOML kit that forgets configFormat gets caught rather than
+			// silently asserting JSON syntax it can never satisfy.
+			name:   "toml_path_left_at_json_default",
+			kit:    "codex",
+			script: tomlScript,
+			user:   "agent",
+			want: &mcpExpectations{
+				ConfigPath:   "$HOME/.codex/config.toml",
+				TransportKey: "url",
+			},
+			errText: `is toml, but configFormat says "json"`,
+		},
+		{
+			name:   "unknown_format",
+			kit:    "codex",
+			script: tomlScript,
+			user:   "agent",
+			want: &mcpExpectations{
+				ConfigFormat: "ini",
+				TransportKey: "url",
+			},
+			errText: `unknown configFormat "ini"`,
+		},
+		{
+			name:    "root_user_rejected",
+			kit:     "codex",
+			script:  tomlScript,
+			user:    "root",
+			want:    nil,
+			errText: "must run as the agent user",
+		},
+	}
+
+	for _, tc := range negatives {
+		t.Run(tc.name, func(t *testing.T) {
+			failed, msg := captureFailure(func(rt mcpT) {
+				assertMCPRegistration(rt, tc.kit, tc.script, tc.user, tc.want)
+			})
+			require.True(t, failed, "expected an assertion failure, got none")
+			require.Contains(t, msg, tc.errText)
+		})
+	}
+}
+
+// TestAssertMCPRegistrationNoExpectations covers the kit that registers a
+// gateway but declares no mcp: block — the format-independent assertions still
+// run and the format-dependent ones are skipped with a notice.
+func TestAssertMCPRegistrationNoExpectations(t *testing.T) {
+	assertMCPRegistration(t, "someagent", tomlScript, "agent", nil)
+
+	failed, msg := captureFailure(func(rt mcpT) {
+		assertMCPRegistration(rt, "someagent", "echo no guard here", "agent", nil)
+	})
+	require.True(t, failed)
+	require.Contains(t, msg, "registration must no-op when MCP is not enabled")
+}


### PR DESCRIPTION
## Summary

Publishes the `codex` agent as a public `kind: sandbox` kit. Contrib only — no
engine changes. Six files, modelled on `droid/`:

| File | What it does |
| --- | --- |
| `codex/spec.yaml` | the kit: image, entrypoint, `openai` credential (apiKey + oauth), egress allow-list, env, install + startup hooks |
| `codex/Dockerfile` | `docker.io/sbx/codex-image`, built on `docker/sandbox-templates:shell-docker` |
| `codex/README.md` | usage, the three auth modes, MCP wiring, network policy, base image |
| `codex/README.image.md` | Docker Hub overview for the base image |
| `codex/.dockerignore` | keeps kit metadata out of the build context |
| `codex/testdata/tck.yaml` | `extractedFromBuiltin: true` + the `mcp:` block |

The kit dir and `name:` are both exactly `codex`, because `codex-acp` and
`codex-app-server` pin `requires.agent: codex` and affinity matching is by
exact name. Both mixins' TCK suites still pass against this branch.

No workflow edits: image build/publish is discovered from the presence of
`codex/Dockerfile` plus `sandbox.image`.

## Spec choices worth flagging for review

**Three fixes to entries carried over from the built-in agent's spec.** These
are the deliberate divergences, not accidents:

1. **MCP header table renamed `headers` → `http_headers`** — the one
   correctness fix, and the important one. Codex spells the key
   `http_headers` and silently ignores unknown config keys, so a `headers`
   table **fails open**: the gateway registers, looks healthy, and every tool
   call through it goes out with no `Authorization` at all. Verified against
   codex-cli 0.151.0 in the built image — with `headers`,
   `codex mcp get mcp-gateway` reports `http_headers: -`; with `http_headers`
   it reports `http_headers: Authorization=*****` and `Auth: Bearer token`.
   `headers` is the correct spelling for the JSON-configured agents
   (`copilot`, `kiro`); it does not transliterate to Codex's TOML.

2. **`corepack npm install -g` → plain `npm install -g`** — the built-in
   image drives the install through `corepack npm` and then attempts
   `corepack disable npm`. Both halves are unsound on this base: `corepack
   npm` downloads an unpinned npm on every build which then warns it does not
   support the image's Node (`npm v12.0.2 does not support Node.js
   v22.22.1`), and `corepack disable npm` cannot succeed at all — the layer
   runs as the non-root `agent` user, so unlinking the root-owned
   `/usr/bin/npm` fails `EACCES` and only the `|| echo` fallback keeps the
   build green. It has nothing to remove either, since nothing ever ran
   `corepack enable`. The end state that matters is unchanged and asserted:
   `/usr/bin/npm` is the real apt npm and is first on `PATH`, which is what
   Codex's self-updater needs. Same `codex-cli 0.151.0`, same install path,
   and the build log is now clean.

3. **`mkdir -p "$HOME/.codex"` added to the MCP startup hook** — small
   hardening. The hook previously went straight to `touch "$cfg"`, which is a
   `set -e` failure if the directory is ever missing. `copilot`'s equivalent
   hook already does this.

**Not fixed, flagged instead** — both are behaviour changes I did not want to
make unilaterally inside a port:

- **`apiKey.inject` includes the bare `openai.com` apex** with an
  `Authorization: Bearer` header. The apex serves OpenAI's website, not the
  API; everything observed from a live CLI goes to `api.openai.com`,
  `chatgpt.com`, `auth.openai.com`, `files.openai.com`. While it stands, any
  process in the sandbox that fetches `openai.com` gets the user's real key
  attached by the proxy. Kept because a missing header is a silent 401 on
  whatever path *did* want it, and "no path wants it" is a negative this port
  cannot prove. There is a `TODO` on the entry and a README section on it —
  **please drop it if you can rule the last path out.**
- **`apiKey` does not set `proxyManaged: true`**, unlike most apiKey-based
  kits here. On the paths this kit configures Codex reads its key from
  `auth.json`, where the kit already writes the `proxy-managed` sentinel
  itself — so the env var is not the delivery path. The consequence is still
  that the real key sits in the container env rather than only in the proxy.
  Turning it on looks more correct and is unverified against Codex's own
  key-discovery order.

**Other deviations from the built-in spec, all deliberate:**

- `sandbox.image` is `docker.io/sbx/codex-image:latest`, not the sandbox
  template. `scripts/check-image-ref.sh` hard-fails anything else for a kit
  that ships a `Dockerfile`. Built `FROM docker/sandbox-templates:shell-docker`.
- Egress hosts are listed **without** port qualifiers. The built-in spec pins
  `:443`/`:80`; every other kit here uses bare hosts, and a hardcoded `:80`
  on the apt mirrors breaks `apt-get update` outright the day the base
  image's sources move to https. `codex-app-server` already proves bare apt
  hosts work under `deny-all`.
- `version: "1.0.0"`, `displayName`, `description` added — kit metadata with
  no built-in equivalent; the TCK requires the latter two.
- `BROWSER=xdg-open` kept for parity even though the base image ships no
  `xdg-utils` (verified absent), so the practical effect is that Codex's
  browser-open attempt fails fast and it falls back to printing the URL.
- The Dockerfile install ends with `codex --version`. An install command's
  exit code only says npm exited 0; `--include=optional` is what actually
  decides whether a usable binary landed, so the outcome is asserted rather
  than assumed.
- `testdata/tck.yaml` sets `configPath` but deliberately **omits**
  `transportKey` and `forbiddenKeys`. Those TCK assertions search for
  *quoted JSON* keys (`"url":`), and Codex's config is TOML (`url = "…"`) —
  declaring `transportKey: url` would fail against a correct script, and the
  `forbiddenKeys` searches could only ever trivially pass. A check that
  cannot fail reads as coverage, so it is left out with the reason recorded
  in the file. Worth a follow-up in the TCK if more TOML-configured agents
  land.

**Known ceiling on CI, please read before trusting the green tick:** while the
`codex` built-in still exists, kit registration rejects the name collision, and
the contrib e2e harness **skips** `extractedFromBuiltin` kits. So green CI here
means TCK plus a local-image build — it does **not** exercise the name path or
a real `sbx create`.

## Origin

Extracted from the `codex` built-in agent shipped inside `sbx`, ported to a
standalone v2 contrib kit. Leg 2 of the embedded-agent extraction (`cursor` is
a separate PR). Prose written fresh; no engine internals reproduced.

## Test plan

CI runs `kit validate` and the TCK on every PR. CI does **not** run e2e on
fork PRs (Docker Hub secrets aren't exposed there), so the e2e step below is
required from your side before requesting review.

- [ ] `sbx kit validate ./codex/` passes
- [x] `./scripts/test-kit.sh codex` passes (the TCK)
- [ ] `./scripts/test-kit-e2e.sh codex` passes. The script applies the same
      `deny-all` baseline CI uses and scopes everything to its own daemon
      (`--app-name sbx-kits-contrib-tck`), so my main sbx state is untouched.
      Every entry I added to `network.allowedDomains` came from
      `sbx --app-name sbx-kits-contrib-tck policy log <tck-e2e-…>`, not a guess.
- [ ] Manual smoke: `sbx run --kit ./codex/ codex` and verified the kit's
      binary / files / env are inside the running container.

The three unticked boxes are unticked on purpose: **all of them need `sbx`
against a host daemon, and `sbx` does not run inside a sandbox.** They have not
been run, and nothing below should be read as substituting for them — in
particular, the egress allow-list has **not** been validated under `deny-all`,
which is why the speculative `*.githubusercontent.com` host was left out rather
than guessed in.

What *was* verified, from inside the sandbox:

- `./scripts/test-kit.sh codex` — green, including `install_execution` (the
  install hook runs for real, as the `agent` user, in the built image) and
  `mcp_registration`.
- `./scripts/test-kit.sh codex-acp` and `./scripts/test-kit.sh codex-app-server`
  — both green, so neither mixin regressed and both still resolve their
  `requires.agent: codex` affinity target by exact name.
- `go test ./spec/... ./scripts/...` — green.
- `scripts/check-image-ref.sh docker.io/sbx latest` and
  `scripts/check-release-tag.sh codex/v1.0.0` — both pass.
- `docker build` of `codex/Dockerfile` — succeeds, `codex-cli 0.151.0`, binary
  at `/usr/local/share/npm-global/bin/codex` (exactly the path
  `codex-app-server`'s wrapper hardcodes), `/usr/bin/npm` intact at 9.2.0.
- The install hook run in the real image for all four `SBX_CRED_OPENAI_MODE`
  values (`oauth`, `apikey`, `none`, unset): correct branch each time, valid
  TOML in every case, `auth.json` created in the managed modes and removed in
  the others, and re-running after a mode change leaves no stale block behind.
- The MCP hook run in the real image: no-ops with no gateway, registers once
  with one reserved, stays a single table when run again, and
  `codex mcp get mcp-gateway` / `codex mcp list` confirm Codex actually parses
  the result and attaches the bearer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
