### PR TITLE
chore(claude-mem): stop setting DO_NOT_TRACK sandbox-wide

### DIFF
--- a/claude-mem/README.md
+++ b/claude-mem/README.md
@@ -63,9 +63,14 @@ sbx ports <sandbox> --publish 37700/tcp
   driven by `SBX_CRED_ANTHROPIC_MODE`) and the `enabledPlugins` entry
   are present, never overwriting existing keys. Trace at
   `/tmp/claude-mem-reconcile.log`.
-- **Telemetry off at the source**: upstream's PostHog telemetry is ON by
-  default; the kit sets `DO_NOT_TRACK=1` + `CLAUDE_MEM_TELEMETRY=0` and
-  does not allow-list `us.i.posthog.com`.
+- **Telemetry off at the source, scoped to claude-mem**: upstream's
+  PostHog telemetry is ON by default; the kit sets
+  `CLAUDE_MEM_TELEMETRY=0` and does not allow-list `us.i.posthog.com`.
+  The cross-tool `DO_NOT_TRACK` convention is deliberately *not* set — it
+  would silence the base claude kit and every other tool in the sandbox,
+  which is not a mixin's call to make. The missing allow-list entry is
+  the durable half of this: it holds even if upstream renames the
+  variable.
 - First memory compression uses your existing claude auth (the proxy
   wiring from the parent kit); first embed lazily downloads Chroma's
   ONNX model (~80MB, allow-listed S3 host).

--- a/claude-mem/spec.yaml
+++ b/claude-mem/spec.yaml
@@ -14,8 +14,8 @@ agentInstructions:
     at session start. Search past sessions with the mem-search skill or the
     mcp-search MCP tools. The worker (viewer UI + live activity stream) runs
     on port 37700 (publish with `sbx ports <sandbox> --publish 37700/tcp`
-    to browse from the host). Telemetry is disabled
-    (DO_NOT_TRACK=1).
+    to browse from the host). claude-mem's telemetry is disabled
+    (CLAUDE_MEM_TELEMETRY=0).
 permissions:
   network:
     allow:
@@ -45,8 +45,14 @@ ports:
     name: memory-viewer
 environment:
   variables:
+    # Scoped to claude-mem on purpose. The cross-tool DO_NOT_TRACK convention
+    # would also silence the base claude kit and anything else in the sandbox,
+    # which is not this mixin's call to make. Upstream's consent ladder is
+    # DO_NOT_TRACK > CLAUDE_MEM_TELEMETRY > config > default-on, so this alone
+    # turns claude-mem's PostHog telemetry off; `us.i.posthog.com` is also
+    # absent from the allow-list above, which holds even if upstream renames
+    # the variable.
     CLAUDE_MEM_TELEMETRY: "0"
-    DO_NOT_TRACK: "1"
     # Worker port otherwise defaults to 37700 + (uid % 100); pinned so it
     # doesn't shift if the base image's agent uid ever changes.
     CLAUDE_MEM_WORKER_PORT: "37700"


### PR DESCRIPTION
## What

Drops `DO_NOT_TRACK: "1"` from the `claude-mem` kit's `environment.variables`, keeping `CLAUDE_MEM_TELEMETRY: "0"`. Updates the two places that documented the old pair (`agentInstructions` and the README design note).

No change to what claude-mem itself reports.

## Why

**It is redundant.** Upstream resolves telemetry consent through one function (`src/services/telemetry/consent.ts`), used by both the worker and the CLI:

```
1. DO_NOT_TRACK set (truthy) -> always off
2. CLAUDE_MEM_TELEMETRY env: '0'/'false'/'off' -> off, '1'/'true'/'on' -> on
3. telemetry.json config
4. Default: on
```

`CLAUDE_MEM_TELEMETRY=0` alone resolves to off at step 2. The installer's opt-in prompt is also unreachable here for a different reason — it returns early on non-interactive stdin, before it ever reads `DO_NOT_TRACK`.

**It is broader than this mixin's remit.** `DO_NOT_TRACK` is the cross-tool convention from [consoledonottrack.com](https://consoledonottrack.com/). Setting it in `environment.variables` applies it to the whole sandbox, so adding this memory mixin also silences the base `claude` kit and any other tool the user runs inside. That is a sandbox-wide policy decision, and a mixin shouldn't make it on the user's behalf.

**It is inconsistent with the rest of the repo.** `claude-mem` is the only kit here that sets `DO_NOT_TRACK`. The established pattern is vendor-scoped: `paperclip` sets `PAPERCLIP_TELEMETRY_DISABLED: "1"`, and `kiro` allow-lists its telemetry hosts rather than suppressing them.

The durable half of the original intent is untouched: `us.i.posthog.com` is still absent from `permissions.network.allow`. That is the stronger guarantee of the two, since it holds even if upstream renames the variable — which matters for a kit that tracks `@latest` on purpose.

## Verification

Run on this branch:

| | |
|---|---|
| `sbx kit validate ./claude-mem/` | VALID |
| `../scripts/test-kit.sh` | `environment_policy/variables` and `container/environment_variables` PASS |

`container/install_execution` fails on this branch, but for an unrelated pre-existing reason — the install step aborts without `--provider`, which is what #273 fixes.

To confirm the two changes compose, I merged this branch with #273 locally and re-ran everything:

| | |
|---|---|
| `sbx kit validate ./claude-mem/` | VALID |
| `../scripts/test-kit.sh` | PASS in full — `install_execution` 52.1s |
| `../scripts/test-kit-e2e.sh` | PASS under `deny-all` — install completes in 156.2s |

The two branches merge cleanly.

## Note

This depends on nothing in #273 and can land in either order, though `test-kit.sh` won't be fully green on this branch alone until #273 merges.
