### PR TITLE
Add cursor kit

### DIFF
--- a/cursor/.dockerignore
+++ b/cursor/.dockerignore
@@ -1,0 +1,15 @@
+# The build context is the kit directory, which also holds kit metadata that the
+# image has no use for. Excluding it keeps the context small and keeps README or
+# testdata edits from touching the image build at all.
+#
+# Listed by exclusion rather than as an allowlist (`*` + `!start.sh`) so that
+# adding a COPY for a new file does not silently fail on a stale ignore rule.
+#
+# README.image.md is listed alongside README.md — it is the Docker Hub overview
+# for the image, read by the hub-overview workflow from the repository, never by
+# the build. The older kits here omit it; that is an oversight, not a rule.
+README.md
+README.image.md
+spec.yaml
+testdata/
+.dockerignore

--- a/cursor/Dockerfile
+++ b/cursor/Dockerfile
@@ -1,0 +1,79 @@
+# syntax=docker/dockerfile:1
+
+# Base image for the `cursor` sandbox kit.
+#
+# One image, no flavour suffix: the kit picks its own image, so the
+# Docker-in-Docker detail never reaches the user. There is no dockerless variant
+# either — a kind:sandbox kit names a single sandbox.image, so a second image
+# would be unreachable without a second kit to consume it.
+#
+# The base is a floating tag, which is why CI also rebuilds on a schedule.
+ARG BASE_IMAGE=docker/sandbox-templates:shell-docker
+FROM ${BASE_IMAGE}
+
+# Re-declared inside the stage: an ARG defined before the first FROM is a global
+# build arg, visible only to FROM lines. Without this, the LABEL below would
+# expand to an empty string.
+ARG BASE_IMAGE
+
+# Cursor Agent has no interactive-auth wrapper to install (unlike kiro's
+# device-flow launcher) — the sandbox proxy resolves the `cursor` credential
+# declared in spec.yaml and injects it per request. So this is just the
+# upstream install script, verbatim from https://cursor.com/cli.
+#
+# It installs into /home/agent/.local/bin/cursor-agent. That path is what
+# spec.yaml's entrypoint names, in full: the directory is on this image's PATH,
+# but the runtime owns PATH and the entrypoint is exec'd rather than run
+# through a login shell, so the kit does not rely on the lookup succeeding.
+#
+# Two departures from the vendor's published one-liner, both about failing
+# closed rather than open:
+#
+#   - `-L`. `-f` does not treat a 3xx as an error, so without `-L` a redirect
+#     would pipe an empty body into bash, bash would exit 0, and `pipefail`
+#     would see nothing wrong — an image with no agent in it that built
+#     "successfully".
+#   - the `test -x` afterwards. The installer's own failure paths are the other
+#     half of the same problem: a completed install command proves an exit
+#     code, not an installed binary. Nothing else in this repo's local
+#     verification asserts the binary exists, so assert it here.
+RUN <<EOF
+set -exo pipefail
+curl -fsSL https://cursor.com/install | bash
+test -x /home/agent/.local/bin/cursor-agent
+EOF
+
+# Inherited from the base image, but re-declared deliberately so the value is
+# owned here rather than depending on inheritance from an image this repository
+# does not own.
+#
+# This is a *request* to the runtime, not a description of the image: setting it
+# over a base with no Docker engine yields a sandbox started in Docker mode with
+# nothing to run. Since BASE_IMAGE is overridable, CI asserts the engine is
+# really present rather than trusting this label.
+LABEL com.docker.sandboxes.start-docker="true"
+
+# Both of the labels below OVERRIDE values inherited from the base image, which
+# describe the base rather than this image. Overriding is not optional for
+# `flavor`: left inherited it would read "shell-docker", and sbx would report
+# this image's agent as "shell-docker".
+#
+# sbx reads `flavor` and treats it as an agent identifier — it surfaces the value
+# as an image's `Agent` in the API, and separately uses it (with any `-docker`
+# suffix trimmed) to warn when a template looks built for a different agent than
+# the one being run. So it must be the kit's own name: `cursor`.
+LABEL com.docker.sandboxes.flavor="cursor"
+
+# Informational only — nothing in sbx reads this. Worth setting because the base
+# is a floating tag rebuilt nightly, so this is the one place the produced image
+# records what it was actually built on.
+LABEL com.docker.sandboxes.base="${BASE_IMAGE}"
+
+# Note: `com.docker.sandboxes=templates` also appears on this image. It is
+# inherited from the base and is not set here — nothing reads it, and this image
+# is not part of that template family, so it is left alone rather than asserted.
+
+# Absolute, matching spec.yaml's entrypoint, for the same reason: no dependence
+# on PATH. Note this CMD carries no --yolo — the kit's entrypoint supplies it,
+# so plain `docker run` of this image keeps the agent's own approval prompts.
+CMD [ "/home/agent/.local/bin/cursor-agent" ]

--- a/cursor/README.image.md
+++ b/cursor/README.image.md
@@ -1,0 +1,20 @@
+# sbx/cursor-image
+
+Base image for the Cursor agent kit for
+[Docker Sandboxes](https://docs.docker.com/ai/sandboxes/).
+
+## Contents
+
+Built on `docker/sandbox-templates:shell-docker`: the standard sandbox tool
+chain plus a Docker engine, requesting Docker-in-Docker via
+`com.docker.sandboxes.start-docker=true`. On top of that:
+
+- `cursor-agent`, Cursor's CLI coding agent, installed via the upstream install
+  script into `/home/agent/.local/bin/cursor-agent`
+
+Runs as the non-root `agent` user, with
+`CMD ["/home/agent/.local/bin/cursor-agent"]`.
+
+## Kit
+
+[`docker.io/sbx/cursor-kit`](https://hub.docker.com/r/sbx/cursor-kit)

--- a/cursor/README.md
+++ b/cursor/README.md
@@ -1,0 +1,250 @@
+# cursor
+
+A standalone sandbox kit (`kind: sandbox`, `schemaVersion: "2"`) for
+[Cursor Agent](https://cursor.com/cli), Cursor's CLI coding agent. The kit runs
+`cursor-agent --yolo` as the entrypoint and authenticates through a single
+credential the sandbox proxy resolves per request: an `apiKey` when a Cursor
+API key is bound on the host, or Cursor's own sign-in flow otherwise.
+
+Cursor was previously a built-in `sbx` agent, run as `sbx run cursor`. This kit
+replaces that, and is backed by a base image built from the
+[`Dockerfile`](./Dockerfile) in this directory rather than by the
+`docker/sandbox-templates` release train.
+
+> [!IMPORTANT]
+> **This kit does not load yet.** `sbx` refuses a kit whose name collides with
+> a built-in agent, and `cursor` is still built in, so every command below
+> fails with `agent "cursor" is already registered (built-in agents cannot be
+> overridden by a kit)` until a release drops the built-in. There is no flag or
+> environment variable to let the kit win.
+>
+> It is published now so the spec can be reviewed against the built-in while
+> both exist. And removing the built-in is not on its own enough to make the
+> kit work: part of Cursor's credential wiring is still supplied by `sbx` from
+> the built-in's own definition rather than from this file. See
+> [What this kit does not own yet](#what-this-kit-does-not-own-yet).
+
+## Prerequisites
+
+Either of these works — you do not need both:
+
+- A Cursor API key bound on your host as the `cursor` credential
+  (`sbx secret set cursor …`, or the interactive wizard on first run). The
+  proxy injects it as `Authorization: Bearer <token>` on outbound requests to
+  `api2.cursor.sh`, `api3.cursor.sh`, `repo42.cursor.sh`, and `cursor.com`.
+- Nothing bound at all — Cursor falls back to its own sign-in flow, which the
+  proxy brokers against `api2.cursor.sh`.
+
+## Usage
+
+These are the commands the kit is meant to be run with. They do **not** work
+while `cursor` is still a built-in agent — see the note at the top.
+
+```console
+sbx run --kit "docker.io/sbx/cursor-kit:latest" cursor
+```
+
+Or from a git URL targeting this repo:
+
+```console
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=cursor" cursor
+```
+
+Or with a local clone of this repo:
+
+```console
+sbx run --kit ./cursor/ cursor
+```
+
+The trailing `cursor` is required, not redundant: for `kind: sandbox` kits,
+`sbx` enforces that the agent name matches the kit's own `name`.
+
+## Passing arguments
+
+The entrypoint is `/home/agent/.local/bin/cursor-agent --yolo`, so anything you
+pass is appended after `--yolo`.
+
+Two details are worth knowing about that entrypoint:
+
+- **The path is absolute.** The installer puts `cursor-agent` in
+  `~/.local/bin`, which is on the image's `PATH` — but `PATH` belongs to the
+  runtime, which may replace it, and the entrypoint is exec'd rather than run
+  through a login shell. Naming the file in full means the launch does not
+  depend on a lookup succeeding.
+- **`--yolo` lets Cursor run tools without asking.** That is deliberate: the
+  container is the boundary, and it is how this agent has always started under
+  `sbx`. If you want the approval prompts back, run the binary yourself:
+  `sbx exec <sandbox> -- /home/agent/.local/bin/cursor-agent`.
+
+`--yolo` does **not** cover Cursor's separate workspace-trust prompt; the kit
+handles that (see [Workspace trust](#workspace-trust)).
+
+## How auth works
+
+The kit declares one credential, `cursor`, with both an `apiKey` and an
+`oauth` block:
+
+- `apiKey` holds `CURSOR_API_KEY`, injected as `Authorization: Bearer <token>`
+  into `api2.cursor.sh`, `api3.cursor.sh`, `repo42.cursor.sh`, and
+  `cursor.com`.
+- `oauth` points at Cursor's sign-in poll endpoint
+  (`api2.cursor.sh/auth/poll`), with `resourceHosts` naming the API hosts the
+  resulting bearer is used on.
+
+When both are declared on one credential, the `apiKey` takes precedence
+whenever it resolves — a host with a bound Cursor API key never triggers the
+interactive flow. The spec also carries a `skipIfEnv: [CURSOR_API_KEY]` entry
+under `oauth`, inherited unchanged from the built-in agent's spec, but it has
+no effect here: it's a host-env-driven shortcut that only applies to older,
+non-binding kit schemas, not to this kit's binding-driven credential
+resolution. It's kept for parity with the built-in spec rather than dropped.
+
+Two deliberate omissions:
+
+- **No `credentialFile`.** Cursor's file-backed credential store validates
+  whatever token it finds, so writing a proxy sentinel into it is worse than
+  writing nothing: validation fails and Cursor asks you to sign in again. The
+  kit sets `AGENT_CLI_CREDENTIAL_STORE=memory` instead, which keeps Cursor from
+  reading that file at all.
+- **No `apiKey.proxyManaged: true`**, unlike most API-key kits here. That flag
+  sets `CURSOR_API_KEY` to the sentinel in *every* sandbox. Cursor treats a
+  set-but-unbacked `CURSOR_API_KEY` as a real key and reports it invalid rather
+  than falling back to sign-in — so on a host with no Cursor credential,
+  enabling it would turn a working login prompt into an authentication error.
+  `sbx` already sets that variable conditionally, only when a host credential
+  exists; declaring the flag here would not add the variable, it would remove
+  the condition.
+
+## What this kit does not own yet
+
+Cursor's credential flow is **not fully expressible in a kit spec today**, and
+that is the one thing to weigh before treating this kit as a replacement for
+the built-in agent.
+
+Specifically: once Cursor's sign-in resolves, the access-token sentinel has to
+reach the agent through an environment variable, because the kit deliberately
+writes no credential file (above). The spec grammar has no field for *"deliver
+the OAuth access-token sentinel as environment variable X"*. `sbx` does that
+step for an agent it knows by the name `cursor` — and it reads the sentinel to
+deliver from **the built-in agent's own definition, not from this file**. The
+conditional setting of `CURSOR_API_KEY` is likewise `sbx`'s, though that one is
+keyed on the agent name alone and so does not depend on the built-in's
+definition surviving.
+
+Consequences, in order:
+
+1. **The built-in cannot be retired behind this kit.** Removing it would take
+   the auth-token delivery with it: this spec declares the sentinel, but
+   nothing would read it from here. Signing in on the host would then leave
+   Cursor still asking to sign in inside the sandbox. Making the kit
+   self-sufficient needs the grammar to grow a way to declare that delivery,
+   which is out of scope for this repository.
+2. **Until then the kit cannot be loaded either**, because the built-in it
+   depends on is also the name collision that blocks registration. The two
+   constraints point in opposite directions, which is why this kit lands as a
+   reviewable spec rather than a usable one.
+3. There is no workaround available to a kit author. Setting the auth-token
+   variable via `environment.variables` would set it unconditionally, which
+   reintroduces exactly the unbacked-sentinel failure described above, so the
+   kit does not do it.
+
+If you hit an auth problem that looks like "signed in on the host, still asked
+to sign in inside the sandbox", this is the area to suspect.
+
+## Workspace trust
+
+Cursor's interactive TUI has a "Workspace Trust Required" gate that `--yolo`
+does not bypass, and its `--trust` flag only applies to headless (`-p`) mode.
+Left alone, that means a prompt on every single run.
+
+The kit's `setup.install` pre-records trust for the sandbox's workspace by
+writing Cursor's own trust marker under `~/.cursor/projects/<slug>/`. The slug
+is derived from the workspace path, so this cannot be a static file — it is
+computed at create time from the in-container workspace path. If the workspace
+path is not available the command logs a notice and exits 0 rather than failing
+the create.
+
+The kit also seeds `~/.cursor/cli-config.json` with
+`{"network": {"useHttp1ForAgent": true}}` (`onlyIfMissing`, so your edits
+survive). Cursor's agent connection otherwise negotiates HTTP/2, which the
+forward proxy does not terminate — the stream never establishes and the agent
+hangs rather than erroring. Pinning HTTP/1.1 + SSE is also what makes
+credential injection possible on that connection at all.
+
+## Network policy
+
+`permissions.network.allow` mirrors every host the credential block injects
+into or routes to, plus `downloads.cursor.com` (where `cursor.com/install`
+redirects the package fetch, and where `cursor-agent` self-updates from), plus
+the apt sources the base image ships with (needed because the startup hook runs
+`apt-get update`, which fails wholesale if any configured source is
+unreachable).
+
+Two notes on the form of the entries:
+
+- **No ports.** A portless pattern matches any port. The built-in spec pinned
+  the apt hosts to `:80`, which breaks as soon as a mirror answers over HTTPS —
+  and because `apt-get update` fails wholesale when one source is unreachable,
+  the failure is not limited to that source.
+- **`*.cursor.sh` is listed alongside the named hosts.** Cursor shards its API
+  across numbered `*.cursor.sh` hosts — `api2` and `api3` are both already
+  named — and `sbx`'s own permissive default policy grants a wildcard over the
+  domain rather than an enumeration. A single-label wildcard is the enforced
+  wildcard form, so this keeps a shard that appears later from breaking the kit
+  under `deny-all`. The named hosts stay listed because they are the
+  credential's injection domains.
+
+> [!IMPORTANT]
+> This list has not been verified end-to-end under `sbx policy init deny-all`.
+> Cursor may reach further hosts (telemetry, MCP registries, docs links) that
+> aren't captured yet. If something fails under deny-all, inspect what was
+> blocked and widen the list:
+>
+> ```console
+> $ sbx policy log
+> ```
+>
+> then add the reported hosts to `permissions.network.allow` in `spec.yaml`.
+
+## Base image
+
+Unlike most kits here — which are `kind: mixin` or `kind: agent` and layer onto
+an existing `docker/sandbox-templates` image — a `kind: sandbox` kit *is* the
+whole environment, so it names the image the sandbox boots from. This kit
+builds and publishes its own, from the `Dockerfile` in this directory.
+
+The image is **`docker.io/sbx/cursor-image`**, built on
+`docker/sandbox-templates:shell-docker`, so it carries a Docker engine and
+requests Docker-in-Docker.
+
+The `-image` suffix distinguishes the base image from the kit itself: the kit
+itself is published as an OCI artifact at `docker.io/sbx/cursor-kit` (see
+[Usage](#usage) above).
+The name is derived from the kit directory and enforced repo-wide — see
+[PUBLISHING.md](../PUBLISHING.md#naming).
+
+There is no flavour suffix and no dockerless variant. The sandbox templates
+distinguish `cursor-agent` from `cursor-agent-docker` because a user picks a
+template directly, but a kit picks its own image — so the Docker-in-Docker
+detail never reaches the user, just as `sbx run cursor` already resolves to the
+Docker flavour today. And a `kind: sandbox` kit names exactly one
+`sandbox.image`, so a second image would be unreachable without a second kit to
+consume it.
+
+### Building and publishing
+
+How the image is named, tagged, verified and pushed is the same for every kit
+in this repo that builds its own image — see
+**[PUBLISHING.md](../PUBLISHING.md)** for the pipeline, the tagging scheme,
+the coordinates, and the Docker Hub OIDC setup. Only the cursor-specific parts
+are below.
+
+### Building locally
+
+```console
+docker build -t docker.io/sbx/cursor-image:latest cursor
+```
+
+`BASE_IMAGE` is a build arg, so the base can be re-pointed or digest-pinned
+without editing the `Dockerfile`: `--build-arg BASE_IMAGE=…` accepts a tag or a
+digest.

--- a/cursor/spec.yaml
+++ b/cursor/spec.yaml
@@ -1,0 +1,257 @@
+schemaVersion: "2"
+kind: sandbox
+name: cursor
+# The KIT's version, not Cursor's. It covers this spec, the network policy and
+# the setup hooks — cursor-agent inside the image floats (it installs from the
+# vendor's latest channel and self-updates), so a newer cursor-agent does not
+# bump this and this does not track Cursor releases.
+#
+# Published as the vnd.docker.sandbox.kit.version OCI annotation at pack time,
+# and `scripts/check-release-tag.sh` refuses a `cursor/vX.Y.Z` tag that
+# disagrees with it. Bump here first, then tag.
+version: "1.0.0"
+displayName: Cursor
+description: Cursor Agent, the CLI coding agent from Cursor.
+sandbox:
+  # Built from the Dockerfile beside this spec and published by
+  # .github/workflows/build-and-publish-kits.yml. Carries a Docker engine and
+  # requests Docker-in-Docker, matching the agent this kit replaces.
+  #
+  # This value is the source of truth for what CI builds and publishes: the
+  # workflow reads it from here rather than deriving a name, because spec.yaml
+  # is consumed literally (no env interpolation) and so cannot follow a
+  # variable. scripts/check-image-ref.sh asserts it stays inside the namespace
+  # CI can actually push to.
+  #
+  # The `-image` suffix distinguishes the base image from the kit artifact:
+  # when the kit itself is published as an OCI artifact it will be
+  # `docker.io/sbx/cursor-kit`.
+  image: "docker.io/sbx/cursor-image:latest"
+  # Absolute path on purpose. The vendor installer drops cursor-agent into
+  # ~/.local/bin, which is on the base image's PATH but is not something a kit
+  # should lean on: the runtime owns PATH and may replace it, and the launch
+  # is an exec of this argv rather than a login shell. Naming the file
+  # outright makes the entrypoint independent of that. (The base image's own
+  # CMD spells it the same way, for the same reason.)
+  #
+  # --yolo makes cursor-agent run tools without asking for per-tool approval.
+  # That is the point of a sandbox — the blast radius is the container — and it
+  # matches how this agent has always started under sbx. It does NOT bypass
+  # the separate workspace-trust gate; see setup.install below.
+  entrypoint: ["/home/agent/.local/bin/cursor-agent", "--yolo"]
+
+credentials:
+  - service: cursor
+    # NOT marked `required: true`. Cursor is usable with nothing bound: with no
+    # credential it starts its own in-agent sign-in, and failing fast at
+    # `sbx create` would take that path away. (Contrast `droid`, which cannot
+    # authenticate at all without a bound credential and so declares it
+    # required.)
+    apiKey:
+      name: CURSOR_API_KEY
+      # Deliberately NOT `proxyManaged: true`, unlike most apiKey-bearing kits
+      # in this repo.
+      #
+      # `proxyManaged` sets the env var to the sentinel unconditionally, for
+      # every sandbox. cursor-agent treats a set-but-unbacked CURSOR_API_KEY as
+      # a real key and reports it invalid instead of falling back to
+      # interactive sign-in — so on a host with no cursor credential, turning
+      # this on would replace a working login prompt with an authentication
+      # error.
+      #
+      # sbx already populates this variable with the sentinel for this agent
+      # *conditionally*, only when a host credential actually exists, which is
+      # the behaviour Cursor needs. Declaring it here too would not add the
+      # variable — it would remove that condition. See the README's
+      # "What this kit does not own yet".
+      #
+      # Spelled out as header + format rather than with the `scheme: bearer`
+      # sugar. The sugar normalises to exactly this, but no kit in this repo
+      # ships it yet, and an sbx release older than the sugar would reject the
+      # unknown field outright under strict decoding. The explicit form is
+      # what every other kit here uses and cannot go stale.
+      inject:
+        - domain: api2.cursor.sh
+          header: Authorization
+          format: Bearer %s
+        - domain: api3.cursor.sh
+          header: Authorization
+          format: Bearer %s
+        - domain: repo42.cursor.sh
+          header: Authorization
+          format: Bearer %s
+        - domain: cursor.com
+          header: Authorization
+          format: Bearer %s
+    oauth:
+      # Cursor's device-style sign-in polls here for the issued token.
+      tokenEndpoint:
+        host: api2.cursor.sh
+        path: /auth/poll
+      # Where the bearer is actually used, so the OAuth grant is
+      # self-describing rather than only inferable from the apiKey block
+      # above. Adding these does not widen anything: routing is the union of
+      # the apiKey inject domains, the token-endpoint host and this list, and
+      # that union is unchanged. api2.cursor.sh is omitted because the token
+      # endpoint host is already routed.
+      resourceHosts:
+        - api3.cursor.sh
+        - repo42.cursor.sh
+        - cursor.com
+      sentinels:
+        # What the container sees in place of a real token. The proxy swaps it
+        # for the real one on the hosts above.
+        accessToken: cursor-oat-proxy-managed
+        # Never rendered anywhere inside the container — this kit declares no
+        # credentialFile (see below) — but still required: the refresh sentinel
+        # is what lets the proxy mask the real refresh token in token
+        # responses and recognise a sentinel-bearing refresh request so it can
+        # substitute the real token upstream. A non-passthrough OAuth policy
+        # without it is rejected.
+        refreshToken: cursor-ort-proxy-managed
+      # No `credentialFile` on purpose. Cursor's file-backed store
+      # (~/.config/cursor/auth.json) JWT-validates whatever it finds, so a
+      # materialised file containing a sentinel is worse than no file at all:
+      # validation fails and the agent re-prompts for login. The environment
+      # block below switches the store to memory instead, and the access-token
+      # sentinel reaches the agent through its auth-token environment variable.
+      # That last step is not expressible in this spec today — see the
+      # README's "What this kit does not own yet".
+      #
+      # Carried over verbatim from the agent this kit replaces, and a no-op
+      # here: `schemaVersion: "2"` selects binding-driven credential
+      # resolution, which never consults host environment variables (a host
+      # env var must not override the user's binding). Kept rather than
+      # dropped so a diff against the built-in stays minimal, and because the
+      # intended precedence — API key beats OAuth — is already what declaring
+      # both shapes on one credential gives you.
+      skipIfEnv:
+        - CURSOR_API_KEY
+      # Cursor's token response is camelCase, not the OAuth-standard
+      # snake_case, so the field names have to be spelled out.
+      responseFields:
+        accessToken: accessToken
+        refreshToken: refreshToken
+
+permissions:
+  network:
+    # The agent this kit replaces shipped no egress policy of its own: it
+    # inherited the host policy, which defaults to permissive. A community kit
+    # cannot rely on that — this repo's e2e runs every kit under
+    # `sbx policy init deny-all`, so the kit gets exactly the reachability it
+    # declares here and nothing more.
+    #
+    # Entries are written without a port. A portless pattern matches any port,
+    # which is what we want for the apt hosts below: pinning them to :80 (as
+    # the built-in spec did) breaks the moment a mirror answers on https, and
+    # the failure mode is a wholesale `apt-get update` failure rather than a
+    # single missed source.
+    allow:
+      # Every host the credential above injects into or routes to. Required
+      # here as well, not just in the credential block: a host absent from
+      # this list is unreachable no matter what the credential declares.
+      - api2.cursor.sh
+      - api3.cursor.sh
+      - repo42.cursor.sh
+      - cursor.com
+      # Cursor shards its API across numbered *.cursor.sh hosts — two of them
+      # are already named above — and sbx's own permissive default policy
+      # grants a wildcard over the domain rather than an enumeration.
+      #
+      # Scope, precisely: `*` never crosses a dot, so this covers one more
+      # single-label sibling (api4.cursor.sh, repo43.cursor.sh) and nothing
+      # else — not a deeper name like us-east.api.cursor.sh, and not the apex
+      # cursor.sh. The multi-label form that would cover those is declared but
+      # not enforced by the current release, so listing it here would read as
+      # broader coverage than a kit actually gets. The named hosts stay listed
+      # because they are the credential's inject domains.
+      - "*.cursor.sh"
+      # cursor-agent's package host: cursor.com/install redirects the tarball
+      # fetch here (observed while building this kit's image), and the agent's
+      # self-update uses the same host. Not covered by cursor.com.
+      - downloads.cursor.com
+      # `apt-get update` (the startup hook below) refreshes metadata for every
+      # configured apt source and returns exit 100 if any one of them fails.
+      # The shell-docker base ships three sources, so all three must be
+      # reachable. Ubuntu serves amd64 from archive/security and arm64 from
+      # ports.ubuntu.com, so all three Ubuntu hosts are listed to keep the kit
+      # working cross-arch.
+      - archive.ubuntu.com        # Ubuntu archive (amd64 main)
+      - security.ubuntu.com       # Ubuntu security updates (amd64)
+      - ports.ubuntu.com          # Ubuntu archive/security (arm64)
+      - download.docker.com       # Docker's apt repo, pre-added by shell-docker
+      #
+      # TODO(cursor-extraction): this list has not been verified end-to-end
+      # under deny-all from this repo — `sbx` does not run inside a sandbox,
+      # so nobody has watched a real cursor-agent session against it yet.
+      # Confirm or widen from a live run:
+      #
+      #   ./scripts/test-kit-e2e.sh cursor
+      #   sbx --app-name sbx-kits-contrib-tck policy log <sandbox>
+
+environment:
+  variables:
+    IS_SANDBOX: "1"
+    # Keep Cursor's credentials in memory only. Left unset, Cursor reads its
+    # file-backed store (~/.config/cursor/auth.json), JWT-validates what it
+    # finds, fails on the proxy sentinel, and re-prompts for login — which is
+    # exactly the prompt a resolved credential is supposed to remove. With the
+    # store in memory the sentinel arrives through the agent's auth-token
+    # environment variable instead and is never validated locally.
+    AGENT_CLI_CREDENTIAL_STORE: "memory"
+
+setup:
+  install:
+    - command: mkdir -p /home/agent/.cursor && chown agent:agent /home/agent/.cursor
+      user: "0"
+      description: Ensure .cursor is owned by agent before setup.files and bind mounts run
+    # Pre-trust the workspace so the interactive TUI skips its "Workspace Trust
+    # Required" prompt on every single run. cursor-agent records trust in
+    # ~/.cursor/projects/<slug>/.workspace-trusted, where <slug> is the
+    # workspace path with the leading slash dropped and the remaining "/"
+    # turned into "-". The slug is per-workspace, so this cannot be a static
+    # file — it is computed from the in-container workspace path the runtime
+    # provides.
+    #
+    # Runs as the agent user so the file is owned by the account cursor-agent
+    # runs under, and as an install command (not a startup one) so it lands
+    # before the agent's first launch.
+    #
+    # --yolo bypasses tool approvals but NOT this gate, and cursor-agent's
+    # --trust flag only applies to headless (-p) mode, not the interactive TUI
+    # that `sbx run cursor` opens.
+    #
+    # Written brace-free ($VAR, not ${VAR}) on purpose: released sbx builds
+    # scan inline spec content for `${...}` placeholders and accept only
+    # ${WORKDIR}, so a defaulted expansion here would be rejected by a
+    # validator this repo's own tooling does not model.
+    - command: |
+        [ -n "$WORKSPACE_DIR" ] || { echo "WORKSPACE_DIR unset; skipping Cursor workspace pre-trust" >&2; exit 0; }
+        ws="$WORKSPACE_DIR"
+        slug=$(printf '%s' "$ws" | sed 's#^/##; s#/#-#g')
+        dir="/home/agent/.cursor/projects/$slug"
+        mkdir -p "$dir"
+        esc=$(printf '%s' "$ws" | sed 's/\\/\\\\/g; s/"/\\"/g')
+        [ -f "$dir/.workspace-trusted" ] || printf '{"trustedAt":"%s","workspacePath":"%s"}\n' "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" "$esc" > "$dir/.workspace-trusted"
+      user: "agent"
+      description: Pre-trust the workspace so cursor-agent skips the interactive Workspace Trust prompt
+  startup:
+    - command: ["sh", "-c", "command -v apt-get > /dev/null 2>&1 && (apt-get update -qq -y > /dev/null 2>&1 || true) &"]
+      user: "root"
+      description: Update apt package cache in background
+  files:
+    # Cursor's agent connection defaults to HTTP/2, which the forward proxy
+    # does not terminate — the stream never establishes and the agent hangs
+    # instead of failing. Pinning HTTP/1.1 + SSE routes it through the proxy,
+    # which is also what makes credential injection possible at all.
+    #
+    # onlyIfMissing so a user who edits this file keeps their edit across
+    # restarts. Written as the agent user, which the install command above
+    # makes possible by creating .cursor first.
+    - path: /home/agent/.cursor/cli-config.json
+      content: '{"network": {"useHttp1ForAgent": true}}'
+      onlyIfMissing: true
+      description: Seed HTTP/1.1+SSE for agent connections so traffic goes through the forward proxy
+
+agentInstructions:
+  filename: AGENTS.md

--- a/cursor/testdata/tck.yaml
+++ b/cursor/testdata/tck.yaml
@@ -1,0 +1,38 @@
+# TCK configuration for the cursor kit.
+#
+# cursor is still a built-in agent in released sbx builds, and sbx refuses to
+# load a kit whose name collides with a built-in ("built-in agents cannot be
+# overridden by a kit"). This flag turns that one specific `sbx create` failure
+# into a skip, so the kit can land and be reviewed here before the built-in is
+# removed from sbx.
+#
+# Nothing needs re-enabling later: once a released sbx no longer registers the
+# built-in, `sbx create` succeeds, the full e2e runs, and the test logs a notice
+# that this line is obsolete and can be deleted.
+extractedFromBuiltin: true
+#
+# `promptArgs` is deliberately omitted, which skips the e2e `prompt` subtest.
+# Two reasons, either of which is sufficient:
+#
+#   - Auth. With no cursor credential on the runner, cursor-agent starts its
+#     own interactive sign-in rather than answering a prompt, so a
+#     non-interactive prompt would block rather than fail. No credential is set
+#     up here, and the built-in agent's own e2e never exercised this path
+#     either.
+#   - Binary lookup. The prompt subtest invokes the agent as
+#     `sbx exec <sandbox> -- <basename of entrypoint[0]>`, i.e. bare
+#     `cursor-agent`. That resolves only if ~/.local/bin is on the PATH the
+#     exec inherits, which is exactly the assumption spec.yaml's absolute
+#     entrypoint declines to make. Whoever wires promptArgs should expect to
+#     also set `binary: /home/agent/.local/bin/cursor-agent` here.
+#
+# Wire promptArgs (`["-p"]` is cursor-agent's non-interactive flag) once a
+# known-working recipe with a real credential exists, rather than guessing at
+# flags that could flake or hang CI.
+#
+# The remaining subtests (env, files, tmpfs, agentContext) still run and are
+# what actually gate this kit — for as long as the built-in exists they are
+# skipped too, so read a green run here as "TCK passed", not "e2e passed".
+
+# The cursor kit's hooks do no MCP-gateway registration, so no `mcp:` block is
+# needed here.


### PR DESCRIPTION
## Summary

Adds a `cursor/` kit — a standalone `kind: sandbox`, `schemaVersion: "2"` kit for
[Cursor Agent](https://cursor.com/cli), extracted from the built-in `cursor`
agent. Modelled on `droid/`, which is the closest steady-state shape in the
repo: `spec.yaml`, a `Dockerfile` for `docker.io/sbx/cursor-image:latest`,
`README.md`, `README.image.md`, `.dockerignore`, `testdata/tck.yaml`.

The kit runs `/home/agent/.local/bin/cursor-agent --yolo`, declares one `cursor`
credential with both an `apiKey` and an `oauth` shape, pre-trusts the workspace
so the TUI's trust prompt does not appear on every run, and pins Cursor's agent
connection to HTTP/1.1 + SSE so it goes through the forward proxy.

**Read the "Spec choices worth flagging" section before this is treated as a
replacement for the built-in — it is not one yet, for two independent reasons.**

## Spec choices worth flagging for review

### 1. This kit is reviewable, not yet usable — and cannot simply be swapped in

Three things are worth separating here — two are blockers that resolve as the
built-in retires and the grammar grows; the third does not:

- **Today it will not load.** `sbx` refuses a kit whose name collides with a
  built-in agent, and `cursor` is still built in. `testdata/tck.yaml` sets
  `extractedFromBuiltin: true`, which turns that one failure into a skip, so the
  contrib e2e harness **skips this kit entirely**. Green CI here means TCK plus
  the local-image container assertions — **not** the name/registration path.
- **Removing the built-in is not sufficient either.** Some of Cursor's
  credential wiring is currently provided by `sbx` rather than by this spec.
  After sign-in resolves, the OAuth access-token sentinel has to reach the agent
  through an environment variable (this kit deliberately writes no credential
  file — see below), and the spec grammar has no field to declare that
  delivery. `sbx` performs it for an agent it knows by the name `cursor`, and it
  reads the sentinel to deliver **from the built-in agent's own definition, not
  from this file**. Delete the built-in and the delivery goes with it: a user who
  signed in on the host would still be asked to sign in inside the sandbox.
- **A third, narrower seam survives both of the above.** The credential's
  `service: cursor` name is itself load-bearing beyond this file: the sandbox
  proxy's Cursor session bootstrap keys on it. Unlike the two blockers above,
  this one does not go away once the built-in is retired and the env-delivery
  gap is closed — renaming the service in this spec would still silently
  disable that bootstrap. It's a seam to keep in mind for as long as this kit
  exists, not just until the other two land.

So the first two are a blocker for retiring the built-in, not for publishing.
The kit is published for parity and review; retiring the built-in behind it
needs the grammar to grow a way to declare that env delivery. There is no
kit-side workaround — see item 3.

The README says all of this in user-facing terms, including at the very top, so
nobody follows the Usage section into a hard registration error.

### 2. Deviations from the built-in spec, and why

| Built-in | This kit | Why |
|---|---|---|
| `image: docker/sandbox-templates:cursor-agent-docker` | `docker.io/sbx/cursor-image:latest`, built from `shell-docker` | A kit that ships a Dockerfile must publish into the namespace CI authenticates to; `scripts/check-image-ref.sh` hard-fails otherwise. |
| `entrypoint: [cursor-agent, --yolo]` | absolute `/home/agent/.local/bin/cursor-agent` | The installer puts the binary there. The directory *is* on the image's `PATH` (verified), but `PATH` belongs to the runtime, which may replace it, and the entrypoint is exec'd rather than run through a login shell. |
| apt hosts pinned `:80`, Cursor hosts `:443` | no ports at all | A portless pattern matches any port. `archive.ubuntu.com:80` blocks the moment a mirror answers over HTTPS — and because `apt-get update` fails wholesale when one source is unreachable, that is not a partial failure. |
| three enumerated `*.cursor.sh` hosts | same three plus `*.cursor.sh` | Cursor shards its API across numbered hosts (`api2`, `api3` are both already named) and sbx's own default policy wildcards the domain rather than enumerating it. `*` never crosses a dot. |
| n/a | `registry.npmjs.org` allowed | cursor-agent's update check and npm-backed features reach the npm registry at runtime — surfaced by live testing. |
| no `resourceHosts` on the OAuth block | `resourceHosts` listed | Purely descriptive: routing is the union of the apiKey inject domains, the token-endpoint host, and this list, and that union is unchanged. |
| n/a | **no** `apiKey.proxyManaged: true` | See item 3. |
| n/a | **no** `required: true` on the credential | Cursor is usable with nothing bound (it falls back to its own sign-in), so failing fast at `sbx create` would remove a working path. |
| `curl -fsS … \| bash` | `curl -fsSL … \| bash` plus `test -x` on the installed binary | `-f` does not treat a 3xx as an error, so without `-L` a redirect pipes an empty body to `bash`, and the image builds "successfully" with no agent in it. |
| `header:`/`format:` on each inject | kept verbatim | The `scheme: bearer` sugar normalises to exactly this, but an older `sbx` would reject the unknown field under strict decoding. |

Also carried over unchanged, deliberately: `skipIfEnv: [CURSOR_API_KEY]` (inert
under `schemaVersion: "2"` binding-driven resolution, kept for spec fidelity)
and the `refreshToken` sentinel (required for the proxy to mask the real
refresh token and recognise sentinel-bearing refresh requests).

### 3. Two deliberate omissions in the credential block

- **No `credentialFile`.** Cursor's file-backed store validates whatever token
  it finds, so materialising a sentinel into it is *worse* than writing nothing:
  validation fails and Cursor re-prompts for login. `AGENT_CLI_CREDENTIAL_STORE=memory`
  keeps Cursor from reading that file at all. This is what forces the env-var
  delivery discussed in item 1.
- **No `apiKey.proxyManaged: true`**, unlike most API-key kits here.
  `proxyManaged` sets the env var to the sentinel **unconditionally, in every
  sandbox**. Cursor treats a set-but-unbacked `CURSOR_API_KEY` as a real key and
  reports it invalid rather than falling back to sign-in, so enabling it would
  turn a working login prompt into an authentication error on any host with no
  Cursor credential. `sbx` already sets that variable *conditionally*, only when
  a host credential exists. Declaring the flag here would not add the variable —
  it would remove the condition.

### Sign-in inside a sandbox (field-verified)

Sign-in works without any browser or display inside the sandbox itself. When
you run `cursor-agent login`, it prints a `cursor.com` sign-in link and
simultaneously tries to open it for you; either way, you (or the sandbox
tooling on your behalf) open that link in a normal browser on your machine,
sign in there, and `cursor-agent` — polling `api2.cursor.sh` in the
background — picks up the completed login automatically within a few seconds.
If the link can't be auto-opened for any reason, the same printed URL still
works when opened by hand, and a network hiccup on the polling side fails
fast with a clear retry message rather than hanging. The kit's network
allow-list covers every host this flow touches. (Verified by driving the real
`cursor-agent login` from the published agent image through a pty harness
across display/SSH/offline permutations, and by a live sandbox session.)

### 4. `promptArgs` omitted from `tck.yaml`

Two independent reasons, either sufficient: with no credential on the runner
Cursor starts interactive sign-in and a non-interactive prompt would block
rather than fail; and the prompt subtest invokes bare `cursor-agent`, which
resolves only if `~/.local/bin` is on the exec's inherited `PATH` — exactly the
assumption the absolute entrypoint declines to make. Both notes are in
`tck.yaml`.

## Origin

Ported from the built-in `cursor` agent in `sbx` — same behaviour, prose written
fresh for this repo. Part of the embedded-agent extraction, after `droid`.
Contrib-only: no engine changes.

## Test plan

CI runs `kit validate` and the TCK on every PR; e2e **skips** this kit while
the `cursor` built-in exists (`extractedFromBuiltin: true`).

- [x] `./scripts/test-kit.sh cursor` passes (the TCK), including the container
      subtests
- [x] `./scripts/check-image-ref.sh docker.io/sbx latest` passes
- [x] Live sandbox session (via a renamed copy, since the name collides with
      the built-in): image runs, workspace mounts, interactive Google-account
      sign-in completes end-to-end, chat works
- [ ] **F5** — Determine cursor-agent's telemetry opt-out knob and set it
      (`aider`/`claude-mem`/`paperclip` precedent), or record explicitly that
      none exists.
- [ ] **F6** — Confirm the released proxy's allow-list matcher treats
      `*.cursor.sh` as single-label (`api4.cursor.sh` reachable,
      `us-east.api.cursor.sh` blocked); if it crosses dots, drop the wildcard.
- [ ] **F7** — The built-in's backgrounded `apt-get update` redirected stdin
      from `/dev/null`; this kit drops that to match repo convention. No
      failure observed; flagging in case a host session surfaces one.
