### PR TITLE
fix(claude-mem): pass --provider claude so the install works unattended

### DIFF
--- a/claude-mem/README.md
+++ b/claude-mem/README.md
@@ -55,6 +55,15 @@ sbx ports <sandbox> --publish 37700/tcp
   inheriting whatever regressions ship in a new claude-mem release
   (claude-mem's issue tracker shows a fairly high rate of worker-lifecycle
   regressions). Re-introduce a pin if this trade proves worse in practice.
+- **Explicit `--provider claude`**: mandatory for an unattended install.
+  Since claude-mem v13.20.0 the installer aborts before doing any work
+  when stdin is not a TTY and no provider was given, so the flag is what
+  keeps this step from failing outright. `claude` is also the only
+  provider that completes without interaction: it uses the sandbox's own
+  Anthropic credentials, where the alternatives (CMEM Pro, Gemini,
+  OpenRouter) need a browser OAuth pairing or a preconfigured personal
+  API key. Upstream's README still describes the pre-13.20.0 behavior —
+  see [thedotmack/claude-mem#3893](https://github.com/thedotmack/claude-mem/issues/3893).
 - **Settings reconciler**: claude-mem's installer merges
   `enabledPlugins` into `~/.claude/settings.json`, while the platform
   seeds the same file at startup *only when missing* — and the two race

--- a/claude-mem/spec.yaml
+++ b/claude-mem/spec.yaml
@@ -70,7 +70,15 @@ setup:
     # (rather than `npm config set`, which would persist to ~/.npmrc for
     # the sandbox's whole lifetime) so it doesn't silently weaken conflict
     # detection for any later npm install the agent or user runs.
-    - command: npm_config_legacy_peer_deps=true npx -y claude-mem@latest install
+    # `--provider claude` is required, not cosmetic: since claude-mem v13.20.0
+    # the installer aborts (exit 1) when stdin is not a TTY and no provider is
+    # given, before doing any work. Provisioning runs with stdin detached, so
+    # without the flag this step always fails. `claude` points memory at the
+    # sandbox's own Anthropic credentials and skips the browser OAuth pairing
+    # that the other providers require -- the only choice that can complete
+    # unattended. Upstream README still documents the pre-13.20.0 behavior;
+    # see https://github.com/thedotmack/claude-mem/issues/3893.
+    - command: npm_config_legacy_peer_deps=true npx -y claude-mem@latest install --provider claude
       user: "1000"
       description: Install latest claude-mem (plugin, marketplace registration, bun deps)
   startup:


### PR DESCRIPTION
## What

The `claude-mem` kit's install step now passes `--provider claude`.

## Why

claude-mem v13.20.0 made the installer abort (exit 1) when stdin is not a TTY and no provider was given — before doing any work. Sandbox provisioning runs with stdin detached, so this kit's install step has failed since that release:

```
✗ npm_config_legacy_peer_deps=true npx -y claude-mem@latest i… (kit=claude-mem, user=1000, exit 1)

  Installation Aborted: unknown-install-error
  provider-selection failed during non-interactive-validation:
  A provider must be explicit when stdin is not interactive.
```

`claude` is the only provider that can complete unattended — CMEM Pro, Gemini and OpenRouter each need a browser OAuth pairing or a preconfigured personal API key. It is also the only one consistent with this kit's existing network policy: it uses the sandbox's own Anthropic credentials and never contacts `cmem.ai`, which is not in `permissions.network.allow`.

The kit tracks `@latest` by design (see its README's design notes), so this arrived without a change on our side. Upstream's README still documents the pre-13.20.0 behaviour; reported as https://github.com/thedotmack/claude-mem/issues/3893.

## Verification

| | |
|---|---|
| `sbx kit validate ./claude-mem/` | VALID |
| `../scripts/test-kit.sh` | PASS — `install_execution` 28.2s |
| `../scripts/test-kit-e2e.sh` | PASS — under `deny-all`, install completes in 137.8s |

A control run with the flag removed reproduces the abort quoted above, so the flag is both necessary and sufficient. The e2e leg passing under `deny-all` also confirms the existing `permissions.network.allow` list is still complete — this change adds no new outbound host.

`sbx run --kit . claude` was run on the default daemon: the install completed (145.1s) and the sandbox was created. Attaching the interactive agent session timed out in my terminal, so the post-create state was checked with `sbx exec` instead:

```
enabledPlugins:  "claude-mem@thedotmack": true
marketplace:     plugin.json v13.24.1
provider:        "CLAUDE_MEM_PROVIDER": "claude"
reconciler:      platform settings present after 0s / reconciled
```

The memory viewer on 37700 does not answer at that point, which is expected and unchanged by this PR: claude-mem skips worker auto-start on a non-TTY install, and the worker comes up on the first `SessionStart` hook once an agent session actually runs.
