### PR TITLE
feat(antigravity): add agent kit

### DIFF
--- a/antigravity/Dockerfile
+++ b/antigravity/Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1.7
+
+ARG BASE_IMAGE=docker/sandbox-templates:shell-docker
+FROM ${BASE_IMAGE}
+
+ARG BASE_IMAGE
+
+USER agent
+RUN curl -fsSL https://antigravity.google/cli/install.sh -o /tmp/install-antigravity.sh && \
+    bash /tmp/install-antigravity.sh --dir /home/agent/.local/bin && \
+    rm -f /tmp/install-antigravity.sh && \
+    agy --help >/dev/null
+
+LABEL com.docker.sandboxes.start-docker="true"
+LABEL com.docker.sandboxes.flavor="antigravity"
+LABEL com.docker.sandboxes.base="${BASE_IMAGE}"
+
+WORKDIR /home/agent
+CMD ["agy", "--dangerously-skip-permissions"]

--- a/antigravity/README.image.md
+++ b/antigravity/README.image.md
@@ -1,0 +1,9 @@
+# sbx/antigravity-image
+
+Base image for the Google Antigravity kit for [Docker Sandboxes](https://docs.docker.com/ai/sandboxes/).
+
+It is built on `docker/sandbox-templates:shell-docker` and installs Google's `agy` terminal coding agent with the official installation script. The installer resolves the current release and verifies its published checksum. The image runs as the non-root `agent` user and requests Docker-in-Docker through the standard sandbox image label.
+
+## Kit
+
+[`docker.io/sbx/antigravity-kit`](https://hub.docker.com/r/sbx/antigravity-kit)

--- a/antigravity/README.md
+++ b/antigravity/README.md
@@ -1,0 +1,44 @@
+# Google Antigravity
+
+A standalone Docker Sandboxes kit for [Google Antigravity](https://antigravity.google/). It runs the `agy` terminal coding agent with sandbox-local permissions pre-approved and supports either Antigravity's Google OAuth login or a Gemini API key.
+
+## Usage
+
+Use the published kit:
+
+```console
+sbx run --kit "docker.io/sbx/antigravity-kit:latest" antigravity
+```
+
+Or load it directly from this repository:
+
+```console
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=antigravity" antigravity
+```
+
+Or use a local clone:
+
+```console
+sbx run --kit ./antigravity/ antigravity
+```
+
+## Authentication
+
+For OAuth, choose **skip** if `sbx` offers to configure the optional `google` credential. Antigravity then starts its native Google sign-in flow. Open the displayed URL in your browser, complete sign-in, and paste the authorization code back into the terminal. The resulting session is retained in the sandbox's persistent home directory.
+
+For API-key mode, provide the key when `sbx` offers to configure the `google` credential, or store it before launching:
+
+```console
+sbx secret set google
+sbx run --kit "docker.io/sbx/antigravity-kit:latest" antigravity
+```
+
+The kit exposes `GEMINI_API_KEY` as a proxy sentinel and injects the real key only into requests to `generativelanguage.googleapis.com`. It also sets Antigravity's required `modelProvider` setting to `gemini`. Removing the stored credential and recreating the sandbox switches back to OAuth mode.
+
+## MCP gateway
+
+When Docker Sandboxes provides an MCP gateway, the kit registers it in Antigravity's user-level MCP configuration with the proxy-managed bearer sentinel. Existing MCP servers in that file are preserved.
+
+## Image
+
+The companion image is built from `docker/sandbox-templates:shell-docker` and installs `agy` with Google's official installation script. The installer resolves the current release and verifies its published checksum.

--- a/antigravity/spec.yaml
+++ b/antigravity/spec.yaml
@@ -1,0 +1,99 @@
+schemaVersion: "2"
+kind: sandbox
+name: antigravity
+version: "1.0.0"
+displayName: Google Antigravity
+description: Google's agent-first development platform, available as the agy terminal coding agent.
+
+sandbox:
+  image: docker.io/sbx/antigravity-image:latest
+  entrypoint:
+    - agy
+  command:
+    default:
+      - --dangerously-skip-permissions
+
+agentInstructions:
+  filename: AGENTS.md
+
+credentials:
+  - service: google
+    description: Gemini API key for Antigravity's headless API-key mode
+    apiKey:
+      name: GEMINI_API_KEY
+      proxyManaged: true
+      inject:
+        - domain: generativelanguage.googleapis.com
+          header: x-goog-api-key
+          format: "%s"
+
+permissions:
+  network:
+    allow:
+      - accounts.google.com
+      - oauth2.googleapis.com
+      - www.googleapis.com
+      - lh3.googleusercontent.com
+      - aicode.googleapis.com
+      - cloudcode-pa.googleapis.com
+      - daily-cloudcode-pa.googleapis.com
+      - generativelanguage.googleapis.com
+      - antigravity.google
+      - antigravity.google.com
+      - antigravity-unleash.goog
+      - play.googleapis.com
+      - safebrowsing.googleapis.com
+      - www.gstatic.com
+      - antigravity-cli-auto-updater-974169037036.us-central1.run.app
+      - storage.googleapis.com
+      - raw.githubusercontent.com
+
+environment:
+  variables:
+    BROWSER: xdg-open
+
+setup:
+  startup:
+    - command:
+        - sh
+        - -c
+        - |
+          set -e
+          cfg="$HOME/.gemini/antigravity-cli/settings.json"
+          mkdir -p "$(dirname "$cfg")"
+          [ -s "$cfg" ] || echo '{}' > "$cfg"
+          if [ "${SBX_CRED_GOOGLE_MODE:-none}" = apikey ]; then
+            jq '.modelProvider = "gemini"' "$cfg" > "$cfg.tmp"
+          else
+            jq 'del(.modelProvider)' "$cfg" > "$cfg.tmp"
+          fi
+          mv "$cfg.tmp" "$cfg"
+      user: "1000"
+      description: Select Gemini API-key mode only when a Google credential is available
+    - command:
+        - sh
+        - -c
+        - |
+          set -e
+          [ -n "$MCP_GATEWAY_URL" ] || exit 0
+          cfg="$HOME/.gemini/config/mcp_config.json"
+          mkdir -p "$(dirname "$cfg")"
+          [ -s "$cfg" ] || echo '{}' > "$cfg"
+          frag=/tmp/antigravity-mcp-gateway.json
+          cat > "$frag" <<EOF
+          {
+            "mcpServers": {
+              "mcp-gateway": {
+                "serverUrl": "$MCP_GATEWAY_URL",
+                "headers": {
+                  "Authorization": "Bearer $MCP_SENTINEL_TOKEN_NAME"
+                }
+              }
+            }
+          }
+          EOF
+          jq -s '.[0] * .[1]' "$cfg" "$frag" > "$cfg.tmp"
+          mv "$cfg.tmp" "$cfg"
+          rm -f "$frag"
+      user: "1000"
+      description: Register the sandbox MCP gateway in Antigravity's user configuration

--- a/antigravity/testdata/tck.yaml
+++ b/antigravity/testdata/tck.yaml
@@ -1,0 +1,6 @@
+mcp:
+  configPath: $HOME/.gemini/config/mcp_config.json
+  transportKey: serverUrl
+  forbiddenKeys:
+    - url
+    - httpUrl


### PR DESCRIPTION
<!--
Thanks for contributing to sbx-kits-contrib!

PRs from forks have CI's `test-kit-e2e` job SKIPPED because GitHub does not
expose `DOCKERPUBLICBOT_USERNAME` / `DOCKERPUBLICBOT_WRITE_PAT` to fork-triggered workflows.
The e2e assertions will not run on your PR — your laptop is the only place
they run before merge. See the checklist below.
-->

## Summary

Add a standalone Google Antigravity kit that:

- Builds the `agy` CLI from Google’s checksummed release manifest.
- Supports native Google OAuth and proxy-managed Gemini API keys.
- Configures API-key mode only when a Google credential is available.
- Registers the Docker Sandboxes MCP gateway.
- Runs with tool permissions pre-approved inside the sandbox.

## Spec choices worth flagging for review

The kit uses a pre-built image based on
`docker/sandbox-templates:shell-docker`. Scheduled image rebuilds resolve the
current Antigravity release from Google’s architecture-specific manifest and
verify its SHA-512 checksum before installation.

OAuth uses Antigravity’s native browser/code flow. API-key authentication uses
the Docker Sandboxes credential store and injects `GEMINI_API_KEY` only for
`generativelanguage.googleapis.com`.

The network allowlist comes from Google’s documentation and observed
`sbx policy log` traffic. `lh3.googleusercontent.com` is required by
Antigravity’s eligibility check when retrieving the signed-in user’s profile
picture.

## Origin

The kit was authored from Google Antigravity’s official CLI installation, authentication, headless-mode, and MCP documentation: https://antigravity.google/docs/cli/install/.

## Test it locally

```
docker build \
  -t docker.io/sbx/antigravity-image:latest \
  ./antigravity

image_tar=$(mktemp "${TMPDIR:-/tmp}/antigravity-image-XXXXXX")
docker save docker.io/sbx/antigravity-image:latest -o "$image_tar"
sbx template load "$image_tar"
rm -f "$image_tar"

sbx template ls
sbx run --kit ./antigravity antigravity
```

<img width="892" height="659" alt="image" src="https://github.com/user-attachments/assets/fbc7ba6d-d405-4407-8061-b991ebcf50f2" />


## Test plan

CI runs `kit validate` and the TCK on every PR. CI does **not** run e2e on
fork PRs (Docker Hub secrets aren't exposed there), so the e2e step below is
required from your side before requesting review.

- [ ] `sbx kit validate ./<kit>/` passes
- [ ] `./scripts/test-kit.sh <kit>` passes (the TCK)
- [ ] `./scripts/test-kit-e2e.sh <kit>` passes. The script applies the same
      `deny-all` baseline CI uses and scopes everything to its own daemon
      (`--app-name sbx-kits-contrib-tck`), so my main sbx state is untouched.
      Every entry I added to `network.allowedDomains` came from
      `sbx --app-name sbx-kits-contrib-tck policy log <tck-e2e-…>`, not a guess.
- [ ] Manual smoke: `sbx run --kit ./<kit>/ <agent>` and verified the kit's
      binary / files / env are inside the running container.

One-time setup if you haven't run e2e on this machine before:
`sbx --app-name sbx-kits-contrib-tck login`.

See [CONTRIBUTING.md → Verifying locally](../CONTRIBUTING.md#verifying-locally)
and [README → Declare every domain your kit needs](../README.md#declare-every-domain-your-kit-needs)
for the cross-arch domain gotchas (`archive.ubuntu.com`,
`security.ubuntu.com`, `ports.ubuntu.com`) and the package-manager refresh trap.
