### PR TITLE
Rename glab kit to gitlab, add gitlab-ssh for git-over-SSH

### DIFF
--- a/gitlab-ssh/README.md
+++ b/gitlab-ssh/README.md
@@ -1,0 +1,73 @@
+# gitlab-ssh
+
+A mixin that pre-populates `~/.ssh/known_hosts` with GitLab.com's SSH host
+keys so SSH operations to GitLab work without interactive host verification
+prompts.
+
+Without this kit, SSH connections from a sandbox to GitLab fail because
+there is no TTY available to interactively accept a new host key.
+
+## Why this exists
+
+The [`gitlab`](../gitlab/) kit wires up PAT auth for `glab` and the GitLab
+REST API over `gitlab.com`, but the sandbox proxy cannot rewrite
+git-over-HTTPS Basic auth on that same domain (see the `gitlab` kit's
+README for why). SSH is the supported path for `git push`/`git pull`/`git
+clone` against GitLab from inside a sandbox. This kit removes the one thing
+that otherwise breaks that path non-interactively: host key verification.
+
+## Prerequisites
+
+Your SSH key must be loaded in the agent on the host and registered with
+your GitLab account:
+
+```console
+ssh-add ~/.ssh/id_ed25519
+```
+
+`SSH_AUTH_SOCK` is forwarded into the sandbox automatically.
+
+Start the sandbox with this kit attached, from its published OCI artifact
+on Docker Hub:
+
+```console
+sbx run --kit "docker.io/sbx/gitlab-ssh-kit:latest" claude
+```
+
+Or from a git URL targeting this repo:
+
+```console
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=gitlab-ssh" claude
+```
+
+## Usage
+
+Once the kit is installed, SSH operations to GitLab work without any
+additional configuration:
+
+```console
+git clone git@gitlab.com:group/project.git
+git push origin my-branch
+```
+
+## Composing with gitlab
+
+Combine with the [`gitlab`](../gitlab/) kit to get both `glab`/API auth
+(Bearer, proxy-injected) and git push/pull (SSH) in one sandbox:
+
+```console
+sbx run \
+  --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=gitlab" \
+  --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=gitlab-ssh" \
+  claude
+```
+
+## How it works
+
+At install time, the kit appends GitLab.com's published SSH host keys
+(ED25519, RSA, ECDSA — from
+[GitLab's SSH host keys fingerprints doc](https://docs.gitlab.com/user/gitlab_com/#ssh-host-keys))
+to `/home/agent/.ssh/known_hosts`. Unlike GitHub, GitLab does not publish an
+HTTPS metadata endpoint for these, so they're pinned directly in this spec.
+GitLab.com's host keys are long-lived; if GitLab ever rotates them, bump the
+`known_hosts` block in `spec.yaml` from the doc above.

--- a/gitlab-ssh/spec.yaml
+++ b/gitlab-ssh/spec.yaml
@@ -1,0 +1,38 @@
+schemaVersion: "2"
+kind: mixin
+name: gitlab-ssh
+displayName: GitLab SSH
+description: Pre-populates GitLab.com's SSH host keys so git clone/push/pull over SSH work without interactive host verification prompts.
+agentInstructions:
+  content: |
+    ## GitLab SSH authentication
+
+    GitLab.com's SSH host keys are pre-populated in `~/.ssh/known_hosts`, so
+    SSH operations to GitLab (clone, push, pull) work without interactive
+    host verification prompts. Use `git@gitlab.com:group/project.git`
+    remotes — the sandbox proxy does not rewrite git-over-HTTPS Basic auth
+    for GitLab (see the `gitlab` kit), so SSH is the supported push/pull path.
+permissions:
+  network:
+    allow:
+      - gitlab.com
+setup:
+  install:
+    # GitLab, unlike GitHub, has no HTTPS metadata endpoint that publishes
+    # current SSH host keys, so they're pinned here from GitLab's own docs.
+    # These are long-lived (GitLab.com's host keys rarely rotate); if they
+    # ever do, refresh from https://docs.gitlab.com/user/gitlab_com/#ssh-host-keys
+    # and update the block below.
+    - command: |
+        mkdir -p /home/agent/.ssh
+        chmod 700 /home/agent/.ssh
+        chown agent:agent /home/agent/.ssh
+        cat >> /home/agent/.ssh/known_hosts <<'EOF'
+        gitlab.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAfuCHKVTjquxvt6CM6tdG4SLp1Btn/nOeHHE5UOzRdf
+        gitlab.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCsj2bNKTBSpIYDEGk9KxsGh3mySTRgMtXL583qmBpzeQ+jqCMRgBqB98u3z++J1sKlXHWfM9dyhSevkMwSbhoR8XIq/U0tCNyokEi/ueaBMCvbcTHhO7FcwzY92WK4Yt0aGROY5qX2UKSeOvuP4D6TPqKF1onrSzH9bx9XUf2lEdWT/ia1NEKjunUqu1xOB/StKDHMoX4/OKyIzuS0q/T1zOATthvasJFoPrAjkohTyaDUz2LN5JoH839hViyEG82yB+MjcFV5MU3N1l1QL3cVUCh93xSaua1N85qivl+siMkPGbO5xR/En4iEY6K2XPASUEMaieWVNTRCtJ4S8H+9
+        gitlab.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFSMqzJeV9rUzU4kWitGjeR4PWSa29SPqJ1fVkhtj3Hw9xjLVXVYrU9QlYWrOLXBpQ6KWjbjTDTdDkoohFzgbEY=
+        EOF
+        chmod 644 /home/agent/.ssh/known_hosts
+        chown agent:agent /home/agent/.ssh/known_hosts
+      user: "0"
+      description: Pin GitLab.com's published SSH host keys into known_hosts

--- a/gitlab/README.md
+++ b/gitlab/README.md
@@ -1,4 +1,4 @@
-# glab — GitLab CLI
+# gitlab — GitLab CLI
 
 A mixin kit that installs the [GitLab CLI (`glab`)](https://gitlab.com/gitlab-org/cli) and wires up personal access token (PAT) authentication for gitlab.com through the sandbox proxy. Pairs with any base agent (claude, codex, gemini, …).
 
@@ -15,7 +15,7 @@ sbx secret set gitlab
 Then create a sandbox with the kit:
 
 ```console
-sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=glab" claude
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=gitlab" claude
 ```
 
 Verify inside the sandbox:
@@ -29,7 +29,40 @@ glab api user
 
 - The kit declares a `gitlab` credential with `proxyManaged: true`. Inside the container, `GITLAB_TOKEN` is set to a sentinel value, which is enough for `glab` to consider itself logged in.
 - On any request to `gitlab.com`, the sandbox proxy replaces the `Authorization` header with `Bearer <your-real-PAT>`. The real token never enters the sandbox filesystem or environment.
-- Git-over-HTTPS push credentials are **not** wired up by this kit — git sends Basic auth, which the kit does not rewrite. Use `glab api`, or public read-only clones. (Native GitLab sign-on, including git, is on the sbx roadmap.)
+
+## Git-over-HTTPS push/pull is not wired up — use SSH instead
+
+Git sends HTTP Basic auth for `git clone`/`push`/`pull`, not Bearer. A
+second `credentials[].apiKey.inject` rule with `scheme: basic` on the same
+`gitlab.com` domain was tried and **confirmed not to work**: the sandbox
+proxy does not disambiguate two inject rules on one domain by which auth
+scheme the client sent, so the Basic-auth request is never rewritten and
+GitLab rejects the literal sentinel value. (GitHub avoids this because its
+built-in credential's Bearer traffic goes to `api.github.com` while
+git-over-HTTPS goes to `github.com` — different domains, no collision.
+GitLab serves both the API and git smart-HTTP from `gitlab.com`.) This is a
+proxy-level gap, not something a kit can work around — it's been raised
+upstream as a feature request for scheme-aware or path-aware credential
+injection.
+
+Use SSH remotes for git operations instead:
+
+```console
+git clone git@gitlab.com:group/project.git
+git push origin my-branch
+```
+
+Add the [`gitlab-ssh`](../gitlab-ssh/) kit alongside this one so SSH
+host-key verification doesn't hang on a missing TTY:
+
+```console
+sbx run \
+  --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=gitlab" \
+  --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=gitlab-ssh" \
+  claude
+```
+
+You'll also need your SSH key loaded in the host agent (`ssh-add ~/.ssh/id_ed25519`) so it forwards into the sandbox, and that key registered with your GitLab account.
 
 ## Self-managed GitLab
 

--- a/gitlab/spec.yaml
+++ b/gitlab/spec.yaml
@@ -1,6 +1,6 @@
 schemaVersion: "2"
 kind: mixin
-name: glab
+name: gitlab
 displayName: GitLab CLI (glab)
 description: Installs the GitLab CLI (glab) with proxy-injected personal access token auth for gitlab.com, so agents can work with GitLab projects the way gh works with GitHub.
 
@@ -20,6 +20,13 @@ credentials:
       # glab reads GITLAB_TOKEN and treats itself as logged in. proxyManaged
       # sets it to the sentinel inside the container; the proxy replaces the
       # Authorization header with the real token on outbound gitlab.com calls.
+      #
+      # A second inject rule with `scheme: basic` (for git-over-HTTPS) was
+      # tried and confirmed NOT to work: the proxy does not disambiguate two
+      # inject rules on the same domain by which auth scheme the client sent,
+      # so the Basic-auth request is never rewritten and GitLab rejects the
+      # literal sentinel. See README for the SSH-based workaround (gitlab-ssh)
+      # and the upstream feature request this gap warrants.
       name: GITLAB_TOKEN
       proxyManaged: true
       inject:
@@ -35,8 +42,15 @@ agentInstructions:
     sandbox proxy — `GITLAB_TOKEN` is a proxy-managed placeholder, never the
     real token. Use `glab api ...` for arbitrary GitLab REST calls and the
     usual `glab mr` / `glab issue` / `glab repo` subcommands. Verify auth
-    with `glab auth status`. Git-over-HTTPS push auth is not wired up by
-    this kit; use `glab api` or read-only clones of public repos.
+    with `glab auth status`.
+
+    Git-over-HTTPS push/pull auth is NOT wired up by this kit (the sandbox
+    proxy cannot rewrite git's Basic auth on gitlab.com without breaking the
+    Bearer auth `glab`/the API rely on — same domain, two schemes). For
+    `git clone` / `git push` / `git pull` against GitLab, use SSH remotes
+    (`git@gitlab.com:group/project.git`) — add the `gitlab-ssh` kit for
+    passwordless host-key verification, and load your key with `ssh-add`
+    on the host so it forwards into the sandbox.
 
 setup:
   install:


### PR DESCRIPTION
## Summary

- Renames the `glab` mixin to `gitlab` (directory + `name:` field) for clarity.
- Adds a new `gitlab-ssh` mixin, mirroring `github-ssh`: pins GitLab.com's published SSH host keys into `known_hosts` so `git clone`/`push`/`pull` over SSH work without an interactive host-key prompt.
- Updates the `gitlab` kit's README/`agentInstructions` to steer git operations at SSH remotes and point at `gitlab-ssh`.

## Why

The `glab` kit only wires up Bearer auth for `glab`/REST API traffic to `gitlab.com`. Git-over-HTTPS push/pull was never covered, and I tried closing that gap by adding a second `credentials[].apiKey.inject` rule with `scheme: basic` (GitLab accepts `oauth2:<PAT>` as HTTP Basic) on the *same* `gitlab.com` domain.

I tested this against a live sandbox and confirmed it does **not** work: the proxy does not disambiguate two inject rules on one domain by which auth scheme the client already sent, so the Basic-auth git request is never rewritten and GitLab rejects the literal sentinel value with `HTTP Basic: Access denied`. Bearer auth for `glab api` continued to work fine throughout.

GitHub avoids this exact collision because its Bearer traffic goes to `api.github.com` while git-over-HTTPS goes to `github.com` — different domains, no collision. GitLab serves both the API and git smart-HTTP from the single `gitlab.com` host, so there's no domain split to fall back on. This looks like a proxy-level gap (no way to disambiguate same-domain inject rules by scheme), not something fixable from the kit side — I'll file a separate feature request for that.

Given HTTPS push isn't fixable here, `gitlab-ssh` makes the documented workaround (SSH remotes via the forwarded host SSH agent) actually usable non-interactively, the same way `github-ssh` does for GitHub.

## Breaking change note for maintainers

`glab` was merged in #225 and is already published as `docker.io/sbx/glab-kit:latest`. Renaming it to `gitlab` means that published tag goes stale rather than updating — happy to add a redirect/alias if there's a preferred mechanism, or to keep the old name if you'd rather avoid the break. Given it's only been live ~2 weeks I judged the clearer name worth it, but deferring to you here.

## Test plan

- [x] `sbx kit validate` — both kits
- [x] TCK (`scripts/test-kit.sh`) — both kits, passing
- [x] e2e under `deny-all` (`scripts/test-kit-e2e.sh`) — both kits, passing
- [x] Manual verification in a live sandbox:
  - `glab auth status` / `glab api user` — Bearer auth unaffected by the rename
  - Basic-auth git-over-HTTPS clone — confirmed still rejected (`HTTP Basic: Access denied`), documenting the proxy limitation
  - `gitlab-ssh`: `known_hosts` populated at create; `ssh -T git@gitlab.com` passes host-key verification (fails cleanly on `publickey`, not on host trust)
  - Full round-trip with a real registered SSH key: clone + commit + push over `git@gitlab.com:...` succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)