### PR TITLE
test(tck): skip e2e when an agent needs a host-stored credential

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@ they run before merge. See the checklist below.
 ## Spec choices worth flagging for review
 
 <!-- Decisions a reviewer should sanity-check: unusual image, deliberately narrow
-allowedDomains, workaround for a known bug, etc. -->
+permissions.network.allow, workaround for a known bug, etc. -->
 
 ## Origin
 
@@ -31,7 +31,7 @@ required from your side before requesting review.
 - [ ] `./scripts/test-kit-e2e.sh <kit>` passes. The script applies the same
       `deny-all` baseline CI uses and scopes everything to its own daemon
       (`--app-name sbx-kits-contrib-tck`), so my main sbx state is untouched.
-      Every entry I added to `network.allowedDomains` came from
+      Every entry I added to `permissions.network.allow` came from
       `sbx --app-name sbx-kits-contrib-tck policy log <tck-e2e-…>`, not a guess.
 - [ ] Manual smoke: `sbx run --kit ./<kit>/ <agent>` and verified the kit's
       binary / files / env are inside the running container.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ For kits that have a corresponding tutorial on [docs.docker.com](https://docs.do
 
 ## Network policy: declare every domain
 
-Your kit's `network.allowedDomains` is the **complete** outbound contract — the CI e2e job runs under `deny-all`, so anything you don't list is blocked.
+Your kit's `permissions.network.allow` is the **complete** outbound contract — the CI e2e job runs under `deny-all`, so anything you don't list is blocked.
 
 Watch out for package managers: `apt-get update`, `npm install`, `pip install`, etc. each refresh metadata for every configured source, not just yours. For kits built on `shell-docker` / `*-docker` templates that means `download.docker.com` must be in your list even if you only `apt-get install` from Ubuntu's main archive — `apt-get update` fails the install otherwise. List `archive.ubuntu.com`, `security.ubuntu.com`, **and** `ports.ubuntu.com` so the kit works on both amd64 (CI) and arm64 (Apple Silicon).
 
@@ -72,7 +72,7 @@ cd my-kit && ../scripts/test-kit-e2e.sh
 That single command:
 
 - scopes every `sbx` call to `--app-name sbx-kits-contrib-tck`, so the test daemon (sandboxes, policy, cache) is isolated from your main sbx state and nothing the script does touches your day-to-day setup,
-- sets the scoped daemon's default network policy to `deny-all` — the same baseline CI uses, so any host your install or startup hooks reach for must be in `network.allowedDomains` or the request is blocked, and
+- sets the scoped daemon's default network policy to `deny-all` — the same baseline CI uses, so any host your install or startup hooks reach for must be in `permissions.network.allow` or the request is blocked, and
 - runs `TestE2EKit` (env, files, tmpfs, agentContext, and — for `kind: sandbox` kits with a `testdata/tck.yaml` — a non-interactive prompt to the agent).
 
 The script is idempotent (re-runs converge on the same state) and non-interactive (no prompts).
@@ -83,7 +83,7 @@ One-time setup per machine — the scoped daemon has its own credential store, s
 sbx --app-name sbx-kits-contrib-tck login
 ```
 
-When the test fails, the script prints how to dump the proxy log. The recurring fix is the same loop: read the log, add the blocked host to `network.allowedDomains`, re-run.
+When the test fails, the script prints how to dump the proxy log. The recurring fix is the same loop: read the log, add the blocked host to `permissions.network.allow`, re-run.
 
 ```console
 sbx --app-name sbx-kits-contrib-tck ls                          # find the tck-e2e-* sandbox
@@ -180,7 +180,7 @@ For deeper background, see GitHub's docs on [managing commit signature verificat
 A useful PR description has:
 
 - **Summary** — what changed.
-- **Spec choices worth flagging for review** — decisions a reviewer should sanity-check (an unusual image choice, a deliberately narrow `allowedDomains`, a workaround for a known bug).
+- **Spec choices worth flagging for review** — decisions a reviewer should sanity-check (an unusual image choice, a deliberately narrow `permissions.network.allow`, a workaround for a known bug).
 - **Test plan** — what CI covers, plus any manual end-to-end you ran.
 - **Origin** — where the kit came from. One sentence is enough.
 

--- a/README.md
+++ b/README.md
@@ -101,23 +101,24 @@ There's no per-kit test file to write — the shared `TestKitTCK` in `tck/kit_te
 2. Write your `spec.yaml`:
 
 ```yaml
-schemaVersion: "1"
+schemaVersion: "2"
 kind: mixin
 name: my-kit
 displayName: My Kit
 description: "Short description of what this kit does"
 
-network:
-  allowedDomains:
-    - example.com
-  deniedDomains:
-    - tracker.example.com
+permissions:
+  network:
+    allow:
+      - example.com
+    deny:
+      - tracker.example.com
 
 environment:
   variables:
     MY_CONFIG: "/home/agent/config.json"
 
-commands:
+setup:
   install:
     - command: "pip install my-tool"
       user: "1000"
@@ -156,11 +157,11 @@ working directory set to the package directory (`./tck/`).
 
 ## Declare every domain your kit needs
 
-A kit's `network.allowedDomains` is its **complete** outbound network contract. The CI e2e job runs with a `deny-all` default policy, so anything not in your `allowedDomains` is blocked at request time — and any failed request inside an install hook surfaces as `sbx create` failing.
+A kit's `permissions.network.allow` is its **complete** outbound network contract. The CI e2e job runs with a `deny-all` default policy, so anything not in your `permissions.network.allow` is blocked at request time — and any failed request inside an install hook surfaces as `sbx create` failing.
 
 The non-obvious trap is **package managers refreshing every configured source**, not just the one you added:
 
-- `apt-get update` re-fetches metadata for every file in `/etc/apt/sources.list[.d/]` — including sources the base template added. If *any* of those returns non-2xx, `apt-get` exits non-zero even if the package you want is in a different source. For kits built on `shell-docker` / `*-docker` templates that means `download.docker.com` (Docker's apt repo, pre-added by the template) needs to be in your `allowedDomains` even if you're only installing something from Ubuntu's main archive.
+- `apt-get update` re-fetches metadata for every file in `/etc/apt/sources.list[.d/]` — including sources the base template added. If *any* of those returns non-2xx, `apt-get` exits non-zero even if the package you want is in a different source. For kits built on `shell-docker` / `*-docker` templates that means `download.docker.com` (Docker's apt repo, pre-added by the template) needs to be in your `permissions.network.allow` even if you're only installing something from Ubuntu's main archive.
 - Ubuntu hosts amd64 packages on `archive.ubuntu.com` + `security.ubuntu.com` and arm64 packages on `ports.ubuntu.com`. List all three for cross-arch coverage; CI is amd64, your Mac is likely arm64.
 - `npm install`, `pip install`, `cargo`, `go get`, etc. each have their own registry/mirror hosts — declare them too.
 
@@ -178,7 +179,7 @@ sbx --app-name $APP ls                            # find the tck-e2e-* sandbox
 sbx --app-name $APP policy log tck-e2e-<short-uuid>
 ```
 
-Every `Blocked requests` row is a domain your install or startup hook reached for under `deny-all`. Add the host (column `HOST`, e.g. `download.docker.com:443`) to `allowedDomains` and re-run until the block list is empty.
+Every `Blocked requests` row is a domain your install or startup hook reached for under `deny-all`. Add the host (column `HOST`, e.g. `download.docker.com:443`) to `permissions.network.allow` and re-run until the block list is empty.
 
 If you'd rather hand-build a probe sandbox without invoking the test harness (useful when iterating on install scripts without touching the spec), the manual flow is:
 

--- a/aidlc-claude/testdata/tck.yaml
+++ b/aidlc-claude/testdata/tck.yaml
@@ -1,0 +1,8 @@
+# TCK configuration for the aidlc-claude kit.
+#
+# aidlc-claude declares `requires.agent: claude-bedrock` (spec.yaml), and
+# creating a claude-bedrock sandbox fails unless an AWS profile is already
+# stored on the host via `sbx --app-name sbx-kits-contrib-tck secret set
+# bedrock`. CI stores no such per-agent cloud credential, so this kit's e2e
+# is skipped there and must be run locally instead.
+requiresHostCredentials: ["bedrock"]

--- a/claude-sbx-statusline/README.md
+++ b/claude-sbx-statusline/README.md
@@ -64,9 +64,9 @@ sbx run claude --kit ./claude-sbx-statusline .
   It creates the file if missing and leaves every other key untouched — only `statusLine`
   is set (replacing a prior one if present) — then `chown`s back to the `agent` user exactly
   the paths it touched: `~/.claude`, `~/.claude/settings.json`, and `~/.claude/statusline.sh`.
-  The chown is deliberately **not** recursive — the shared skills directory under `~/.claude`
-  is mounted read-only by default, so a `chown -R` over the parent fails there and would break
-  sandbox creation. Re-running is idempotent. The temp file is created inside `~/.claude`
+  The chown is deliberately **not** recursive — `~/.claude` holds runtime-managed content this
+  kit doesn't own, so a `chown -R` over the parent would claim ownership of paths outside the
+  kit's control. Re-running is idempotent. The temp file is created inside `~/.claude`
   so the final `mv` is an atomic same-filesystem rename rather than a cross-device copy.
 - Note that the script does _not_ perform any checks to verify that you are indeed inside a sandbox. Care should be taken to not put this status line to your host's Claude Code installation as it would then incorrectly state that you are inside a sandbox when you are not.
 

--- a/claude-sbx-statusline/README.md
+++ b/claude-sbx-statusline/README.md
@@ -49,8 +49,9 @@ sbx run claude --kit ./claude-sbx-statusline .
 ## How it works
 
 - **`files/home/.claude/statusline.sh`** is copied to `~/.claude/statusline.sh` at sandbox
-  start. The engine preserves the file's executable bit, so Claude Code can invoke it
-  directly. The script receives the session JSON on stdin and prints the two lines.
+  start. The copy's mode is not guaranteed to keep the executable bit, so the install hook
+  below `chmod +x`es it — without that, Claude Code silently renders no status line. The
+  script receives the session JSON on stdin and prints the two lines.
 - **The `install` hook** (run as root) merges the `statusLine` block into
   `~/.claude/settings.json` with `jq`:
 
@@ -61,9 +62,12 @@ sbx run claude --kit ./claude-sbx-statusline .
   ```
 
   It creates the file if missing and leaves every other key untouched — only `statusLine`
-  is set (replacing a prior one if present) — then `chown`s `~/.claude` back to the `agent`
-  user. Re-running is idempotent. The temp file is created inside `~/.claude` so the final
-  `mv` is an atomic same-filesystem rename rather than a cross-device copy.
+  is set (replacing a prior one if present) — then `chown`s back to the `agent` user exactly
+  the paths it touched: `~/.claude`, `~/.claude/settings.json`, and `~/.claude/statusline.sh`.
+  The chown is deliberately **not** recursive — the shared skills directory under `~/.claude`
+  is mounted read-only by default, so a `chown -R` over the parent fails there and would break
+  sandbox creation. Re-running is idempotent. The temp file is created inside `~/.claude`
+  so the final `mv` is an atomic same-filesystem rename rather than a cross-device copy.
 - Note that the script does _not_ perform any checks to verify that you are indeed inside a sandbox. Care should be taken to not put this status line to your host's Claude Code installation as it would then incorrectly state that you are inside a sandbox when you are not.
 
 ## Requirements

--- a/claude-sbx-statusline/spec.yaml
+++ b/claude-sbx-statusline/spec.yaml
@@ -30,8 +30,9 @@ setup:
         mv "$tmp" "$f"
         # Shipped files arrive 0644; unexecutable, it renders nothing and no error.
         chmod +x /home/agent/.claude/statusline.sh
-        # Enumerated, not recursive: ~/.claude holds the shared skills directory,
-        # mounted read-only by default, so `chown -R` on the parent fails there.
+        # Enumerated, not recursive: ~/.claude holds runtime-managed content
+        # this kit doesn't own, so `chown -R` on the parent would take
+        # ownership of paths outside the kit's control.
         chown agent:agent /home/agent/.claude "$f" /home/agent/.claude/statusline.sh
       user: "0"
       description: Set the statusLine key in ~/.claude/settings.json to ~/.claude/statusline.sh (jq merge, so all other keys are preserved; any existing statusLine is replaced by design) and make the script executable

--- a/claude-sbx-statusline/spec.yaml
+++ b/claude-sbx-statusline/spec.yaml
@@ -30,6 +30,8 @@ setup:
         mv "$tmp" "$f"
         # Shipped files arrive 0644; unexecutable, it renders nothing and no error.
         chmod +x /home/agent/.claude/statusline.sh
-        chown -R agent:agent /home/agent/.claude
+        # Enumerated, not recursive: ~/.claude holds the shared skills directory,
+        # mounted read-only by default, so `chown -R` on the parent fails there.
+        chown agent:agent /home/agent/.claude "$f" /home/agent/.claude/statusline.sh
       user: "0"
       description: Set the statusLine key in ~/.claude/settings.json to ~/.claude/statusline.sh (jq merge, so all other keys are preserved; any existing statusLine is replaced by design) and make the script executable

--- a/scripts/test-kit-e2e.sh
+++ b/scripts/test-kit-e2e.sh
@@ -14,7 +14,7 @@
 #     sbx state. Nothing the script does touches your day-to-day daemon.
 #     The Go harness uses the same app-name internally (tck/e2e_test.go).
 #   - Sets the scoped daemon's default network policy to `deny-all` so
-#     the run is a real contract test of network.allowedDomains — the same
+#     the run is a real contract test of permissions.network.allow — the same
 #     baseline CI runs under.
 #   - For a kit that ships its own Dockerfile: builds that image and
 #     side-loads it into the scoped daemon's image store, so e2e runs against
@@ -295,7 +295,7 @@ EOF
 fi
 
 # Auto-diagnose on failure — the most common e2e failure is a missing entry
-# in network.allowedDomains, which `sbx policy log` surfaces precisely. In CI
+# in permissions.network.allow, which `sbx policy log` surfaces precisely. In CI
 # the runner (and its scoped daemon) is destroyed the moment the job ends, so
 # printing instructions for a human to run afterward is useless there — by
 # the time anyone reads the log, there's nothing left to inspect. Instead,
@@ -327,16 +327,47 @@ on_exit() {
     echo "e2e test failed (exit $rc)." >&2
 
     if [ -s "$sbx_name_log" ]; then
+      saw_blocked_requests=0
+      policy_log_read_failed=0
       while IFS= read -r sbox; do
         [ -n "$sbox" ] || continue
         echo "" >&2
         echo "Policy log for sandbox $sbox (policy: ${POLICY:-current default}):" >&2
-        sbx --app-name "$APP_NAME" policy log "$sbox" >&2 || true
+        if policy_log_out=$(sbx --app-name "$APP_NAME" policy log "$sbox" 2>&1); then
+          echo "$policy_log_out" >&2
+          case "$policy_log_out" in
+            *"Blocked requests"*) saw_blocked_requests=1 ;;
+          esac
+        else
+          echo "$policy_log_out" >&2
+          policy_log_read_failed=1
+        fi
       done < "$sbx_name_log"
-      cat >&2 <<EOF
+
+      # A failed read must never be conflated with a clean, empty log: each
+      # gets its own conclusion below, and a blocked-rows sighting always
+      # wins over a same-run read failure on another sandbox.
+      if [ "$saw_blocked_requests" -eq 1 ]; then
+        cat >&2 <<EOF
 
 Every row under 'Blocked requests' above is a host your kit reached for. Add
-it to network.allowedDomains in spec.yaml and re-run this script.
+it to permissions.network.allow in spec.yaml and re-run this script.
+EOF
+      elif [ "$policy_log_read_failed" -eq 1 ]; then
+        cat >&2 <<EOF
+
+The policy log could not be read for one or more sandboxes above, so this
+failure could not be ruled egress-related or not.
+EOF
+      else
+        cat >&2 <<EOF
+
+The policy log above reported no blocked requests, so this failure is
+probably not egress-related.
+EOF
+      fi
+
+      cat >&2 <<EOF
 
 If the sandbox still exists (e.g. a failure other than a rolled-back create),
 it was left running for further inspection:

--- a/skills/kit-author/topics/testing.md
+++ b/skills/kit-author/topics/testing.md
@@ -107,7 +107,9 @@ Every `sbx` call carries `--app-name sbx-kits-contrib-tck` so all commands route
 
 ### `testdata/tck.yaml` — kit-specific e2e config
 
-`kind: sandbox` kits **should** ship a `testdata/tck.yaml` file alongside their `spec.yaml` to opt in to the `prompt` subtest. The file is optional — the subtest is simply absent when the file is missing or `promptArgs` is empty. Kits whose agent requires a long async installation (e.g. nanoclaw, hermes-agent) may omit it until the installation reliably completes within the test timeout.
+`kind: sandbox` kits **should** ship a `testdata/tck.yaml` file alongside their `spec.yaml` to opt in to the `prompt` subtest, which only exists for `kind: sandbox` kits (see the table above). The file is optional there too — the subtest is simply absent when the file is missing or `promptArgs` is empty. Kits whose agent requires a long async installation (e.g. nanoclaw, hermes-agent) may omit it until the installation reliably completes within the test timeout.
+
+The file itself is not sandbox-only, though: a `kind: mixin` kit ships one too when it needs `requiresHostCredentials` (see "Kits whose agent needs a host-stored credential" below). Only `promptArgs`, `readyFile`, `binary`, and `extractedFromBuiltin` are meaningful solely for `kind: sandbox`.
 
 **Full schema:**
 
@@ -135,6 +137,11 @@ binary: "claude"
 # extractedFromBuiltin: set this only on a kind:sandbox kit whose name is still
 # that of an agent built into sbx. See "Kits that replace a built-in agent".
 extractedFromBuiltin: true
+
+# requiresHostCredentials: sbx secret service name(s) that must already be
+# stored on the host before this kit's agent can be created at all. See
+# "Kits whose agent needs a host-stored credential".
+requiresHostCredentials: ["bedrock"]
 ```
 
 #### Kits that replace a built-in agent
@@ -163,6 +170,34 @@ It is deliberately not a blanket "skip e2e for this kit": only the collision err
 tolerated, every other failure still fails, and nothing needs re-enabling afterwards —
 once the built-in is gone the test starts running on its own. Delete the line when you see
 the obsolete-flag notice.
+
+#### Kits whose agent needs a host-stored credential
+
+Some agents cannot be created at all unless a credential is already stored on the host via
+`sbx --app-name sbx-kits-contrib-tck secret set <service>`. `aidlc-claude`'s `claude-bedrock`
+affinity is the current example: `sbx create` for that agent needs an AWS profile stored under
+the `bedrock` service, and CI stores no such per-agent cloud credentials.
+
+`requiresHostCredentials: ["bedrock"]` declares that dependency. Before `sbx create` runs, the
+test probes `sbx --app-name sbx-kits-contrib-tck secret ls --service <service> --json` for each
+declared service instead of matching `sbx create`'s failure text — that failure gives no
+indication of a missing credential, so string-matching it would be fragile:
+
+| Situation | Result |
+|---|---|
+| Declared service not stored | `SKIP`, naming the service and the scoped `sbx secret set` command |
+| Declared service stored | Runs in full |
+| Probe fails or is unparseable | **FAIL** |
+
+It is deliberately not a blanket "skip e2e for this kit": only kits that declare the field are
+affected, and only a missing credential produces a skip — every other failure still fails.
+
+Unlike `extractedFromBuiltin`, this does not self-obsolete. The agent keeps needing the
+credential indefinitely, so the entry stays for as long as the kit declares this agent
+affinity — there is no obsolete-flag notice to watch for here.
+
+The check applies to any kit kind — `aidlc-claude` is `kind: mixin` — since it runs before
+`sbx create` regardless of kind.
 
 #### How `binary` is resolved
 

--- a/tck/e2e_test.go
+++ b/tck/e2e_test.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -25,6 +26,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v3"
 )
+
+// appName scopes every sbx call in this suite to a dedicated daemon instance,
+// isolated from the operator's default sbx state.
+const appName = "sbx-kits-contrib-tck"
 
 // sandboxWorkDir is the workspace mount point inside every sbx template
 // container. All templates inherit from the shared `base` stage which sets
@@ -81,6 +86,8 @@ func TestE2EKit(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 		defer cancel()
+
+		checkHostCredentials(t, ctx, td)
 
 		name := createSbx(t, ctx, absKit, agent, td)
 
@@ -332,6 +339,18 @@ type kitTCKData struct {
 	//   * When the flag is set but creation succeeds, the test logs a notice
 	//     that the flag is now obsolete and should be deleted.
 	ExtractedFromBuiltin bool `yaml:"extractedFromBuiltin"`
+
+	// RequiresHostCredentials names `sbx secret` service(s) that must already
+	// be stored on the host — via `sbx --app-name sbx-kits-contrib-tck secret
+	// set <service>` — before this kit's agent can be created at all. Every
+	// listed service is checked before `sbx create` runs; if any is missing,
+	// the whole kit e2e is skipped naming the missing service(s) and the
+	// command to store them.
+	//
+	// Unlike ExtractedFromBuiltin, this does not self-obsolete: the agent
+	// keeps needing the credential indefinitely, so the entry is permanent
+	// for as long as the kit declares this agent affinity.
+	RequiresHostCredentials []string `yaml:"requiresHostCredentials"`
 }
 
 // builtinCollisionMarker is the distinguishing text of the error sbx returns
@@ -362,6 +381,53 @@ func loadKitTCKData(t *testing.T, kitDir string) *kitTCKData {
 		require.NoErrorf(t, err, "parse %s", p)
 	}
 	return &td
+}
+
+// checkHostCredentials skips the kit's e2e run if any service in
+// td.RequiresHostCredentials has no secret stored on this sbx daemon. It
+// probes for presence rather than matching `sbx create`'s failure text: that
+// failure gives no indication of a missing credential, so string-matching it
+// would be fragile and, being generic, could mask unrelated create failures
+// as a skip. A probe failure or an unparseable probe result therefore fails
+// the test instead of skipping — only a clean "stored count is zero" does.
+// No-op when td is nil or declares no required services.
+func checkHostCredentials(t *testing.T, ctx context.Context, td *kitTCKData) {
+	t.Helper()
+	if td == nil || len(td.RequiresHostCredentials) == 0 {
+		return
+	}
+
+	var missing []string
+	for _, svc := range td.RequiresHostCredentials {
+		out, err := runSbxStdout(t, ctx, "secret", "ls", "--service", svc, "--json")
+		if err != nil {
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) {
+				out += string(exitErr.Stderr)
+			}
+		}
+		require.NoErrorf(t, err, "probe for a stored %q secret failed:\n%s", svc, out)
+
+		stored, perr := secretServiceStored([]byte(out))
+		require.NoErrorf(t, perr, "parse `sbx secret ls --service %s --json` output:\n%s", svc, out)
+
+		if !stored {
+			missing = append(missing, svc)
+		}
+	}
+	if len(missing) == 0 {
+		return
+	}
+
+	var setCmds strings.Builder
+	for _, svc := range missing {
+		fmt.Fprintf(&setCmds, "  sbx --app-name %s secret set %s\n", appName, svc)
+	}
+	t.Skipf("kit's agent needs credential(s) not stored on this sbx daemon: %s.\n"+
+		"This is expected in CI, which stores no per-agent cloud credentials — the requirement "+
+		"is permanent for this agent, not something to remove. To run the full e2e locally, "+
+		"store the missing service(s) first:\n%s",
+		strings.Join(missing, ", "), setCmds.String())
 }
 
 // promptMessage is the fixed text sent to every agent in TestE2EKit's prompt subtest.
@@ -405,12 +471,12 @@ func createSbx(t *testing.T, ctx context.Context, absKit, agent string, td *kitT
 		// during the normal failure unwind of require.NoErrorf/t.Fatal,
 		// before the process ever exits.
 		if t.Failed() {
-			t.Logf("keeping sandbox %q for post-mortem: sbx --app-name sbx-kits-contrib-tck policy log %s", name, name)
+			t.Logf("keeping sandbox %q for post-mortem: sbx --app-name %s policy log %s", name, appName, name)
 			return
 		}
 		cleanCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 		defer cancel()
-		out, err := exec.CommandContext(cleanCtx, "sbx", "--app-name", "sbx-kits-contrib-tck", "rm", "-f", name).CombinedOutput()
+		out, err := exec.CommandContext(cleanCtx, "sbx", "--app-name", appName, "rm", "-f", name).CombinedOutput()
 		// A sandbox that was never created has nothing to remove. Reporting
 		// that as a cleanup failure buries the real error under a misleading
 		// "not found" whenever `sbx create` itself failed.
@@ -519,6 +585,15 @@ func sandboxName(t *testing.T, kitDir string) string {
 	return "e2e-" + base + "-" + hex.EncodeToString(raw[:])
 }
 
+func buildSbxCmd(ctx context.Context, args ...string) *exec.Cmd {
+	all := make([]string, 0, len(args)+2)
+	all = append(all, "--app-name", appName)
+	all = append(all, args...)
+	cmd := exec.CommandContext(ctx, "sbx", all...)
+	cmd.Env = os.Environ()
+	return cmd
+}
+
 // runSbx invokes the sbx CLI and returns combined stdout+stderr. Inherits the
 // current environment so secrets and credential stores set up by the CI
 // `sbx login` step flow through. --app-name is prepended to every call for
@@ -526,12 +601,21 @@ func sandboxName(t *testing.T, kitDir string) string {
 // inside callers point at the call site, not this wrapper.
 func runSbx(t *testing.T, ctx context.Context, args ...string) (string, error) {
 	t.Helper()
-	all := make([]string, 0, len(args)+2)
-	all = append(all, "--app-name", "sbx-kits-contrib-tck")
-	all = append(all, args...)
-	cmd := exec.CommandContext(ctx, "sbx", all...)
-	cmd.Env = os.Environ()
+	cmd := buildSbxCmd(ctx, args...)
 	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// runSbxStdout invokes the sbx CLI like runSbx but returns stdout only,
+// discarding stderr. Callers that decode --json output need this: any stderr
+// text sbx writes alongside a JSON payload would otherwise be interleaved
+// into it and break decoding. On a non-zero exit the returned error is an
+// *exec.ExitError whose Stderr field carries the process's stderr, so callers
+// can still surface it in a failure message.
+func runSbxStdout(t *testing.T, ctx context.Context, args ...string) (string, error) {
+	t.Helper()
+	cmd := buildSbxCmd(ctx, args...)
+	out, err := cmd.Output()
 	return string(out), err
 }
 

--- a/tck/hostcredentials_test.go
+++ b/tck/hostcredentials_test.go
@@ -1,0 +1,62 @@
+package tck_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+// secretServiceStored reports whether the JSON emitted by
+// `sbx secret ls --service <name> --json` declares at least one stored
+// secret for that service. The `secrets` key must be present in the decoded
+// document — its absence is treated as an unrecognized payload shape, not as
+// zero entries — while a present-but-empty array means the service has
+// nothing stored. Unknown keys besides `secrets` are tolerated.
+func secretServiceStored(raw []byte) (bool, error) {
+	var doc struct {
+		Secrets *[]json.RawMessage `json:"secrets"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return false, err
+	}
+	if doc.Secrets == nil {
+		return false, fmt.Errorf(`missing "secrets" key in: %s`, raw)
+	}
+	return len(*doc.Secrets) > 0, nil
+}
+
+// TestSecretServiceStored pins secretServiceStored's contract against the
+// documented `sbx secret ls --service <name> --json` shapes, without
+// needing a live sbx daemon.
+func TestSecretServiceStored(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    bool
+		wantErr bool
+	}{
+		{name: "zero entries", raw: `{"secrets": []}`, want: false},
+		{name: "one entry", raw: `{"secrets": [{"name": "bedrock"}]}`, want: true},
+		{name: "malformed json", raw: `not json`, wantErr: true},
+		{name: "missing secrets key", raw: `{}`, wantErr: true},
+		{name: "different document shape", raw: `{"other": []}`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := secretServiceStored([]byte(tt.raw))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("secretServiceStored(%q): got nil error, want non-nil", tt.raw)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("secretServiceStored(%q): got error %v, want nil", tt.raw, err)
+			}
+			if got != tt.want {
+				t.Fatalf("secretServiceStored(%q) = %v, want %v", tt.raw, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The `aidlc-claude` kit has been failing e2e on `main` since it merged ([run 33415633658](https://github.com/docker/sbx-kits-contrib/actions/runs/33415633658)). It declares `requires.agent: claude-bedrock`, and creating that agent needs an AWS profile stored via `sbx secret set bedrock` — which CI does not have, and should not have. `sbx create` reports only a generic `failed to run sandbox container`, so the cause is invisible in the log, and the script's failure epilogue then pointed at the network allowlist, which was a dead end.

Kits can now declare that dependency:

```yaml
# aidlc-claude/testdata/tck.yaml
requiresHostCredentials: ["bedrock"]
```

The harness probes `sbx secret ls --service <svc> --json` before `sbx create` and skips the kit when nothing is stored. It probes for *presence* rather than matching the create failure text, since that text says nothing about credentials and matching it would be fragile. A probe that errors or returns an unrecognized payload still **fails** — only a confirmed-absent credential produces a skip, so this is not a blanket "skip e2e for this kit". Unlike `extractedFromBuiltin`, the flag does not self-obsolete: the requirement is permanent for the agent.

## Follow-ons, each its own commit

- **`fix(aidlc-claude)`** — `awslabs/aidlc-workflows` deleted its `v2` branch, so the kit's install step failed with `Remote branch v2 not found in upstream origin` entirely independently of the above. The harness it copies now lives on `main`. The per-project SHA pin in `aidlc/.aidlc-workflows-version` is unaffected: the clone still resolves a branch tip once and records that commit. This commit is self-contained and reverts cleanly on its own if you would rather handle the kit separately.
- **`fix(scripts)`** — the e2e failure epilogue told authors to widen their network allowlist even when the policy log reported no blocked requests. It now distinguishes three outcomes: blocked rows found, none found, or the log could not be read.
- **`docs`** — contributor docs still named the v1 `network.allowedDomains` field, and the README's new-kit tutorial showed a `schemaVersion: "1"` spec whose grammar is a hard error under v2.

## Why this reached `main`

Both e2e legs are gated on `head.repo.full_name == github.repository`, and the `e2e` job treats `skipped` as a pass. #238 came from a fork, so both legs were skipped and it merged green — the gap this repo's own PR template already warns about. This PR is same-repo, so e2e runs for real.

Note the CI matrix here is large: changes under `tck/**` escalate `detect-changes` to every kit, so all of them run. That is the intended coverage for a shared-harness change.

## Test plan

- [x] `go test ./spec/... ./tck/...` (the `test-tck` job) passes
- [x] `go test ./scripts/...` (the `test-scripts` job) passes
- [x] `./scripts/test-kit.sh aidlc-claude` passes, **including `install_execution`** — this is what the `v2`→`main` fix restores, and it exercises the kit for real (Bun install + harness clone + file placement in the container)
- [ ] `./scripts/test-kit-e2e.sh aidlc-claude` — **not run.** No `bedrock` profile is available to me, so the "credential stored → e2e runs in full" path is unexercised, and CI cannot exercise it by design. The absent-credential path is covered by `TestSecretServiceStored` and will show as a SKIP on this PR's `aidlc-claude` e2e leg. Flagging this rather than ticking the box.

The new `TestSecretServiceStored` deliberately sits in an untagged file so the fast `test-tck` job runs it — the e2e leg invokes `go test -run TestE2EKit`, which would otherwise filter it out and leave it running nowhere.
