### PR TITLE
fix(spec): gate LoadFromBytes on schemaVersion for a deterministic v1 contract

### DIFF
--- a/spec/artifact.go
+++ b/spec/artifact.go
@@ -226,16 +226,10 @@ func LoadArtifactFromBytes(yamlBytes []byte) (*Artifact, error) {
 }
 
 // LoadFromBytes parses spec.yaml bytes into a normalized SpecFile using the v1
-// grammar only. Normalization (v1 sugar folding, legacy field removal) happens
-// inside this call.
-//
-// Unlike LoadArtifactFromBytes it does not fork on schemaVersion, so what happens
-// to a schemaVersion: "2" document depends on which keys it uses. Names the v1
-// grammar does not have (permissions, setup, agentInstructions) fail the strict
-// decode and return an error naming this limitation. Names v1 also has
-// (environment, credentials, sandbox) decode under the v1 shape instead, as does
-// a document carrying none of them — so a v2 spec can appear to load here. Treat
-// neither outcome as a contract: this entry point is not version-aware.
+// grammar. schemaVersion must be "1" or omitted; any other declared value is
+// rejected before the v1 decode runs, naming the version and pointing to
+// LoadArtifactFromBytes. A malformed document is not rejected here — it falls
+// through to the v1 decoder so its actual syntax error surfaces.
 //
 // For v2 (or version-agnostic) input, load the artifact and project it back to
 // the v2 grammar instead:
@@ -249,6 +243,9 @@ func LoadArtifactFromBytes(yamlBytes []byte) (*Artifact, error) {
 // Deprecated: LoadFromBytes only understands the frozen v1 grammar. Use
 // LoadArtifactFromBytes with NewV2View.
 func LoadFromBytes(yamlBytes []byte) (*SpecFile, error) {
+	if version, err := peekSchemaVersion(yamlBytes); err == nil && version != "" && version != "1" {
+		return nil, fmt.Errorf("spec: %s declares schemaVersion %q, which LoadFromBytes does not accept — it understands schemaVersion \"1\" (or omitted) only; use LoadArtifactFromBytes (then NewV2View for the v2 grammar shape)", specFileName, version)
+	}
 	return parseSpecFileBytes(yamlBytes)
 }
 
@@ -333,17 +330,11 @@ func decodeSpecFile(data []byte) (SpecFile, error) {
 }
 
 // parseSpecFileBytes decodes spec.yaml bytes with the frozen v1 grammar and
-// normalizes them. There is deliberately no schemaVersion fork here — SpecFile
-// is the v1 shape — but a v2 document failing strict decoding produces a raw
-// unknown-field error naming an internal Go type, which tells the author
-// nothing. Detect that case and say what actually happened, keeping the
-// underlying error wrapped.
+// normalizes them. Callers gate on schemaVersion before reaching this
+// function, so it only performs the decode itself.
 func parseSpecFileBytes(data []byte) (*SpecFile, error) {
 	spec, err := decodeSpecFile(data)
 	if err != nil {
-		if peekSchemaVersion(data) == "2" {
-			return nil, fmt.Errorf("spec: %s declares schemaVersion \"2\", which this loader does not decode — it understands the v1 grammar only; use LoadArtifactFromBytes (then NewV2View for the v2 grammar shape): %w", specFileName, err)
-		}
 		return nil, fmt.Errorf("spec: invalid %s: %w", specFileName, err)
 	}
 	w := &warnings{}
@@ -354,16 +345,14 @@ func parseSpecFileBytes(data []byte) (*SpecFile, error) {
 	return &spec, nil
 }
 
-// peekSchemaVersion does a cheap, non-strict decode of just the
-// schemaVersion field so the loader can fork on it before committing to a
-// version-specific grammar. A malformed document returns "" (routed to the
-// v1 decoder, which surfaces the real parse error).
-func peekSchemaVersion(data []byte) string {
+// peekSchemaVersion decodes just the schemaVersion field. The returned error
+// is non-nil only for a malformed document; omitted schemaVersion returns ("", nil).
+func peekSchemaVersion(data []byte) (string, error) {
 	var probe struct {
 		SchemaVersion string `yaml:"schemaVersion"`
 	}
-	_ = yaml.Unmarshal(data, &probe)
-	return probe.SchemaVersion
+	err := yaml.Unmarshal(data, &probe)
+	return probe.SchemaVersion, err
 }
 
 // parseArtifactBytes decodes spec.yaml bytes and applies normalization.
@@ -377,7 +366,7 @@ func peekSchemaVersion(data []byte) string {
 // produce the same canonical Artifact and preserve Manifest.SchemaVersion —
 // the signal the credential-binding regime keys on.
 func parseArtifactBytes(data []byte) (*Artifact, error) {
-	if peekSchemaVersion(data) == "2" {
+	if version, _ := peekSchemaVersion(data); version == "2" {
 		return parseArtifactV2(data)
 	}
 	spec, err := decodeSpecFile(data)

--- a/spec/normalize_test.go
+++ b/spec/normalize_test.go
@@ -375,10 +375,67 @@ displayName: Normalize Kit
 		require.Equal(t, fromBytes.Manifest.Kind, sf.Kind)
 	})
 
-	// LoadFromBytes decodes the v1 grammar only. A v2 spec must fail with an
-	// error that says so and names the API that does handle v2, rather than a
-	// raw unknown-field error about an internal Go type.
-	t.Run("v2_input_is_actionable_error", func(t *testing.T) {
+	t.Run("omitted_schema_version_accepted", func(t *testing.T) {
+		in := []byte(`kind: mixin
+name: normalize-kit
+`)
+		sf, err := LoadFromBytes(in)
+		require.NoError(t, err)
+		require.Equal(t, "normalize-kit", sf.Name)
+	})
+
+	// Previously accepted here under the v1 shape; the gate now rejects on
+	// schemaVersion alone.
+	t.Run("v2_alone_is_rejected", func(t *testing.T) {
+		in := []byte(`schemaVersion: "2"
+kind: mixin
+name: v2-alone
+`)
+		sf, err := LoadFromBytes(in)
+		require.Nil(t, sf)
+		require.Error(t, err)
+		require.ErrorContains(t, err, `schemaVersion "2"`)
+		require.ErrorContains(t, err, "LoadFromBytes does not accept")
+		require.ErrorContains(t, err, "LoadArtifactFromBytes")
+	})
+
+	// environment has a v1 field home too, so this also used to load cleanly
+	// under the v1 shape despite declaring schemaVersion "2".
+	t.Run("v2_with_v1_shaped_keys_is_rejected", func(t *testing.T) {
+		in := []byte(`schemaVersion: "2"
+kind: mixin
+name: v2-env
+environment:
+  variables:
+    FOO: "bar"
+`)
+		_, err := LoadArtifactFromBytes(in)
+		require.NoError(t, err)
+
+		sf, err := LoadFromBytes(in)
+		require.Nil(t, sf)
+		require.Error(t, err)
+		require.ErrorContains(t, err, `schemaVersion "2"`)
+		require.ErrorContains(t, err, "LoadFromBytes does not accept")
+		require.ErrorContains(t, err, "LoadArtifactFromBytes")
+	})
+
+	t.Run("garbage_schema_version_is_rejected", func(t *testing.T) {
+		in := []byte(`schemaVersion: "3"
+kind: mixin
+name: v3-garbage
+`)
+		sf, err := LoadFromBytes(in)
+		require.Nil(t, sf)
+		require.Error(t, err)
+		require.ErrorContains(t, err, `schemaVersion "3"`)
+		require.ErrorContains(t, err, "LoadFromBytes does not accept")
+		require.ErrorContains(t, err, "LoadArtifactFromBytes")
+	})
+
+	// A v2-only field would fail the strict v1 decode too; the gate must
+	// still win so the error names the version, not a raw unknown-field.
+	t.Run("v2_input_with_v2_only_fields_is_actionable_error", func(t *testing.T) {
 		in := []byte(`schemaVersion: "2"
 kind: mixin
 name: cloudflare-dns
@@ -395,10 +452,18 @@ permissions:
 		require.Nil(t, sf)
 		require.Error(t, err)
 		require.ErrorContains(t, err, `schemaVersion "2"`)
-		require.ErrorContains(t, err, "v1 grammar only")
+		require.ErrorContains(t, err, "LoadFromBytes does not accept")
 		require.ErrorContains(t, err, "LoadArtifactFromBytes")
-		require.ErrorContains(t, err, "NewV2View")
-		// The underlying decode error is still wrapped, not swallowed.
-		require.ErrorContains(t, err, "field permissions not found")
+	})
+
+	// A parse failure must surface the v1 decoder's syntax error, not a
+	// schemaVersion complaint.
+	t.Run("malformed_yaml_surfaces_decoder_syntax_error", func(t *testing.T) {
+		in := []byte("schemaVersion: \"1\"\nkind: mixin\n\tname: broken\n")
+		sf, err := LoadFromBytes(in)
+		require.Nil(t, sf)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "found a tab character")
+		require.NotContains(t, err.Error(), "LoadFromBytes does not accept")
 	})
 }


### PR DESCRIPTION
## Summary

Follow-up from the #178 review ([@ilopezluna's proposal](https://github.com/docker/sbx-kits-contrib/pull/178#pullrequestreview-4895200359)): `LoadFromBytes` accepted or rejected a v2 document depending on which keys it used. It now gates on `schemaVersion` before the v1 decode — `"1"` and omitted accepted, anything else rejected with a pointer to `LoadArtifactFromBytes`. A malformed document still falls through to the v1 decoder so its real syntax error surfaces.

Tests cover the full acceptance table and are mutation-checked; no callers outside the `spec` package exist.

@ilopezluna: keep or drop the `Deprecated:` marker? Kept as-is here — your call per #178.

Authored by Claude (Sonnet 5) on behalf of @mdelapenya.
