### PR TITLE
feat(tck): substitute ${{ kit.args.* }} before the spec is decoded

### DIFF
--- a/skills/kit-author/topics/spec-anatomy.md
+++ b/skills/kit-author/topics/spec-anatomy.md
@@ -69,9 +69,11 @@ args:
     required: true                     # installer must supply a value
 ```
 
-Each argument declares exactly one of `default` or `required: true`, and constrains its value with at most one of `enum` or `pattern` (a Go RE2 regexp matched against the whole value). Values are always strings: quote the placeholder in a string-valued field (`VERSION: "${{ kit.args.version }}"`), or a value like `1.20` is read as a float.
+Each argument declares exactly one of `default` or `required: true`, and constrains its value with at most one of `enum` or `pattern` (a Go RE2 regexp matched against the whole value). Values are always strings: quote the placeholder in a string-valued field (`VERSION: "${{ kit.args.version }}"`), or a value like `1.20` is read as a float. Write `$${{` where you want a literal `${{` and no substitution — except in a mapping key, which is rejected for naming an argument whether escaped or not (see [SPEC-v2 §2.1](../../../spec/SPEC-v2.md#21-args)).
 
 `args` is v2-only, and unrelated to `sandbox.build.args` (Docker build arguments). Because the block lives in `spec.yaml`, a signature covers the declarations and defaults; the values an installer supplies do not.
+
+In this repository the TCK is the installer that supplies them — it reads them from your kit's `testdata/tck.yaml`. See [Testing — Kits that declare `args`](testing.md#kits-that-declare-args).
 
 ### `mixins`
 

--- a/skills/kit-author/topics/testing.md
+++ b/skills/kit-author/topics/testing.md
@@ -27,6 +27,7 @@ This repository ships a TCK package at [`tck/`](../../../tck/). It validates:
 6. Container files (files from `files/` are injected at the correct paths)
 7. Volumes (block-backed and `type: tmpfs` entries — plus the implicit `/run/secrets` tmpfs)
 8. Published ports (`ports[]` entries validate)
+9. Arguments (in `spec.yaml` scalars outside `args:`, and in every regular file under `files/`, each `${{ kit.args.<name> }}` reference names a declared argument and resolves to a constraint-satisfying value — checked as the suite loads, before any subtest runs)
 
 ### Writing a TCK test
 
@@ -53,6 +54,49 @@ suite, err := tck.NewSuiteFromDir(".", tck.WithImage("my-custom/template:latest"
 ```
 
 The TCK auto-resolves well-known parent agents (shell, claude, codex, copilot, cursor, docker-agent, droid, gemini, kiro, opencode) via their template images.
+
+### Kits that declare `args`
+
+A kit that declares [`args`](spec-anatomy.md#args) is installed with values someone supplies. The TCK is that someone: it substitutes every `${{ kit.args.<name> }}` reference in `spec.yaml` and in the regular files under `files/` before the spec is decoded, which is why an argument works in a field the schema pattern-checks, such as `requires.agent`. [SPEC-v2 §2.1](../../../spec/SPEC-v2.md#21-args) is the reference for what counts as a reference and what does not — a key, the `args:` block itself, another namespace, a substituted value.
+
+Each value comes from the `args:` block of your kit's `testdata/tck.yaml`, or from the argument's declared `default` when that block says nothing about it:
+
+```yaml
+# my-kit/spec.yaml
+args:
+  channel:
+    default: "stable"
+    enum: ["stable", "nightly"]
+  token:
+    required: true
+    description: "API token"
+
+setup:
+  install:
+    - command: "install-my-tool --channel '${{ kit.args.channel }}'"
+```
+
+```yaml
+# my-kit/testdata/tck.yaml
+args:
+  token: "dummy-for-ci"
+```
+
+An argument declared `required: true` has no default to fall back on, so the TCK **fails** the kit until `testdata/tck.yaml` supplies a value — naming the argument and the file. That is deliberate: a skip here is how a kit ends up shipping with nothing testing it. Pick a value that is safe in a public repo and good enough for the install to run; the TCK container has no real credentials either way.
+
+| Situation | Result |
+|---|---|
+| `tck.yaml` supplies a value | That value is substituted |
+| No value, argument has a `default` | The default is substituted |
+| No value, argument is `required` | **FAIL**, naming the argument and `testdata/tck.yaml` |
+| Value violates the argument's `enum` or `pattern` | **FAIL**, naming the value and the constraint |
+| A reference no `args:` entry declares | **FAIL**, naming the file and the reference |
+| A reference that does not parse — a dotted name, a missing `}}` | **FAIL**, naming the file and the offending text |
+| A `spec.yaml` mapping key naming an argument, escaped or not | **FAIL**, naming the key |
+
+Values are strings, and quoting the placeholder in `spec.yaml` is what keeps the substituted value one: leave it unquoted in a field that takes a number and `1.20` is read as a number, which is what you want there and not what you want in a string field.
+
+The e2e layer passes the very same `testdata/tck.yaml` values to `sbx create`, using its repeatable `--kit-arg <kit-name>.name=value` flag, so both layers install the kit with identical values. Arguments you leave to their defaults need no entry — the create resolves those the same way the TCK does.
 
 ### Running TCK
 
@@ -109,7 +153,7 @@ Every `sbx` call carries `--app-name sbx-kits-contrib-tck` so all commands route
 
 `kind: sandbox` kits **should** ship a `testdata/tck.yaml` file alongside their `spec.yaml` to opt in to the `prompt` subtest, which only exists for `kind: sandbox` kits (see the table above). The file is optional there too — the subtest is simply absent when the file is missing or `promptArgs` is empty. Kits whose agent requires a long async installation (e.g. nanoclaw, hermes-agent) may omit it until the installation reliably completes within the test timeout.
 
-The file itself is not sandbox-only, though: a `kind: mixin` kit ships one too when it needs `requiresHostCredentials` (see "Kits whose agent needs a host-stored credential" below). Only `promptArgs`, `readyFile`, `binary`, and `extractedFromBuiltin` are meaningful solely for `kind: sandbox`.
+The file itself is not sandbox-only, though: a `kind: mixin` kit ships one too when it needs `requiresHostCredentials` (see "Kits whose agent needs a host-stored credential" below) or `args` (see ["Kits that declare `args`"](#kits-that-declare-args)). Only `promptArgs`, `readyFile`, `binary`, and `extractedFromBuiltin` are meaningful solely for `kind: sandbox`.
 
 **Full schema:**
 
@@ -142,6 +186,11 @@ extractedFromBuiltin: true
 # stored on the host before this kit's agent can be created at all. See
 # "Kits whose agent needs a host-stored credential".
 requiresHostCredentials: ["bedrock"]
+
+# args: values for the arguments spec.yaml declares. Both the TCK layer and
+# e2e install the kit with these — see "Kits that declare `args`" above.
+args:
+  token: "dummy-for-ci"
 ```
 
 #### Kits that replace a built-in agent

--- a/spec/SPEC-v2.md
+++ b/spec/SPEC-v2.md
@@ -153,6 +153,21 @@ environment:
 - **Every reference MUST be declared.** A `${{ kit.args.x }}` with no `args.x`
   declaration is an error. That is what makes the block a complete, trustworthy
   list of a kit's inputs.
+- **A reference stands in for a value.** A mapping key that names an argument
+  is an error, escaped or not: nothing rewrites a key, so nothing there is
+  escapable.
+- **Escaping.** Write `$${{`, before any namespace, to emit a literal `${{`
+  and start no reference.
+- **Text that opens the namespace MUST parse.** An unescaped `${{ kit.args.`
+  that does not continue into a well-formed name and a closing `}}` is an
+  error, not text that survives into the value. A `${{ … }}` opening any other
+  namespace is otherwise left as written.
+- **The `args` block is never substituted.** Everything under it — defaults,
+  descriptions, enums, patterns — is the declaration of the kit's inputs, not
+  a use of them, so it reads exactly as written and a name mentioned only
+  there is no reference at all.
+- **A substituted value is spliced literally** and never re-read, so a value
+  that is itself shaped like a reference stays that text.
 - **Declarations are signed; values are not.** The block lives in `spec.yaml`,
   so a signature covers the argument names, defaults, and constraints. The
   values an installer supplies sit outside it.

--- a/spec/validate.go
+++ b/spec/validate.go
@@ -411,6 +411,16 @@ func ValidateLicenses(licenses []string) error {
 	return nil
 }
 
+// ValidArgName reports whether name is a well-formed kit-argument name.
+//
+// One grammar governs both ends of an argument: the key a kit declares under
+// args and the name a `${{ kit.args.<name> }}` reference selects it by. A
+// consumer that resolves references checks the second against this so the two
+// cannot drift apart and leave a name declarable but unreferenceable.
+func ValidArgName(name string) bool {
+	return argNamePattern.MatchString(name)
+}
+
 // ValidateArgs validates the well-formedness of a kit's argument
 // declarations (see KitArg). Each argument declares exactly one of default or
 // required: an argument with neither would silently substitute an empty
@@ -428,7 +438,7 @@ func ValidateLicenses(licenses []string) error {
 func ValidateArgs(args map[string]KitArg) error {
 	for _, name := range slices.Sorted(maps.Keys(args)) {
 		a := args[name]
-		if !argNamePattern.MatchString(name) {
+		if !ValidArgName(name) {
 			return fmt.Errorf("args[%q] is not a valid argument name (must start with a letter or underscore, followed by letters, digits, underscores, or hyphens)", name)
 		}
 		switch {

--- a/tck/args.go
+++ b/tck/args.go
@@ -1,0 +1,639 @@
+package tck
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/docker/sbx-kits-contrib/spec"
+	"go.yaml.in/yaml/v3"
+)
+
+const (
+	refOpen  = "${{"
+	refClose = "}}"
+
+	// refNamespace is the only `${{ … }}` namespace this package resolves.
+	// Text opening any other one is left as written, bar the escape, so a kit
+	// may carry `${{ github.sha }}` for something else to resolve.
+	refNamespace = "kit.args."
+)
+
+// specFileNames are the accepted spellings of a kit's spec file, in the order
+// the spec loader tries them.
+var specFileNames = []string{"spec.yaml", "spec.yml"}
+
+// openKitArtifact loads the kit at dir with every `${{ kit.args.<name> }}`
+// reference in its spec file and under files/ replaced by its resolved value,
+// bar the ones inside the spec's own args: block.
+//
+// Substitution runs before the spec is decoded and validated. That ordering is
+// what lets an argument parameterize a field the schema type-checks or
+// pattern-checks — requires.agent, a numeric resource — and not merely a
+// free-form string.
+//
+// In the spec file the substitution is made inside the YAML scalars, not on
+// the file's bytes: a value carrying a quote, a newline or its own `key:` text
+// then stays the single scalar the author wrote instead of reshaping the
+// document. Content under files/ is not YAML and is substituted as bytes.
+func openKitArtifact(dir string) (*spec.Artifact, error) {
+	// A spec file that is missing, unreadable, or not well-formed YAML fails
+	// for a reason that has nothing to do with arguments, so the loader is
+	// left to name it in its own terms.
+	doc, specName := openSpecDocument(dir)
+	if doc == nil {
+		return spec.OpenFromDirectory(dir)
+	}
+
+	values, err := resolveKitArgs(dir, doc, specName)
+	if err != nil {
+		return nil, err
+	}
+
+	specContent, refs, err := expandSpecDocument(doc, values)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", specName, err)
+	}
+	if err := undeclaredError(specName, refs, values, specName); err != nil {
+		return nil, err
+	}
+
+	staged, err := stageExpandedKit(dir, specName, specContent, values)
+	if err != nil {
+		return nil, err
+	}
+	if staged == "" {
+		return spec.OpenFromDirectory(dir)
+	}
+	defer removeStaging(staged)
+
+	artifact, err := spec.OpenFromDirectory(staged)
+	if err != nil {
+		return nil, err
+	}
+	// The staging tree is deleted when this call returns, so no file may be
+	// left behind a ContentSource that would read from it later.
+	if err := artifact.Materialize(); err != nil {
+		return nil, err
+	}
+	return artifact, nil
+}
+
+// KitArgFlags renders kitName's argument values as flags for `sbx create`,
+// which documents --kit-arg as a repeatable option. The kit-scoped
+// <kit>.<name>=value spelling is used rather than the bare name: a create can
+// carry several kits, and an unscoped value is offered to every one of them
+// that happens to declare that argument name. Names are sorted so a command
+// line is reproducible.
+func KitArgFlags(kitName string, args map[string]string) []string {
+	flags := make([]string, 0, 2*len(args))
+	for _, name := range slices.Sorted(maps.Keys(args)) {
+		flags = append(flags, "--kit-arg", kitName+"."+name+"="+args[name])
+	}
+	return flags
+}
+
+// resolveKitArgs pairs each argument the kit declares with the value the TCK
+// substitutes for it: the entry under `args:` in <dir>/testdata/tck.yaml when
+// there is one, otherwise the argument's declared default. A required
+// argument with no value in tck.yaml is an error rather than a skip — a kit
+// whose arguments cannot be resolved is a kit nothing tests.
+func resolveKitArgs(dir string, doc *yaml.Node, specName string) (map[string]string, error) {
+	decls, err := readArgDeclarations(doc, specName)
+	if err != nil {
+		return nil, err
+	}
+	if err := spec.ValidateArgs(decls); err != nil {
+		return nil, err
+	}
+
+	tckPath := filepath.Join(dir, "testdata", "tck.yaml")
+	supplied, err := readTCKArgs(tckPath)
+	if err != nil {
+		return nil, err
+	}
+	for _, name := range slices.Sorted(maps.Keys(supplied)) {
+		if _, declared := decls[name]; !declared {
+			return nil, fmt.Errorf("%s sets args[%q], which %s does not declare", tckPath, name, specName)
+		}
+	}
+
+	values := make(map[string]string, len(decls))
+	for _, name := range slices.Sorted(maps.Keys(decls)) {
+		decl := decls[name]
+		value, ok := supplied[name]
+		if !ok {
+			if decl.Default == nil {
+				return nil, fmt.Errorf(
+					"args[%q] is required and %s supplies no value; declare it there as `args:` with a %q entry",
+					name, tckPath, name)
+			}
+			values[name] = *decl.Default
+			continue
+		}
+		// ValidateArgs has already rejected a declaration whose own default
+		// violates its enum or pattern, so only a tck.yaml value reaches here
+		// unchecked.
+		if err := decl.ValidateValue(value); err != nil {
+			return nil, fmt.Errorf("%s: args[%q]: %w", tckPath, name, err)
+		}
+		values[name] = value
+	}
+	return values, nil
+}
+
+// readArgDeclarations decodes only the args: block of the parsed spec
+// document. A full decode cannot run first: an unexpanded placeholder in a
+// typed or pattern-checked field fails it, and these declarations are what
+// tell the expansion how to replace that placeholder.
+//
+// A document that is not a mapping declares no arguments here; saying so is
+// the loader's job, not this one's.
+func readArgDeclarations(doc *yaml.Node, specName string) (map[string]spec.KitArg, error) {
+	if len(doc.Content) == 0 || doc.Content[0].Kind != yaml.MappingNode {
+		return nil, nil
+	}
+	var block struct {
+		Args map[string]spec.KitArg `yaml:"args"`
+	}
+	if err := doc.Content[0].Decode(&block); err != nil {
+		return nil, fmt.Errorf("read the args: block of %s: %w", specName, err)
+	}
+	return block.Args, nil
+}
+
+// readTCKArgs reads the `args:` block of a kit's testdata/tck.yaml. A missing
+// file yields no values, which is the ordinary case for a kit whose arguments
+// all have defaults.
+func readTCKArgs(path string) (map[string]string, error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var doc struct {
+		Args map[string]string `yaml:"args"`
+	}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parse the args: block of %s: %w", path, err)
+	}
+	return doc.Args, nil
+}
+
+// openSpecDocument parses the kit's spec file and returns it with the name it
+// was found under, or a nil node when there is nothing readable and parseable
+// to work from.
+func openSpecDocument(dir string) (*yaml.Node, string) {
+	for _, name := range specFileNames {
+		data, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			continue
+		}
+		var doc yaml.Node
+		if err := yaml.Unmarshal(data, &doc); err != nil {
+			return nil, ""
+		}
+		return &doc, name
+	}
+	return nil, ""
+}
+
+// scanArgs rewrites s, replacing each `${{ kit.args.<name> }}` reference whose
+// name values holds with that value, and returns every name it referenced —
+// including ones values does not hold, which are left in place for the caller
+// to report together.
+//
+// An occurrence of `${{` that opens the kit.args namespace must parse as a
+// whole reference: an unclosed one, or one whose name is not a name, is an
+// error rather than text that survives into an install command. A `${{` that
+// opens any other namespace is copied through, and `$${{` emits a literal
+// `${{` and opens nothing.
+//
+// A substituted value is written out as-is and never rescanned, so a value can
+// carry reference-shaped text without it resolving to anything.
+func scanArgs(s string, values map[string]string) (string, []string, error) {
+	if !strings.Contains(s, refOpen) {
+		return s, nil, nil
+	}
+
+	var b strings.Builder
+	var refs []string
+	for i := 0; i < len(s); {
+		j := strings.Index(s[i:], refOpen)
+		if j < 0 {
+			b.WriteString(s[i:])
+			break
+		}
+		j += i
+
+		if j > i && s[j-1] == '$' {
+			b.WriteString(s[i : j-1])
+			b.WriteString(refOpen)
+			i = j + len(refOpen)
+			continue
+		}
+
+		b.WriteString(s[i:j])
+		i = j + len(refOpen)
+
+		if !opensArgNamespace(s[i:]) {
+			b.WriteString(refOpen)
+			continue
+		}
+
+		end := strings.Index(s[i:], refClose)
+		if end < 0 {
+			return "", nil, fmt.Errorf("unterminated argument reference %q: close it with %s", excerpt(s[j:]), refClose)
+		}
+		inner := s[i : i+end]
+		// Trimmed before the prefix is cut, so nothing may sit between the
+		// namespace dot and the name it selects.
+		name := strings.TrimPrefix(strings.TrimSpace(inner), refNamespace)
+		if !spec.ValidArgName(name) {
+			return "", nil, fmt.Errorf(
+				"malformed argument reference %q: an argument name starts with a letter or underscore, then letters, digits, underscores or hyphens — a dot is not part of one",
+				excerpt(refOpen+inner+refClose))
+		}
+		i += end + len(refClose)
+
+		refs = append(refs, name)
+		if value, ok := values[name]; ok {
+			b.WriteString(value)
+			continue
+		}
+		b.WriteString(refOpen + inner + refClose)
+	}
+	return b.String(), refs, nil
+}
+
+// excerpt shortens text quoted back to the author so one runaway reference
+// cannot print a whole file. The cut lands on a rune boundary, never inside a
+// multi-byte character.
+func excerpt(s string) string {
+	const max = 60
+	if len(s) <= max {
+		return s
+	}
+	cut := max
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + "…"
+}
+
+// undeclaredError reports the references in refs that values cannot resolve.
+// where names the file they were read from, which is not always the spec file
+// the declaration is missing from.
+func undeclaredError(where string, refs []string, values map[string]string, specName string) error {
+	var missing []string
+	for _, name := range refs {
+		if _, ok := values[name]; !ok && !slices.Contains(missing, name) {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	slices.Sort(missing)
+	quoted := make([]string, len(missing))
+	for i, name := range missing {
+		quoted[i] = refOpen + " " + refNamespace + name + " " + refClose
+	}
+	return fmt.Errorf("%s references %s, which %s does not declare in its args: block",
+		where, strings.Join(quoted, ", "), specName)
+}
+
+type specExpander struct {
+	values  map[string]string
+	refs    []string
+	changed bool
+}
+
+// expandSpecDocument substitutes doc's scalars in place and re-encodes it,
+// returning nil content when nothing was substituted so the caller can keep
+// the author's own bytes.
+func expandSpecDocument(doc *yaml.Node, values map[string]string) ([]byte, []string, error) {
+	e := &specExpander{values: values}
+	if err := e.walk(doc, false); err != nil {
+		return nil, nil, err
+	}
+	if !e.changed {
+		return nil, e.refs, nil
+	}
+	out, err := yaml.Marshal(doc)
+	if err != nil {
+		return nil, nil, err
+	}
+	return out, e.refs, nil
+}
+
+// walk substitutes n's scalars. atRoot marks the spec document's top-level
+// node, the one mapping whose args key names the declaration block rather
+// than ordinary content.
+func (e *specExpander) walk(n *yaml.Node, atRoot bool) error {
+	switch n.Kind {
+	case yaml.DocumentNode:
+		for _, child := range n.Content {
+			if err := e.walk(child, true); err != nil {
+				return err
+			}
+		}
+	case yaml.SequenceNode:
+		for _, child := range n.Content {
+			if err := e.walk(child, false); err != nil {
+				return err
+			}
+		}
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(n.Content); i += 2 {
+			key := n.Content[i]
+			if err := e.checkKey(key); err != nil {
+				return err
+			}
+			// The args block is the signed contract naming a kit's inputs, so
+			// substitution must never rewrite a declaration into something its
+			// author did not write — reference-shaped text in a default or a
+			// description documents an input rather than using one.
+			if atRoot && key.Kind == yaml.ScalarNode && key.Value == "args" {
+				continue
+			}
+			if err := e.walk(n.Content[i+1], false); err != nil {
+				return err
+			}
+		}
+	case yaml.ScalarNode:
+		return e.walkScalar(n)
+	}
+	return nil
+}
+
+// checkKey rejects a mapping key that names an argument. An argument
+// parameterizes a value in the grammar; a key is the grammar.
+//
+// A key is never rewritten, so there is nothing for `$${{` to escape and the
+// check does not honor it: text shaped like a reference is refused wherever it
+// appears in a key. A key that is not a scalar is left alone entirely.
+func (e *specExpander) checkKey(n *yaml.Node) error {
+	if n.Kind != yaml.ScalarNode || !opensArgRef(n.Value) {
+		return nil
+	}
+	return fmt.Errorf("mapping key %q references an argument, which may only stand in for a value", n.Value)
+}
+
+// opensArgNamespace reports whether s — the text just past a `${{` opener —
+// names the kit-args namespace. Its notion of leading space is the same one
+// that trims the name out, so no reference can read as a foreign namespace
+// here and as a kit argument there.
+func opensArgNamespace(s string) bool {
+	return strings.HasPrefix(strings.TrimLeftFunc(s, unicode.IsSpace), refNamespace)
+}
+
+// opensArgRef reports whether s contains an opener for the kit.args namespace.
+func opensArgRef(s string) bool {
+	for i := 0; i < len(s); {
+		j := strings.Index(s[i:], refOpen)
+		if j < 0 {
+			return false
+		}
+		i += j + len(refOpen)
+		if opensArgNamespace(s[i:]) {
+			return true
+		}
+	}
+	return false
+}
+
+func (e *specExpander) walkScalar(n *yaml.Node) error {
+	out, refs, err := scanArgs(n.Value, e.values)
+	if err != nil {
+		return err
+	}
+	e.refs = append(e.refs, refs...)
+	if out == n.Value {
+		return nil
+	}
+	n.Value = out
+	e.changed = true
+	if n.Style != yaml.SingleQuotedStyle && n.Style != yaml.DoubleQuotedStyle {
+		// The scalar carries the resolver's !!str tag from before the
+		// substitution. Dropping tag and style together re-infers the type
+		// from the substituted text, which is the whole of the spec's quoting
+		// rule: only a quoted placeholder promises a string, and every other
+		// style — plain, literal, folded — asks for the ordinary inference.
+		n.Tag = ""
+		n.Style = 0
+	}
+	return nil
+}
+
+// stagedEntry is one path of a kit directory as it will be recreated in the
+// staging tree. A regular file with nil content is copied from the kit
+// unchanged.
+type stagedEntry struct {
+	rel     string
+	mode    fs.FileMode
+	isDir   bool
+	link    string
+	content []byte
+}
+
+// stageExpandedKit copies dir into a temporary tree carrying specContent as
+// the spec file and every files/ reference expanded, and returns that tree's
+// path. It returns "" when nothing was substituted anywhere, so a kit that
+// references no argument is loaded straight from its own directory and cannot
+// be perturbed by the copy.
+//
+// The whole directory is copied, not only the substituted files, so that a
+// symlink under files/ pointing at a target elsewhere in the kit still
+// resolves inside the staged root. Links are recreated as links rather than
+// followed, leaving the loader something to resolve and check: a relative
+// in-tree target lands inside the copy, an absolute one wherever it points.
+func stageExpandedKit(dir, specName string, specContent []byte, values map[string]string) (string, error) {
+	// The walk below lstats what it is given, so a kit directory that is
+	// itself a symlink would yield one entry and no tree. The loader accepts
+	// such a kit; resolving here keeps staging able to copy it.
+	kitDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return "", fmt.Errorf("stage expanded kit: %w", err)
+	}
+
+	entries, expanded, err := planStaging(kitDir, specName, specContent, values)
+	if err != nil || !expanded {
+		return "", err
+	}
+
+	root, err := os.MkdirTemp("", "tck-kit-args-")
+	if err != nil {
+		return "", fmt.Errorf("stage expanded kit: %w", err)
+	}
+	if err := writeStaging(root, kitDir, entries); err != nil {
+		removeStaging(root)
+		return "", fmt.Errorf("stage expanded kit: %w", err)
+	}
+	return root, nil
+}
+
+// removeStaging deletes a staging tree, restoring owner write access on the
+// way in: a directory staged read-only to match the kit cannot have its
+// children unlinked otherwise.
+func removeStaging(root string) {
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err == nil && d.IsDir() {
+			_ = os.Chmod(path, 0o700)
+		}
+		return nil
+	})
+	_ = os.RemoveAll(root)
+}
+
+// planStaging walks dir, substituting the files/ content an argument reference
+// may appear in and recording every other path for a verbatim copy. expanded
+// reports whether anything — here or in the already-expanded spec file — was
+// actually substituted.
+//
+// Anything that is neither a regular file, a directory nor a symlink is left
+// out rather than opened: a fifo would block the walk forever, and whether
+// such an entry matters to a kit is the loader's judgement to make.
+func planStaging(dir, specName string, specContent []byte, values map[string]string) (entries []stagedEntry, expanded bool, err error) {
+	expanded = specContent != nil
+
+	err = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		rel = filepath.ToSlash(rel)
+
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		entry := stagedEntry{rel: rel, mode: info.Mode().Perm(), isDir: d.IsDir()}
+
+		switch {
+		case rel == specName:
+			// Ahead of the symlink case: a spec file reached through a link
+			// must still be staged as the substituted bytes, not as a link
+			// back to text nothing has substituted.
+			target, err := os.Stat(path)
+			if err != nil {
+				return err
+			}
+			entry.mode = target.Mode().Perm()
+			entry.content = specContent
+		case d.IsDir():
+		case d.Type()&fs.ModeSymlink != 0:
+			if entry.link, err = os.Readlink(path); err != nil {
+				return err
+			}
+		case !info.Mode().IsRegular():
+			return nil
+		case strings.HasPrefix(rel, "files/"):
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			if !bytes.Contains(raw, []byte(refOpen)) {
+				break
+			}
+			src := string(raw)
+			out, refs, err := scanArgs(src, values)
+			if err != nil {
+				return fmt.Errorf("%s: %w", rel, err)
+			}
+			if err := undeclaredError(rel, refs, values, specName); err != nil {
+				return err
+			}
+			if out != src {
+				expanded = true
+				entry.content = []byte(out)
+			}
+		}
+
+		entries = append(entries, entry)
+		return nil
+	})
+	if err != nil {
+		return nil, false, fmt.Errorf("plan the expanded copy of %s: %w", dir, err)
+	}
+	return entries, expanded, nil
+}
+
+func writeStaging(root, kitDir string, entries []stagedEntry) error {
+	for _, e := range entries {
+		rel := filepath.FromSlash(e.rel)
+		if err := writeStagedEntry(filepath.Join(root, rel), filepath.Join(kitDir, rel), e); err != nil {
+			return err
+		}
+	}
+
+	// Directories were created wide enough to write into. Narrowing them back
+	// in reverse walk order narrows each one only once its own subtree is in
+	// place.
+	for i := len(entries) - 1; i >= 0; i-- {
+		if !entries[i].isDir {
+			continue
+		}
+		path := filepath.Join(root, filepath.FromSlash(entries[i].rel))
+		if err := os.Chmod(path, entries[i].mode); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeStagedEntry(path, kitPath string, e stagedEntry) error {
+	switch {
+	case e.link != "":
+		return os.Symlink(e.link, path)
+	case e.isDir:
+		return os.MkdirAll(path, e.mode|0o700)
+	case e.content != nil:
+		if err := os.WriteFile(path, e.content, e.mode); err != nil {
+			return err
+		}
+	default:
+		if err := copyFile(kitPath, path, e.mode); err != nil {
+			return err
+		}
+	}
+	// The umask applies to the create modes above, and a staged file's mode is
+	// an assertion of the TCK's: it is what the file is created with in the
+	// container.
+	return os.Chmod(path, e.mode)
+}
+
+func copyFile(src, dst string, mode fs.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
+}

--- a/tck/args_test.go
+++ b/tck/args_test.go
@@ -1,0 +1,440 @@
+package tck
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
+)
+
+func TestScanArgs(t *testing.T) {
+	values := map[string]string{"version": "1.20", "api-token": "shhh"}
+
+	t.Run("replaces_declared_reference", func(t *testing.T) {
+		out, refs, err := scanArgs(`VERSION: "${{ kit.args.version }}"`, values)
+		require.NoError(t, err)
+		require.Equal(t, []string{"version"}, refs)
+		require.Equal(t, `VERSION: "1.20"`, out)
+	})
+
+	t.Run("tolerates_whitespace_and_hyphenated_names", func(t *testing.T) {
+		out, _, err := scanArgs("${{kit.args.api-token}} ${{   kit.args.version   }}", values)
+		require.NoError(t, err)
+		require.Equal(t, "shhh 1.20", out)
+	})
+
+	t.Run("leaves_other_namespaces_alone", func(t *testing.T) {
+		src := "${WORKDIR} ${{ github.sha }} $HOME ${{ kit.other.version }} ${{ matrix.kit }}"
+		out, refs, err := scanArgs(src, values)
+		require.NoError(t, err)
+		require.Empty(t, refs)
+		require.Equal(t, src, out)
+	})
+
+	t.Run("doubled_dollar_escapes_the_opener", func(t *testing.T) {
+		out, refs, err := scanArgs("literal $${{ kit.args.version }} and real ${{ kit.args.version }}", values)
+		require.NoError(t, err)
+		require.Equal(t, []string{"version"}, refs, "the escaped occurrence is not a reference")
+		require.Equal(t, "literal ${{ kit.args.version }} and real 1.20", out)
+	})
+
+	t.Run("escape_consumes_exactly_one_dollar", func(t *testing.T) {
+		out, refs, err := scanArgs("$$${{ kit.args.version }}", values)
+		require.NoError(t, err)
+		require.Empty(t, refs)
+		require.Equal(t, "$${{ kit.args.version }}", out)
+	})
+
+	t.Run("unicode_space_opens_a_reference", func(t *testing.T) {
+		out, refs, err := scanArgs("${{\u00a0kit.args.version\u00a0}}", values)
+		require.NoError(t, err)
+		require.Equal(t, []string{"version"}, refs,
+			"a non-breaking space is space to both halves of the scan")
+		require.Equal(t, "1.20", out)
+	})
+
+	t.Run("space_after_the_namespace_dot_is_malformed", func(t *testing.T) {
+		_, _, err := scanArgs("${{ kit.args. version }}", values)
+		require.ErrorContains(t, err, `malformed argument reference "${{ kit.args. version }}"`)
+	})
+
+	t.Run("dotted_name_is_malformed", func(t *testing.T) {
+		_, _, err := scanArgs("${{ kit.args.foo.bar }}", values)
+		require.ErrorContains(t, err, `malformed argument reference "${{ kit.args.foo.bar }}"`)
+		require.ErrorContains(t, err, "a dot is not part of one")
+	})
+
+	t.Run("unterminated_reference_is_an_error", func(t *testing.T) {
+		_, _, err := scanArgs("install --version ${{ kit.args.version", values)
+		require.ErrorContains(t, err, `unterminated argument reference "${{ kit.args.version"`)
+		require.ErrorContains(t, err, "close it with }}")
+	})
+
+	t.Run("reports_every_referenced_name", func(t *testing.T) {
+		_, refs, err := scanArgs("${{ kit.args.zeta }} ${{ kit.args.alpha }} ${{ kit.args.zeta }}", nil)
+		require.NoError(t, err)
+		require.Equal(t, []string{"zeta", "alpha", "zeta"}, refs)
+	})
+
+	t.Run("undeclared_reference_is_left_in_place", func(t *testing.T) {
+		out, refs, err := scanArgs("${{ kit.args.nope }}", values)
+		require.NoError(t, err)
+		require.Equal(t, []string{"nope"}, refs)
+		require.Equal(t, "${{ kit.args.nope }}", out)
+	})
+
+	t.Run("a_substituted_value_is_not_rescanned", func(t *testing.T) {
+		out, refs, err := scanArgs("${{ kit.args.version }}", map[string]string{
+			"version":   "${{ kit.args.api-token }}",
+			"api-token": "shhh",
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"version"}, refs)
+		require.Equal(t, "${{ kit.args.api-token }}", out)
+	})
+}
+
+func TestExpandSpecDocument(t *testing.T) {
+	expand := func(t *testing.T, src string, values map[string]string) ([]byte, error) {
+		t.Helper()
+		var doc yaml.Node
+		require.NoError(t, yaml.Unmarshal([]byte(src), &doc))
+		out, _, err := expandSpecDocument(&doc, values)
+		return out, err
+	}
+
+	t.Run("value_reshaping_the_document_stays_one_scalar", func(t *testing.T) {
+		hostile := "he said \"hi\"\nname: not-a-key\n- not an item"
+		out, err := expand(t, "description: \"${{ kit.args.text }}\"\nname: real\n",
+			map[string]string{"text": hostile})
+		require.NoError(t, err)
+
+		var got struct {
+			Description string `yaml:"description"`
+			Name        string `yaml:"name"`
+		}
+		require.NoError(t, yaml.Unmarshal(out, &got))
+		require.Equal(t, hostile, got.Description)
+		require.Equal(t, "real", got.Name, "the substituted value did not introduce a key")
+	})
+
+	t.Run("unquoted_placeholder_re_infers_its_type", func(t *testing.T) {
+		out, err := expand(t, "cpu: ${{ kit.args.cpu }}\n", map[string]string{"cpu": "1.20"})
+		require.NoError(t, err)
+
+		var got struct {
+			CPU float64 `yaml:"cpu"`
+		}
+		require.NoError(t, yaml.Unmarshal(out, &got))
+		require.InDelta(t, 1.20, got.CPU, 0)
+	})
+
+	t.Run("block_scalars_re_infer_their_type_too", func(t *testing.T) {
+		for _, style := range []string{">-", "|-"} {
+			out, err := expand(t, "cpu: "+style+"\n  ${{ kit.args.cpu }}\n", map[string]string{"cpu": "1.20"})
+			require.NoErrorf(t, err, "style %s", style)
+
+			var got struct {
+				CPU float64 `yaml:"cpu"`
+			}
+			require.NoErrorf(t, yaml.Unmarshal(out, &got), "style %s decodes: %s", style, out)
+			require.InDeltaf(t, 1.20, got.CPU, 0, "style %s", style)
+		}
+	})
+
+	t.Run("quoted_placeholder_stays_a_string", func(t *testing.T) {
+		for _, quote := range []string{`"`, "'"} {
+			out, err := expand(t, "cpu: "+quote+"${{ kit.args.cpu }}"+quote+"\n", map[string]string{"cpu": "1.20"})
+			require.NoErrorf(t, err, "quote %s", quote)
+
+			var got struct {
+				CPU any `yaml:"cpu"`
+			}
+			require.NoErrorf(t, yaml.Unmarshal(out, &got), "quote %s", quote)
+			require.Equalf(t, "1.20", got.CPU, "a quoted placeholder stays a string under %s", quote)
+		}
+	})
+
+	t.Run("reference_in_a_mapping_key_is_an_error", func(t *testing.T) {
+		_, err := expand(t, "environment:\n  ${{ kit.args.name }}: value\n", map[string]string{"name": "K"})
+		require.ErrorContains(t, err,
+			`mapping key "${{ kit.args.name }}" references an argument, which may only stand in for a value`)
+	})
+
+	t.Run("escaping_does_not_excuse_a_kit_args_key", func(t *testing.T) {
+		_, err := expand(t, "environment:\n  \"$${{ kit.args.name }}\": value\n", map[string]string{"name": "K"})
+		require.ErrorContains(t, err, `mapping key "$${{ kit.args.name }}" references an argument`)
+	})
+
+	t.Run("unicode_space_does_not_disguise_a_key", func(t *testing.T) {
+		_, err := expand(t, "environment:\n  \"${{\u00a0kit.args.name }}\": value\n", map[string]string{"name": "K"})
+		require.ErrorContains(t, err, "references an argument")
+	})
+
+	t.Run("foreign_namespace_key_passes_through", func(t *testing.T) {
+		var doc yaml.Node
+		require.NoError(t, yaml.Unmarshal([]byte(
+			"environment:\n  \"$${{ github.sha }}\": \"${{ kit.args.v }}\"\n"), &doc))
+		_, _, err := expandSpecDocument(&doc, map[string]string{"v": "X"})
+		require.NoError(t, err)
+
+		env := doc.Content[0].Content[1]
+		require.Equal(t, "$${{ github.sha }}", env.Content[0].Value, "keys are never rewritten")
+		require.Equal(t, "X", env.Content[1].Value)
+	})
+
+	t.Run("complex_key_contents_are_left_alone", func(t *testing.T) {
+		var doc yaml.Node
+		require.NoError(t, yaml.Unmarshal([]byte(
+			"? [a, \"${{ kit.args.v }}\"]\n: keyed\nname: \"${{ kit.args.v }}\"\n"), &doc))
+		_, _, err := expandSpecDocument(&doc, map[string]string{"v": "X"})
+		require.NoError(t, err)
+
+		root := doc.Content[0]
+		require.Equal(t, yaml.SequenceNode, root.Content[0].Kind)
+		require.Equal(t, "${{ kit.args.v }}", root.Content[0].Content[1].Value)
+		require.Equal(t, "X", root.Content[3].Value, "an ordinary value alongside it is still substituted")
+	})
+
+	t.Run("the_args_block_is_never_substituted", func(t *testing.T) {
+		var doc yaml.Node
+		require.NoError(t, yaml.Unmarshal([]byte(
+			"args:\n  literal:\n    default: \"${{ kit.args.other }}\"\n"+
+				"    description: \"see ${{ kit.args.nosuch }}\"\nname: \"${{ kit.args.other }}\"\n"), &doc))
+		_, refs, err := expandSpecDocument(&doc, map[string]string{"other": "X", "literal": "Y"})
+		require.NoError(t, err)
+		require.Equal(t, []string{"other"}, refs, "references inside args: are not collected")
+
+		block := doc.Content[0].Content[1]
+		require.Equal(t, "${{ kit.args.other }}", block.Content[1].Content[1].Value)
+		require.Equal(t, "see ${{ kit.args.nosuch }}", block.Content[1].Content[3].Value)
+		require.Equal(t, "X", doc.Content[0].Content[3].Value)
+	})
+
+	t.Run("a_nested_args_key_is_ordinary_content", func(t *testing.T) {
+		var doc yaml.Node
+		require.NoError(t, yaml.Unmarshal([]byte(
+			"args:\n  v:\n    default: \"1.2.3\"\n"+
+				"sandbox:\n  build:\n    args:\n      VERSION: \"${{ kit.args.v }}\"\n"), &doc))
+		_, refs, err := expandSpecDocument(&doc, map[string]string{"v": "1.2.3"})
+		require.NoError(t, err)
+		require.Equal(t, []string{"v"}, refs)
+
+		// sandbox.build.args carries Docker build arguments, which the spec is
+		// explicit are not the kit's own args block.
+		build := doc.Content[0].Content[3].Content[1]
+		require.Equal(t, "1.2.3", build.Content[1].Content[1].Value)
+	})
+
+	t.Run("no_reference_leaves_the_authors_bytes", func(t *testing.T) {
+		out, err := expand(t, "name: plain\n", map[string]string{"v": "x"})
+		require.NoError(t, err)
+		require.Nil(t, out)
+	})
+}
+
+func TestExcerptCutsOnARuneBoundary(t *testing.T) {
+	s := strings.Repeat("a", 59) + "é" + strings.Repeat("b", 20)
+	got := excerpt(s)
+
+	require.True(t, utf8.ValidString(got), "excerpt must not split a multi-byte character")
+	require.Equal(t, strings.Repeat("a", 59)+"…", got)
+}
+
+func TestKitArgFlags(t *testing.T) {
+	require.Equal(t,
+		[]string{
+			"--kit-arg", "my-kit.alpha=1", "--kit-arg", "my-kit.beta=2",
+			"--kit-arg", "my-kit.gamma=3", "--kit-arg", "my-kit.token=dummy-for-ci",
+		},
+		KitArgFlags("my-kit", map[string]string{
+			"token": "dummy-for-ci", "gamma": "3", "alpha": "1", "beta": "2",
+		}),
+		"values are scoped to the kit and ordered by name")
+	require.Empty(t, KitArgFlags("my-kit", nil))
+}
+
+func TestResolveKitArgs(t *testing.T) {
+	resolve := func(t *testing.T, dir string) (map[string]string, error) {
+		t.Helper()
+		doc, name := openSpecDocument(dir)
+		require.NotNil(t, doc, "fixture %s has no parseable spec file", dir)
+		return resolveKitArgs(dir, doc, name)
+	}
+
+	t.Run("tck_yaml_value_beats_the_default", func(t *testing.T) {
+		values, err := resolve(t, "testdata/args-install")
+		require.NoError(t, err)
+		require.Equal(t, "supplied by tck.yaml", values["greeting"])
+		require.Equal(t, "1.20", values["version"], "an argument tck.yaml omits falls back to its default")
+		require.Equal(t, "dummy-for-ci", values["token"])
+	})
+
+	t.Run("required_without_a_value_fails", func(t *testing.T) {
+		_, err := resolve(t, "testdata/args-required-missing")
+		require.ErrorContains(t, err, `args["token"] is required`)
+		require.ErrorContains(t, err,
+			filepath.Join("testdata", "args-required-missing", "testdata", "tck.yaml")+" supplies no value")
+		require.ErrorContains(t, err, `declare it there as `+"`args:`"+` with a "token" entry`)
+	})
+
+	t.Run("value_violating_its_enum_fails", func(t *testing.T) {
+		_, err := resolve(t, "testdata/args-bad-value")
+		require.ErrorContains(t, err, filepath.Join("testdata", "args-bad-value", "testdata", "tck.yaml"))
+		require.ErrorContains(t, err, `args["channel"]: "beta" is not one of "stable", "nightly"`)
+	})
+
+	t.Run("undeclared_tck_yaml_value_fails", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "spec.yaml"), []byte(
+			"schemaVersion: \"2\"\nkind: mixin\nname: stray\n"), 0o644))
+		require.NoError(t, os.Mkdir(filepath.Join(dir, "testdata"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "testdata", "tck.yaml"), []byte(
+			"args:\n  nobody: \"x\"\n"), 0o644))
+
+		_, err := resolve(t, dir)
+		require.ErrorContains(t, err, `sets args["nobody"], which spec.yaml does not declare`)
+	})
+}
+
+func TestNewSuiteFromDirSubstitutesArgs(t *testing.T) {
+	t.Run("pattern_checked_field", func(t *testing.T) {
+		suite, err := NewSuiteFromDir("testdata/args-requires-agent")
+		require.NoError(t, err)
+		require.Equal(t, "codex", suite.Artifact.Requires.Agent)
+		require.Equal(t, wellKnownTemplates["codex"], suite.Image,
+			"image resolution reads the substituted affinity")
+	})
+
+	t.Run("quoted_reference_stays_a_string", func(t *testing.T) {
+		suite, err := NewSuiteFromDir("testdata/args-install")
+		require.NoError(t, err)
+		require.Equal(t, "1.20", suite.Artifact.Environment.Variables["ARGS_FIXTURE_VERSION"])
+		require.Equal(t, "dummy-for-ci", suite.Artifact.Environment.Variables["ARGS_FIXTURE_TOKEN"])
+	})
+
+	t.Run("files_payload", func(t *testing.T) {
+		suite, err := NewSuiteFromDir("testdata/args-install")
+		require.NoError(t, err)
+		require.Len(t, suite.Artifact.Files, 1)
+
+		rc, err := suite.Artifact.Files[0].Open()
+		require.NoError(t, err)
+		defer rc.Close()
+		content, err := io.ReadAll(rc)
+		require.NoError(t, err)
+		require.Equal(t, "version=1.20\nliteral=${{ kit.args.version }}\n", string(content),
+			"files/ content is substituted, and $${{ emits a literal opener")
+	})
+
+	t.Run("undeclared_reference", func(t *testing.T) {
+		_, err := NewSuiteFromDir("testdata/args-undeclared")
+		require.ErrorContains(t, err,
+			"spec.yaml references ${{ kit.args.token }}, which spec.yaml does not declare in its args: block")
+	})
+
+	t.Run("malformed_reference_under_files", func(t *testing.T) {
+		dir := writeKit(t, map[string]string{
+			"spec.yaml":         "schemaVersion: \"2\"\nkind: mixin\nname: bad-ref\nargs:\n  v:\n    default: \"1\"\n",
+			"files/home/run.sh": "echo ${{ kit.args.v.patch }}\n",
+		})
+
+		_, err := NewSuiteFromDir(dir)
+		require.ErrorContains(t, err, "files/home/run.sh: malformed argument reference")
+	})
+
+	t.Run("declarations_reach_the_artifact_untouched", func(t *testing.T) {
+		suite, err := NewSuiteFromDir("testdata/args-block-literal")
+		require.NoError(t, err)
+
+		literal := suite.Artifact.Args["literal"]
+		require.Equal(t, "${{ kit.args.other }}", *literal.Default)
+		require.Equal(t, "prose naming ${{ kit.args.nosuch }}, which no declaration answers for",
+			literal.Description, "an undeclared name in prose is prose, not a reference")
+		require.Equal(t, "${{ kit.args.other }}",
+			suite.Artifact.Environment.Variables["ARGS_FIXTURE_LITERAL"],
+			"the declared default ships as the value it is, unrescanned")
+	})
+
+	t.Run("value_that_would_reshape_the_spec_survives_whole", func(t *testing.T) {
+		hostile := "he said \"hi\"\nKEEP: hijacked"
+		tckYAML, err := yaml.Marshal(map[string]any{"args": map[string]string{"note": hostile}})
+		require.NoError(t, err)
+
+		dir := writeKit(t, map[string]string{
+			"spec.yaml": "schemaVersion: \"2\"\nkind: mixin\nname: hostile-value\n" +
+				"args:\n  note:\n    required: true\n" +
+				"environment:\n  variables:\n    NOTE: \"${{ kit.args.note }}\"\n    KEEP: \"sentinel\"\n",
+			"testdata/tck.yaml": string(tckYAML),
+		})
+
+		suite, err := NewSuiteFromDir(dir)
+		require.NoError(t, err)
+		require.Equal(t, hostile, suite.Artifact.Environment.Variables["NOTE"])
+		require.Equal(t, "sentinel", suite.Artifact.Environment.Variables["KEEP"],
+			"the substituted value must not introduce a key of its own")
+	})
+}
+
+func TestNewSuiteFromDirWithoutArgsIsUntouched(t *testing.T) {
+	suite, err := NewSuiteFromDir("../spec/testdata/sample-mixin")
+	require.NoError(t, err)
+	require.Len(t, suite.Artifact.Files, 1)
+
+	// Content nil with a live ContentSource is the streaming path: a kit that
+	// references no argument is loaded from its own directory, never from a
+	// staged copy that would have been materialized eagerly.
+	f := suite.Artifact.Files[0]
+	require.Nil(t, f.Content)
+	require.NotNil(t, f.ContentSource)
+
+	onDisk, err := os.ReadFile(filepath.Join(
+		"..", "spec", "testdata", "sample-mixin", "files", "home", filepath.FromSlash(f.RelativePath)))
+	require.NoError(t, err)
+	rc, err := f.Open()
+	require.NoError(t, err)
+	defer rc.Close()
+	streamed, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	require.Equal(t, onDisk, streamed)
+}
+
+func TestNewSuiteFromDirBrokenYAMLIsNotAnArgsError(t *testing.T) {
+	dir := writeKit(t, map[string]string{
+		"spec.yaml": "schemaVersion: \"2\"\nkind: mixin\n  name: bad-indent\n",
+	})
+
+	_, err := NewSuiteFromDir(dir)
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "args",
+		"a YAML syntax error belongs to the loader, not to argument resolution")
+	require.ErrorContains(t, err, "mapping values are not allowed in this context")
+}
+
+// TestSuiteArgsInstallExecution runs the fixture through the same path a real
+// kit takes, so the install commands reach `sh -c` with their arguments
+// already substituted — an unexpanded `${{ … }}` is a shell bad substitution
+// and exits non-zero.
+func TestSuiteArgsInstallExecution(t *testing.T) {
+	suite, err := NewSuiteFromDir("testdata/args-install")
+	require.NoError(t, err)
+	suite.RunAll(t)
+}
+
+// writeKit writes a throwaway kit directory from kit-relative slash paths.
+func writeKit(t *testing.T, files map[string]string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	for rel, content := range files {
+		path := filepath.Join(dir, filepath.FromSlash(rel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	}
+	return dir
+}

--- a/tck/args_unix_test.go
+++ b/tck/args_unix_test.go
@@ -1,0 +1,105 @@
+//go:build unix
+
+package tck
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// argsKitSpec is a minimal kit that substitutes one defaulted argument, so a
+// load either reaches the staging copy or fails visibly.
+const argsKitSpec = "schemaVersion: \"2\"\nkind: mixin\nname: staging-kit\n" +
+	"args:\n  v:\n    default: \"substituted\"\n" +
+	"environment:\n  variables:\n    V: \"${{ kit.args.v }}\"\n"
+
+func TestNewSuiteFromDirSkipsNonRegularFiles(t *testing.T) {
+	dir := writeKit(t, map[string]string{
+		"spec.yaml":                        argsKitSpec,
+		"files/home/.staging-kit/keep.txt": "kept\n",
+	})
+	require.NoError(t, syscall.Mkfifo(filepath.Join(dir, "pipe"), 0o600))
+
+	type result struct {
+		suite *Suite
+		err   error
+	}
+	done := make(chan result, 1)
+	go func() {
+		suite, err := NewSuiteFromDir(dir)
+		done <- result{suite, err}
+	}()
+
+	select {
+	case got := <-done:
+		require.NoError(t, got.err)
+		require.Equal(t, "substituted", got.suite.Artifact.Environment.Variables["V"])
+	case <-time.After(20 * time.Second):
+		t.Fatal("loading a kit that contains a fifo blocked; a non-regular file must never be opened")
+	}
+}
+
+func TestNewSuiteFromDirThroughASymlinkedRoot(t *testing.T) {
+	dir := writeKit(t, map[string]string{
+		"spec.yaml":                        argsKitSpec,
+		"files/home/.staging-kit/keep.txt": "kept\n",
+	})
+	link := filepath.Join(t.TempDir(), "kit-link")
+	require.NoError(t, os.Symlink(dir, link))
+
+	suite, err := NewSuiteFromDir(link)
+	require.NoError(t, err)
+	require.Equal(t, "substituted", suite.Artifact.Environment.Variables["V"])
+	require.Len(t, suite.Artifact.Files, 1, "the kit's files/ tree must survive the copy")
+}
+
+func TestNewSuiteFromDirWithASymlinkedSpecFile(t *testing.T) {
+	dir := writeKit(t, map[string]string{
+		"real/kit.yaml":                    argsKitSpec,
+		"files/home/.staging-kit/keep.txt": "kept\n",
+	})
+	require.NoError(t, os.Symlink(filepath.Join(dir, "real", "kit.yaml"), filepath.Join(dir, "spec.yaml")))
+
+	suite, err := NewSuiteFromDir(dir)
+	require.NoError(t, err)
+	require.Equal(t, "substituted", suite.Artifact.Environment.Variables["V"],
+		"the staged spec must carry the substituted bytes, not a link to unsubstituted ones")
+}
+
+func TestStagedDirectoryKeepsItsMode(t *testing.T) {
+	dir := writeKit(t, map[string]string{
+		"spec.yaml":                        argsKitSpec,
+		"files/home/.staging-kit/config":   "x\n",
+		"files/home/.staging-kit/sub/deep": "y\n",
+	})
+	guarded := filepath.Join(dir, "files", "home", ".staging-kit")
+	require.NoError(t, os.Chmod(filepath.Join(guarded, "sub"), 0o555))
+	require.NoError(t, os.Chmod(guarded, 0o555))
+	// t.TempDir's own cleanup cannot unlink out of a read-only directory.
+	t.Cleanup(func() {
+		_ = os.Chmod(guarded, 0o755)
+		_ = os.Chmod(filepath.Join(guarded, "sub"), 0o755)
+	})
+
+	staged, err := stageExpandedKit(dir, "spec.yaml", []byte("spec: replaced\n"), map[string]string{"v": "1"})
+	require.NoError(t, err)
+	require.NotEmpty(t, staged)
+	t.Cleanup(func() { removeStaging(staged) })
+
+	for _, rel := range []string{
+		filepath.Join("files", "home", ".staging-kit"),
+		filepath.Join("files", "home", ".staging-kit", "sub"),
+	} {
+		info, err := os.Stat(filepath.Join(staged, rel))
+		require.NoError(t, err)
+		require.Equalf(t, os.FileMode(0o555), info.Mode().Perm(), "staged mode of %s", rel)
+	}
+	deep, err := os.ReadFile(filepath.Join(staged, "files", "home", ".staging-kit", "sub", "deep"))
+	require.NoError(t, err, "a read-only directory must still have been populated")
+	require.Equal(t, "y\n", string(deep))
+}

--- a/tck/derive.go
+++ b/tck/derive.go
@@ -21,10 +21,15 @@ func WithImage(image string) Option {
 // NewSuiteFromDir loads a kit artifact from the given directory and derives
 // all test expectations from the spec.yaml and files/ directory.
 //
-// The artifact is loaded via spec.OpenFromDirectory (streaming path) so the
-// TCK exercises on-demand file reading via ArtifactFile.Open. File content is
-// still read into memory at the copy boundary inside RunContainerTests, but
-// only one file at a time.
+// A `${{ kit.args.<name> }}` reference in spec.yaml or under files/ is
+// substituted before the spec is decoded, taking its value from the `args:`
+// block of <dir>/testdata/tck.yaml or, failing that, from the argument's
+// declared default.
+//
+// A kit with nothing to substitute is loaded via spec.OpenFromDirectory
+// (streaming path), so the TCK exercises on-demand file reading via
+// ArtifactFile.Open. File content is still read into memory at the copy
+// boundary inside RunContainerTests, but only one file at a time.
 //
 // For kind=agent artifacts, the container image is taken from the manifest's template.
 // For kind=mixin artifacts, the image is resolved from extends or the declared
@@ -32,7 +37,7 @@ func WithImage(image string) Option {
 // defaults to the shell template.
 // Use WithImage to override the image for any artifact.
 func NewSuiteFromDir(dir string, opts ...Option) (*Suite, error) {
-	artifact, err := spec.OpenFromDirectory(dir)
+	artifact, err := openKitArtifact(dir)
 	if err != nil {
 		return nil, fmt.Errorf("load artifact from %q: %w", dir, err)
 	}

--- a/tck/e2e_test.go
+++ b/tck/e2e_test.go
@@ -89,7 +89,7 @@ func TestE2EKit(t *testing.T) {
 
 		checkHostCredentials(t, ctx, td)
 
-		name := createSbx(t, ctx, absKit, agent, td)
+		name := createSbx(t, ctx, absKit, suite.Artifact.Manifest.Name, agent, td)
 
 		// Verify kit content landed inside the running container. Files are
 		// re-derived here so `${WORKDIR}` resolves to the real sandbox workdir
@@ -263,8 +263,9 @@ func assertSbxAgentContext(t *testing.T, ctx context.Context, name string, a *sp
 
 // agentContextFilename returns the filename the engine writes a kit's
 // agentContext into.
-//   kind: sandbox → Manifest.AIFilename (inlined agentContext)
-//   kind: mixin   → "<kit-name>.md" under .../kits-agent-context/
+//
+//	kind: sandbox → Manifest.AIFilename (inlined agentContext)
+//	kind: mixin   → "<kit-name>.md" under .../kits-agent-context/
 func agentContextFilename(a *spec.Artifact) string {
 	if a.Manifest.Kind == spec.KindSandbox {
 		return a.Manifest.AIFilename
@@ -351,6 +352,13 @@ type kitTCKData struct {
 	// keeps needing the credential indefinitely, so the entry is permanent
 	// for as long as the kit declares this agent affinity.
 	RequiresHostCredentials []string `yaml:"requiresHostCredentials"`
+
+	// Args are the values to substitute for the arguments the kit declares,
+	// keyed by argument name. The TCK layer reads the same block, so both
+	// layers install the kit with the same values: here they are passed to
+	// `sbx create` as kit-argument flags. An argument absent from this block
+	// resolves to its declared default on both sides and needs no entry.
+	Args map[string]string `yaml:"args"`
 }
 
 // builtinCollisionMarker is the distinguishing text of the error sbx returns
@@ -440,7 +448,7 @@ const promptMessage = "what version are you running"
 // dir is used as the workspace.
 // td may be nil (no testdata/tck.yaml); see kitTCKData.ExtractedFromBuiltin for
 // the one failure this tolerates.
-func createSbx(t *testing.T, ctx context.Context, absKit, agent string, td *kitTCKData) string {
+func createSbx(t *testing.T, ctx context.Context, absKit, kitName, agent string, td *kitTCKData) string {
 	t.Helper()
 	workspace := t.TempDir()
 	name := sandboxName(t, absKit)
@@ -484,7 +492,12 @@ func createSbx(t *testing.T, ctx context.Context, absKit, agent string, td *kitT
 			t.Logf("cleanup `sbx rm -f %s` failed: %v\n%s", name, err, out)
 		}
 	})
-	createOut, err := runSbx(t, ctx, "create", "--kit", absKit, "--name", name, agent, workspace)
+	createArgs := []string{"create", "--kit", absKit, "--name", name}
+	if td != nil {
+		createArgs = append(createArgs, tck.KitArgFlags(kitName, td.Args)...)
+	}
+	createArgs = append(createArgs, agent, workspace)
+	createOut, err := runSbx(t, ctx, createArgs...)
 
 	if err != nil && strings.Contains(createOut, builtinCollisionMarker) {
 		if td != nil && td.ExtractedFromBuiltin {

--- a/tck/suite.go
+++ b/tck/suite.go
@@ -34,7 +34,7 @@ type Suite struct {
 	// Artifact is the loaded and validated kit artifact.
 	Artifact *spec.Artifact
 
-	// Dir is the kit directory the artifact was loaded from. Assertions that
+	// Dir is the kit directory the suite was built from. Assertions that
 	// need kit-supplied expectations (rather than ones derived from the spec)
 	// read them from <Dir>/testdata/. Empty when the suite was built from an
 	// already-loaded artifact rather than a directory.

--- a/tck/testdata/args-bad-value/spec.yaml
+++ b/tck/testdata/args-bad-value/spec.yaml
@@ -1,0 +1,13 @@
+schemaVersion: "2"
+kind: mixin
+name: args-bad-value
+description: "TCK fixture: a testdata/tck.yaml value that violates its argument's enum."
+
+args:
+  channel:
+    default: "stable"
+    enum: ["stable", "nightly"]
+
+environment:
+  variables:
+    ARGS_FIXTURE_CHANNEL: "${{ kit.args.channel }}"

--- a/tck/testdata/args-bad-value/testdata/tck.yaml
+++ b/tck/testdata/args-bad-value/testdata/tck.yaml
@@ -1,0 +1,2 @@
+args:
+  channel: "beta"

--- a/tck/testdata/args-block-literal/spec.yaml
+++ b/tck/testdata/args-block-literal/spec.yaml
@@ -1,0 +1,15 @@
+schemaVersion: "2"
+kind: mixin
+name: args-block-literal
+description: "TCK fixture: an args: block whose own text is reference-shaped and must reach the artifact untouched."
+
+args:
+  other:
+    default: "resolved"
+  literal:
+    default: "${{ kit.args.other }}"
+    description: "prose naming ${{ kit.args.nosuch }}, which no declaration answers for"
+
+environment:
+  variables:
+    ARGS_FIXTURE_LITERAL: "${{ kit.args.literal }}"

--- a/tck/testdata/args-install/files/home/.args-install/config.txt
+++ b/tck/testdata/args-install/files/home/.args-install/config.txt
@@ -1,0 +1,2 @@
+version=${{ kit.args.version }}
+literal=$${{ kit.args.version }}

--- a/tck/testdata/args-install/spec.yaml
+++ b/tck/testdata/args-install/spec.yaml
@@ -1,0 +1,35 @@
+schemaVersion: "2"
+kind: mixin
+name: args-install
+version: "1.0.0"
+displayName: Args Install Fixture
+description: "TCK fixture: arguments substituted into an install command, a files/ payload, and environment variables."
+
+args:
+  greeting:
+    default: "the declared default"
+    description: "Overridden by testdata/tck.yaml; the install command asserts the override won."
+  version:
+    default: "1.20"
+    description: "Number-shaped, and quoted wherever it is referenced."
+    pattern: '^[0-9]+\.[0-9]+$'
+  token:
+    required: true
+    description: "Has no default, so testdata/tck.yaml must supply it."
+
+environment:
+  variables:
+    ARGS_FIXTURE_VERSION: "${{ kit.args.version }}"
+    ARGS_FIXTURE_TOKEN: "${{ kit.args.token }}"
+
+setup:
+  install:
+    - command: 'test "${{ kit.args.greeting }}" = "supplied by tck.yaml"'
+      description: install command receives a substituted argument
+    - command: 'grep -qx "version=${{ kit.args.version }}" /home/agent/.args-install/config.txt'
+      description: files payload carries a substituted argument
+    # The expected text is assembled in the shell from ${dollar} so that this
+    # command carries no opener of its own: were it written with the escape it
+    # is checking, both sides would move together and assert nothing.
+    - command: 'dollar=$; grep -qxF "literal=${dollar}{{ kit.args.version }}" /home/agent/.args-install/config.txt'
+      description: an escaped opener stays literal in the files payload

--- a/tck/testdata/args-install/testdata/tck.yaml
+++ b/tck/testdata/args-install/testdata/tck.yaml
@@ -1,0 +1,3 @@
+args:
+  greeting: "supplied by tck.yaml"
+  token: "dummy-for-ci"

--- a/tck/testdata/args-required-missing/spec.yaml
+++ b/tck/testdata/args-required-missing/spec.yaml
@@ -1,0 +1,13 @@
+schemaVersion: "2"
+kind: mixin
+name: args-required-missing
+description: "TCK fixture: a required argument that no testdata/tck.yaml supplies, which must fail rather than skip."
+
+args:
+  token:
+    required: true
+    description: "Deliberately unsupplied — this kit ships no testdata/tck.yaml."
+
+environment:
+  variables:
+    ARGS_FIXTURE_TOKEN: "${{ kit.args.token }}"

--- a/tck/testdata/args-requires-agent/spec.yaml
+++ b/tck/testdata/args-requires-agent/spec.yaml
@@ -1,0 +1,13 @@
+schemaVersion: "2"
+kind: mixin
+name: args-requires-agent
+description: "TCK fixture: an argument substituted into requires.agent, a field the spec pattern-checks."
+
+args:
+  agent:
+    default: "codex"
+    enum: ["codex", "claude"]
+    description: "Base-agent affinity, so the container image follows the argument."
+
+requires:
+  agent: "${{ kit.args.agent }}"

--- a/tck/testdata/args-undeclared/spec.yaml
+++ b/tck/testdata/args-undeclared/spec.yaml
@@ -1,0 +1,8 @@
+schemaVersion: "2"
+kind: mixin
+name: args-undeclared
+description: "TCK fixture: a reference to an argument no args: block declares."
+
+environment:
+  variables:
+    ARGS_FIXTURE_TOKEN: "${{ kit.args.token }}"


### PR DESCRIPTION
Fixes #278.

SPEC-v2 §2.1 lets a kit reference `${{ kit.args.<name> }}` anywhere in `spec.yaml` and under `files/`, but nothing in this repo performs the substitution, so a kit declaring `args:` fails its own CI (`Bad substitution` in install commands; pattern-checked fields reject the placeholder). No kit in the repo uses the feature as a result.

This makes the TCK a conforming consumer:

- References are substituted before the spec is decoded — inside `spec.yaml` scalar values and in the raw bytes of regular files under `files/` — so validation, pattern-checked fields, file assertions, and install execution all see real values.
- Values come from a new `args:` map in `<kit>/testdata/tck.yaml`, falling back to declared defaults. A `required` argument with no test value fails with a fix-it message rather than skipping; resolved values are checked against `enum`/`pattern`.
- The `args:` block and mapping keys are never rewritten; a key naming an argument is an error, escaped or not; text that opens the `kit.args.` namespace but does not parse is an error; other `${{ … }}` namespaces pass through; `$${{` emits a literal `${{`.
- The e2e layer feeds the same `testdata/tck.yaml` values to `sbx create --kit-arg <kit>.<name>=<value>`, so both layers install identical values.
- A kit with nothing to substitute loads byte-identically through the existing streaming path — no change for the 45 existing kits.

`spec/` changes are minimal and deliberate: one additive export (`ValidArgName`) so the argument-name grammar has a single source, and new §2.1 bullets writing down the reference rules the harness enforces. **Please confirm the SPEC-v2.md bullets** — they document released behavior the spec was silent on.

Reviewer notes:

- The branch carries #275's commits (both touch `tck/e2e_test.go`); once #275 merges, this rebases down to its own five commits.
- Out of scope, found while testing: `scripts/verify-kit-spec` fails on a kit using an argument in a pattern-checked field, and `scripts/kit-meta.sh` / the publish workflows scrape spec fields textually, so they would emit a placeholder literally. Both matter only once a shipped kit adopts `args:`.
- Pre-existing doc nit, untouched: §2.1's "an unquoted `1.20` … fails to decode into a string" overstates — go-yaml coerces a float scalar into a string-typed field; quoting matters for non-string-typed fields (now covered by tests).
- `tck/e2e_test.go` includes a two-line gofmt normalization of a pre-existing comment; `gofmt -l .` is now clean repo-wide.

Testing: 45 leaf assertions plus 4 unix-guarded tests, each mutation-checked; six fixtures under `tck/testdata/args-*`; full `go test ./spec/... ./tck/... ./scripts/...`; TCK regression runs against `git-ssh-sign` and `aidlc-claude`.
