### PR TITLE
Add vibe kit

### DIFF
--- a/vibe/Dockerfile
+++ b/vibe/Dockerfile
@@ -1,0 +1,51 @@
+# syntax=docker/dockerfile:1
+
+# Base image for the `vibe` sandbox kit: the shell-docker template with
+# Mistral Vibe installed from PyPI.
+#
+# Built and pushed as docker.io/sbx/vibe-image by build-and-publish-kits.yml
+# (see ../PUBLISHING.md). The base is a floating tag and Vibe is installed from
+# a `latest` channel, which is why CI also rebuilds on a schedule.
+#
+# Build it locally the way the test scripts do:
+#   docker build -t docker.io/sbx/vibe-image:latest ./vibe
+ARG BASE_IMAGE=docker/sandbox-templates:shell-docker
+FROM ${BASE_IMAGE}
+
+# Re-declared inside the stage: an ARG defined before the first FROM is a global
+# build arg, visible only to FROM lines. Without this the LABEL below would
+# expand to an empty string.
+ARG BASE_IMAGE
+
+# PyPI version of mistral-vibe: "latest", or an exact number such as 2.25.0 to
+# pin the image to a known release.
+ARG VIBE_VERSION=latest
+
+# uv ships with the template at /usr/local/bin/uv, and `uv tool install` puts
+# the executables in ~/.local/bin, which is already on the template's PATH --
+# so `sandbox.entrypoint` can stay the bare name `vibe`.
+USER agent
+RUN set -ex; \
+    if [ "${VIBE_VERSION}" = "latest" ]; then SPEC="mistral-vibe"; else SPEC="mistral-vibe==${VIBE_VERSION}"; fi; \
+    uv tool install "${SPEC}"; \
+    vibe --version
+
+# Requests Docker-in-Docker from the runtime. Inherited from the base image,
+# but re-declared so the value is owned here rather than depending on
+# inheritance from an image this repository does not own.
+LABEL com.docker.sandboxes.start-docker="true"
+
+# sbx reads `flavor` as the image's agent identifier and surfaces it in the API,
+# so it must be the kit's own name -- left inherited it would read
+# "shell-docker" and sbx would report this image's agent as that.
+LABEL com.docker.sandboxes.flavor="vibe"
+
+# Informational only. Worth setting because the base is a floating tag rebuilt
+# nightly: this is the one place the produced image records what it was built on.
+LABEL com.docker.sandboxes.base="${BASE_IMAGE}"
+
+WORKDIR /home/agent
+
+# The kit sets the real entrypoint (spec.yaml); this only applies to a plain
+# `docker run` of the image, outside sbx.
+CMD ["vibe"]

--- a/vibe/README.image.md
+++ b/vibe/README.image.md
@@ -1,0 +1,9 @@
+# sbx/vibe-image
+
+Base image for the Mistral Vibe kit for [Docker Sandboxes](https://docs.docker.com/ai/sandboxes/).
+
+It is built on `docker/sandbox-templates:shell-docker` and installs [Mistral Vibe](https://github.com/mistralai/vibe) from PyPI with `uv tool install`, as the non-root `agent` user. The `VIBE_VERSION` build argument pins a release; the default, `latest`, is what the nightly rebuild tracks. The image requests Docker-in-Docker through the standard sandbox image label.
+
+## Kit
+
+[`docker.io/sbx/vibe-kit`](https://hub.docker.com/r/sbx/vibe-kit)

--- a/vibe/README.image.md
+++ b/vibe/README.image.md
@@ -2,7 +2,7 @@
 
 Base image for the Mistral Vibe kit for [Docker Sandboxes](https://docs.docker.com/ai/sandboxes/).
 
-It is built on `docker/sandbox-templates:shell-docker` and installs [Mistral Vibe](https://github.com/mistralai/vibe) from PyPI with `uv tool install`, as the non-root `agent` user. The `VIBE_VERSION` build argument pins a release; the default, `latest`, is what the nightly rebuild tracks. The image requests Docker-in-Docker through the standard sandbox image label.
+It is built on `docker/sandbox-templates:shell-docker` and installs [Mistral Vibe](https://github.com/mistralai/mistral-vibe) from PyPI with `uv tool install`, as the non-root `agent` user. The `VIBE_VERSION` build argument pins a release; the default, `latest`, is what the nightly rebuild tracks. The image requests Docker-in-Docker through the standard sandbox image label.
 
 ## Kit
 

--- a/vibe/README.md
+++ b/vibe/README.md
@@ -1,0 +1,78 @@
+# Mistral Vibe
+
+A standalone Docker Sandboxes kit for [Mistral Vibe](https://github.com/mistralai/vibe), Mistral AI's open source coding agent. It runs the `vibe` CLI inside a sandbox with the workspace pre-trusted, tool approval pre-granted, and the Mistral API key held by the sandbox proxy rather than by the container.
+
+## Usage
+
+Use the published kit:
+
+```console
+sbx run --kit "docker.io/sbx/vibe-kit:latest" vibe
+```
+
+Or load it directly from this repository:
+
+```console
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=vibe" vibe
+```
+
+Or use a local clone:
+
+```console
+sbx run --kit ./vibe/ vibe
+```
+
+## Authentication
+
+Get a key from the [Mistral console](https://console.mistral.ai/api-keys), then store it on the host under the `mistral` service — the name the kit's `credentials` block declares:
+
+```console
+printf '%s' "$MISTRAL_API_KEY" | sbx secret set mistral
+```
+
+Piping the key in keeps it out of your shell history and out of the process table, where passing it as a flag value would put it. `printf` rather than `echo` because `echo` appends a newline to what it pipes; the sibling kits use `echo` without trouble, so `sbx` evidently trims it, but `printf` leaves nothing to trim and no `401` to diagnose.
+
+`sbx secret set mistral` on its own is equally valid — it prompts for the value on a TTY. Either way the secret is stored once on the host; `sbx` also offers to configure the credential on first launch if none is stored.
+
+Then launch:
+
+```console
+sbx run --kit "docker.io/sbx/vibe-kit:latest" vibe
+```
+
+The container only ever sees `MISTRAL_API_KEY` set to a proxy sentinel. The real key is substituted by the proxy on requests to `api.mistral.ai`, `chat.mistral.ai` and `console.mistral.ai`, and on no other host — so a prompt injection that talks the agent into exfiltrating the variable exfiltrates the sentinel.
+
+## Agent profile
+
+Vibe's [agent profile](https://github.com/mistralai/vibe) decides which tool calls need confirmation. The kit starts `auto-approve`, on the same reasoning as the `crush` and `grok` kits: the sandbox is the security boundary, so a confirmation prompt inside it buys little and blocks non-interactive use.
+
+Pick another one at install time:
+
+```console
+sbx run --kit "docker.io/sbx/vibe-kit:latest" --kit-arg agent=plan vibe
+```
+
+The value is any builtin (`ask`, `plan`, `accept-edits`, `auto-approve`) or a custom agent declared in `~/.vibe/agents/NAME.toml`.
+
+## Persistence
+
+`~/.vibe` is a 1 GB volume, so `config.toml`, sessions, logs, custom agents and `.env` survive recreating a sandbox of the same name. The volume is mounted root-owned, which is why a startup command hands it back to the `agent` user before Vibe writes to it.
+
+## Network
+
+The allow list is the four hosts Vibe reaches for, and nothing else:
+
+| Host | Why |
+| --- | --- |
+| `api.mistral.ai` | Inference API. |
+| `chat.mistral.ai` | Vibe's own base URL — sessions and account state. |
+| `console.mistral.ai` | Admin-managed configuration read at startup; also the browser-auth base URL. |
+| `*.mistral.services` | Feature-flag / experiments service queried at startup. |
+
+Anything else your work needs — a package registry, a git host — has to be added to `permissions.network.allow` or allowed on the host with `sbx policy allow network`.
+
+Telemetry and Vibe's self-update are both switched off through `VIBE_ENABLE_TELEMETRY` / `VIBE_ENABLE_AUTO_UPDATE`, so a run is reproducible and needs no egress to PyPI: the version is whatever the image ships.
+
+## Image
+
+The companion image, `docker.io/sbx/vibe-image`, is built from `docker/sandbox-templates:shell-docker` and installs `mistral-vibe` from PyPI with `uv tool install`. Pin a release at build time with `--build-arg VIBE_VERSION=2.25.0`; the default, `latest`, is what CI's nightly rebuild tracks.

--- a/vibe/README.md
+++ b/vibe/README.md
@@ -65,9 +65,9 @@ The allow list is the four hosts Vibe reaches for, and nothing else:
 | Host | Why |
 | --- | --- |
 | `api.mistral.ai` | Inference API. |
-| `chat.mistral.ai` | Vibe's own base URL — sessions and account state. |
-| `console.mistral.ai` | Admin-managed configuration read at startup; also the browser-auth base URL. |
-| `*.mistral.services` | Feature-flag / experiments service queried at startup. |
+| `chat.mistral.ai` | Vibe's own base URL; also where the organization's admin-managed configuration is read at startup. |
+| `console.mistral.ai` | The `/whoami` account and plan lookup, and the browser-auth base URL. |
+| `experiments.mistral.services` | Feature-flag / experiments service. Only reached when telemetry is enabled, which this kit disables. |
 
 Anything else your work needs — a package registry, a git host — has to be added to `permissions.network.allow` or allowed on the host with `sbx policy allow network`.
 

--- a/vibe/README.md
+++ b/vibe/README.md
@@ -30,7 +30,7 @@ Get a key from the [Mistral console](https://console.mistral.ai/api-keys), then 
 printf '%s' "$MISTRAL_API_KEY" | sbx secret set mistral
 ```
 
-Piping the key in keeps it out of your shell history and out of the process table, where passing it as a flag value would put it. `printf` rather than `echo` because `echo` appends a newline to what it pipes; the sibling kits use `echo` without trouble, so `sbx` evidently trims it, but `printf` leaves nothing to trim and no `401` to diagnose.
+Piping the key in keeps it out of your shell history and out of the process table, where `-t/--token` would put it.
 
 `sbx secret set mistral` on its own is equally valid — it prompts for the value on a TTY. Either way the secret is stored once on the host; `sbx` also offers to configure the credential on first launch if none is stored.
 

--- a/vibe/README.md
+++ b/vibe/README.md
@@ -1,6 +1,6 @@
 # Mistral Vibe
 
-A standalone Docker Sandboxes kit for [Mistral Vibe](https://github.com/mistralai/vibe), Mistral AI's open source coding agent. It runs the `vibe` CLI inside a sandbox with the workspace pre-trusted, tool approval pre-granted, and the Mistral API key held by the sandbox proxy rather than by the container.
+A standalone Docker Sandboxes kit for [Mistral Vibe](https://github.com/mistralai/mistral-vibe), Mistral AI's open source coding agent. It runs the `vibe` CLI inside a sandbox with the workspace pre-trusted, tool approval pre-granted, and the Mistral API key held by the sandbox proxy rather than by the container.
 
 ## Usage
 

--- a/vibe/README.md
+++ b/vibe/README.md
@@ -56,7 +56,7 @@ The value is any builtin (`ask`, `plan`, `accept-edits`, `auto-approve`) or a cu
 
 ## Persistence
 
-`~/.vibe` is a 1 GB volume, so `config.toml`, sessions, logs, custom agents and `.env` survive recreating a sandbox of the same name. The volume is mounted root-owned, which is why a startup command hands it back to the `agent` user before Vibe writes to it.
+`~/.vibe` is a 1 GB volume, so `config.toml`, sessions, logs, custom agents and `.env` survive recreating a sandbox of the same name. `.env` is Vibe's own key store; the environment takes precedence over it, so the proxy-managed `MISTRAL_API_KEY` is what Vibe uses regardless of what lands there. The volume is mounted root-owned, which is why a startup command hands it back to the `agent` user before Vibe writes to it.
 
 ## Network
 

--- a/vibe/README.md
+++ b/vibe/README.md
@@ -44,7 +44,7 @@ The container only ever sees `MISTRAL_API_KEY` set to a proxy sentinel. The real
 
 ## Agent profile
 
-Vibe's [agent profile](https://github.com/mistralai/vibe) decides which tool calls need confirmation. The kit starts `auto-approve`, on the same reasoning as the `crush` and `grok` kits: the sandbox is the security boundary, so a confirmation prompt inside it buys little and blocks non-interactive use.
+Vibe's [agent profile](https://github.com/mistralai/mistral-vibe#built-in-agents) decides which tool calls need confirmation. The kit starts `auto-approve`, on the same reasoning as the `crush` and `grok` kits: the sandbox is the security boundary, so a confirmation prompt inside it buys little and blocks non-interactive use.
 
 Pick another one at install time:
 

--- a/vibe/spec.yaml
+++ b/vibe/spec.yaml
@@ -1,0 +1,120 @@
+# Docker Sandboxes kit for Mistral Vibe.
+# Usage, prerequisites and design notes: see README.md in this directory.
+schemaVersion: "2"
+kind: sandbox
+name: vibe
+version: "0.1.0"
+displayName: Mistral Vibe
+description: Mistral AI's open source coding agent, with its API key injected by the sandbox proxy
+licenses:
+  - MIT
+
+# The agent profile Vibe starts with. Overridable at install time:
+#   sbx run --kit docker.io/sbx/vibe-kit:latest --kit-arg agent=plan vibe
+args:
+  agent:
+    default: "auto-approve"
+    description: >-
+      Vibe agent to start: a builtin (ask, plan, accept-edits, auto-approve) or
+      a custom agent declared in ~/.vibe/agents/NAME.toml.
+    pattern: '^[A-Za-z0-9_-]+$'
+
+sandbox:
+  # Pre-baked image: the shell-docker template plus mistral-vibe from PyPI,
+  # built and published by build-and-publish-kits.yml, the shared kit-image
+  # pipeline (see ../PUBLISHING.md). Creating a sandbox therefore waits on no
+  # install, and the pipeline's nightly rebuild keeps Vibe current -- same
+  # arrangement as the pi and kiro kits.
+  image: docker.io/sbx/vibe-image:latest
+  # `uv tool install` puts the binary in ~/.local/bin, which the template
+  # already has on PATH, so the bare name resolves.
+  #
+  # --trust: the workspace is the user's own project, mounted by sbx, so Vibe's
+  #   trust prompt has nothing left to protect against and would only block a
+  #   non-interactive start.
+  # --agent: the sandbox is the security boundary, so the default profile lets
+  #   Vibe act without per-tool confirmation -- the same call the crush
+  #   (--yolo) and grok (--yolo) kits make. Narrow it with --kit-arg agent=ask.
+  entrypoint:
+    - vibe
+    - --trust
+    - --agent
+    - "${{ kit.args.agent }}"
+
+agentInstructions:
+  # Vibe loads ~/.vibe/AGENTS.md and every AGENTS.md from the project root up
+  # through the trust chain.
+  filename: AGENTS.md
+  content: |
+    ## Sandbox
+
+    You are running inside a Docker sandbox (sbx). The working directory is the
+    user's project, mounted from the host.
+
+    MISTRAL_API_KEY holds a sentinel value, not the real key: the sandbox proxy
+    swaps it for the real one on requests to Mistral. Do not read, print or
+    reconfigure it.
+
+# Every destination the kit needs. e2e runs under deny-all, so a host that is
+# not listed here is blocked -- see README, "Network".
+permissions:
+  network:
+    allow:
+      # Inference API (DEFAULT_MISTRAL_SERVER_URL).
+      - "api.mistral.ai:443"
+      # Vibe's own base URL (DEFAULT_VIBE_BASE_URL) -- sessions and account
+      # state.
+      - "chat.mistral.ai:443"
+      # Console, which is also the browser-auth base URL: Vibe reads the
+      # organization's admin-managed configuration from it at startup. Without
+      # it that call 401s into ~/.vibe/logs/vibe.log -- non-fatal, but noisy.
+      - "console.mistral.ai:443"
+      # Feature-flag / experiments service (experiments.mistral.services),
+      # queried at startup.
+      - "*.mistral.services:443"
+
+credentials:
+  - service: mistral
+    description: "Mistral API key (https://console.mistral.ai/api-keys)"
+    apiKey:
+      name: MISTRAL_API_KEY
+      # The container only ever sees a sentinel; the proxy substitutes the real
+      # key on the hosts listed below, and nowhere else.
+      proxyManaged: true
+      inject:
+        - domain: api.mistral.ai
+          header: Authorization
+          format: "Bearer %s"
+        # The two other hosts Vibe calls with the same key.
+        - domain: chat.mistral.ai
+          header: Authorization
+          format: "Bearer %s"
+        - domain: console.mistral.ai
+          header: Authorization
+          format: "Bearer %s"
+
+environment:
+  variables:
+    # Vibe maps VIBE_<CONFIG_FIELD> onto its config schema, so these two are
+    # the `enable_telemetry` / `enable_auto_update` fields of ~/.vibe/config.toml.
+    VIBE_ENABLE_TELEMETRY: "false"
+    # No silent self-update inside the sandbox: the version is whatever the
+    # image ships, so a run is reproducible and needs no egress to PyPI.
+    VIBE_ENABLE_AUTO_UPDATE: "false"
+    # Never block on a git credential prompt in a non-interactive session.
+    GIT_TERMINAL_PROMPT: "0"
+
+setup:
+  startup:
+    # ~/.vibe is a block volume (see `volumes`). It is mounted root-owned, so
+    # it has to be handed back to the agent user on every start, before Vibe
+    # writes to it. Idempotent, as every startup command must be.
+    - command: ["sh", "-c", "mkdir -p /home/agent/.vibe && chown -R agent:agent /home/agent/.vibe"]
+      user: "0"
+      description: Hand ~/.vibe (persistent volume) back to the agent user
+
+# Keeps config.toml, sessions, logs, custom agents and .env across re-creations
+# of a sandbox with the same name.
+volumes:
+  - path: /home/agent/.vibe
+    size: 1g

--- a/vibe/spec.yaml
+++ b/vibe/spec.yaml
@@ -108,7 +108,7 @@ setup:
     # ~/.vibe is a block volume (see `volumes`). It is mounted root-owned, so
     # it has to be handed back to the agent user on every start, before Vibe
     # writes to it. Idempotent, as every startup command must be.
-    - command: ["sh", "-c", "mkdir -p /home/agent/.vibe && chown -R agent:agent /home/agent/.vibe"]
+    - command: ["sh", "-c", "mkdir -p /home/agent/.vibe && chown agent:agent /home/agent/.vibe"]
       user: "0"
       description: Hand ~/.vibe (persistent volume) back to the agent user
 

--- a/vibe/spec.yaml
+++ b/vibe/spec.yaml
@@ -68,9 +68,9 @@ permissions:
       # Console: the /whoami account and plan lookup, and the browser-auth
       # base URL.
       - "console.mistral.ai:443"
-      # Feature-flag / experiments service (experiments.mistral.services),
-      # queried at startup.
-      - "*.mistral.services:443"
+      # Feature-flag / experiments service. Only reached when telemetry is
+      # enabled, which this kit disables below.
+      - "experiments.mistral.services:443"
 
 credentials:
   - service: mistral

--- a/vibe/spec.yaml
+++ b/vibe/spec.yaml
@@ -62,12 +62,11 @@ permissions:
     allow:
       # Inference API (DEFAULT_MISTRAL_SERVER_URL).
       - "api.mistral.ai:443"
-      # Vibe's own base URL (DEFAULT_VIBE_BASE_URL) -- sessions and account
-      # state.
+      # Vibe's own base URL (DEFAULT_VIBE_BASE_URL), which is also where the
+      # organization's admin-managed configuration is read at startup.
       - "chat.mistral.ai:443"
-      # Console, which is also the browser-auth base URL: Vibe reads the
-      # organization's admin-managed configuration from it at startup. Without
-      # it that call 401s into ~/.vibe/logs/vibe.log -- non-fatal, but noisy.
+      # Console: the /whoami account and plan lookup, and the browser-auth
+      # base URL.
       - "console.mistral.ai:443"
       # Feature-flag / experiments service (experiments.mistral.services),
       # queried at startup.

--- a/vibe/spec.yaml
+++ b/vibe/spec.yaml
@@ -7,7 +7,7 @@ version: "0.1.0"
 displayName: Mistral Vibe
 description: Mistral AI's open source coding agent, with its API key injected by the sandbox proxy
 licenses:
-  - MIT
+  - Apache-2.0
 
 # The agent profile Vibe starts with. Overridable at install time:
 #   sbx run --kit docker.io/sbx/vibe-kit:latest --kit-arg agent=plan vibe

--- a/vibe/testdata/tck.yaml
+++ b/vibe/testdata/tck.yaml
@@ -1,0 +1,7 @@
+# TCK configuration for the vibe kit.
+#
+# `-p` is Vibe's programmatic mode: it sends the prompt, prints the response and
+# exits. `--trust` is repeated here because the e2e prompt subtest invokes the
+# binary through `sbx exec`, which bypasses `sandbox.entrypoint` and would
+# otherwise stop on the workspace trust prompt with no TTY to answer it.
+promptArgs: ["--trust", "-p"]


### PR DESCRIPTION
## Summary

Adds `vibe`, a `kind: sandbox` kit for [Mistral Vibe](https://mistral.ai/products/vibe/),
Mistral AI's open source coding agent.

- `vibe/Dockerfile` — `docker/sandbox-templates:shell-docker` + `mistral-vibe`
  installed from PyPI with `uv tool install`, published by the shared pipeline
  as `docker.io/sbx/vibe-image`. `VIBE_VERSION` pins a release at build time.
- `vibe/spec.yaml` — entrypoint `vibe --trust --agent <arg>`, a proxy-managed
  `MISTRAL_API_KEY`, a four-host allow list, and `~/.vibe` on a 1 GB volume.
- `vibe/README.md`, `vibe/README.image.md`, `vibe/testdata/tck.yaml`.

## Spec choices worth flagging for review

- **`args` is a first for this repo.** `agent` (default `auto-approve`) selects
  Vibe's agent profile and is referenced from `sandbox.entrypoint` as
  `${{ kit.args.agent }}`. No other kit here uses SPEC-v2 §2.1 args yet, so
  this is the first spec whose entrypoint is only correct after substitution.
  Neither automated surface exercises that path — the TCK overrides the
  entrypoint with `sleep infinity`, and the e2e prompt subtest goes through
  `sbx exec` — so it was verified by hand instead (see the test plan).
- **`--agent auto-approve` by default.** Same call the `crush` (`--yolo`) and
  `grok` (`--yolo`) kits make: the sandbox is the security boundary, and a
  confirmation prompt inside it blocks non-interactive use. Narrowed with
  `--kit-arg agent=ask`.
- **`--trust` in the entrypoint**, because the workspace is the user's own
  project mounted by sbx, and the trust prompt has no TTY to answer it on a
  non-interactive start. It is repeated in `testdata/tck.yaml`'s `promptArgs`,
  since the e2e prompt subtest goes through `sbx exec` and bypasses the
  entrypoint.
- **Deliberately narrow `allow` list** — four hosts, each one read out of the
  installed package rather than guessed: `api.mistral.ai`
  (`DEFAULT_MISTRAL_SERVER_URL`), `chat.mistral.ai` (`DEFAULT_VIBE_BASE_URL`),
  `console.mistral.ai` (browser-auth base and admin-managed config, which 401s
  noisily into `~/.vibe/logs/vibe.log` without it), and `*.mistral.services`
  (the experiments/feature-flag service). No PyPI, no apt hosts: the image is
  pre-baked and `VIBE_ENABLE_AUTO_UPDATE=false`, so nothing installs at runtime.
- **The API key is injected into three hosts, not one.** Vibe sends it to
  `chat.mistral.ai` and `console.mistral.ai` as well as the inference API.
- **`~/.vibe` volume** keeps `config.toml`, sessions, logs and custom agents
  across recreations; it is mounted root-owned, hence the `chown` startup hook.

## Origin

Kit authored by @k33g for this repo, from a working local setup for running
Mistral Vibe under Docker Sandboxes.

## Test plan

CI runs `kit validate` and the TCK on every PR. CI does **not** run e2e on fork
PRs (Docker Hub secrets aren't exposed there), so the e2e step below is required
from my side before requesting review.

- [x] Spec validates clean — `go run ./scripts/verify-kit-spec ./vibe`
      (`valid, no warnings`); the repo's stand-in for `sbx kit validate` where
      no `sbx` binary is available.
- [x] `./scripts/test-kit.sh vibe` passes (the TCK) — builds
      `docker.io/sbx/vibe-image:latest` from the branch's Dockerfile and runs
      validation, network/credential/environment policy, and the container
      subtests against it. Vibe 2.25.0 installs and reports its version.
- [x] `./scripts/test-kit-e2e.sh` passes under the `deny-all` baseline, scoped
      to `--app-name sbx-kits-contrib-tck` — `env`, `tmpfs`, `agentContext` and
      `prompt` all green in 27.6s. The `prompt` subtest answers
      `Error: API error from mistral … Invalid API key`, which is the expected
      shape with no credential stored: the sentinel travelled to
      `api.mistral.ai` and Mistral itself replied, so nothing in the allow list
      was missing and no request was blocked by the policy.
- [x] Manual smoke: `sbx run ./vibe/` — the session starts and a real
      `mistral` secret drives it end to end. That run is also what proves the
      arg substitution: Vibe aborts on an unknown profile
      (`Error: Agent 'x' not found.`), so an unsubstituted
      `${{ kit.args.agent }}` could not have reached a working session. The
      non-default `--kit-arg agent=plan` path has not been exercised
      separately.

Reviewers trying this before the kit merges: `sandbox.image` points at
`docker.io/sbx/vibe-image:latest`, which the pipeline only publishes on merge,
so `sbx run` stops at PREPARE IMAGE with a `403`. Build and side-load it first
— `docker build -t docker.io/sbx/vibe-image:latest ./vibe`, `docker save … -o
/tmp/vibe.tar`, `sbx template load /tmp/vibe.tar` — which is exactly what
`scripts/test-kit-e2e.sh` does on its own scoped daemon.

## Note on commit signatures

The commit carries a DCO `Signed-off-by:` trailer but is not cryptographically
signed — it was made in an environment with no signing key. It will be re-signed
before this PR is ready for review.