### PR TITLE
feat(spec): reject malformed apiKey credentials at validate time

### DIFF
--- a/amp/spec.yaml
+++ b/amp/spec.yaml
@@ -24,7 +24,7 @@ permissions:
 credentials:
   - service: amp
     apiKey:
-      name: ""
+      name: AMP_API_KEY
       inject:
         - domain: ampcode.com
           header: Authorization

--- a/skills/kit-author/topics/lifecycle.md
+++ b/skills/kit-author/topics/lifecycle.md
@@ -58,7 +58,7 @@ After normalization, only the canonical fields are populated. The legacy fields 
 `spec.ValidateArtifact` runs from each `Load*` path:
 
 - **Manifest** — `schemaVersion ∈ {"1", "2"}`, `kind ∈ {sandbox, mixin}` (also accepts v1 `agent` alias), `name` is lowercase alphanumeric + hyphen (1–64 chars), exactly one of `sandbox.image` / `sandbox.build` required for sandbox kits, `resources.cpu` must be a non-negative number and `resources.memory` (v2) a valid byte-size string if set.
-- **permissions.network** — entry strings are exact host, exact host+port, or leading-label wildcard (`*.example.com`). Overlap between `allow` and `deny` is **legal** — at request time, deny wins.
+- **permissions.network** — entry strings are an exact host (any port), an exact host with a numeric port, a single-label wildcard (`*.example.com`), a multi-label wildcard (`**.example.com`), or a port wildcard (`host:*`); a port range (`host:80-443`) is declared but never matches a request. Overlap between `allow` and `deny` is **legal** — at request time, deny wins.
 - **Credentials** — each entry has `service` set; `apiKey.inject[].format` (when set) is well-formed; a v2 `apiKey.inject[].scheme` is mutually exclusive with `format` and expands to it; `oauth.tokenEndpoint` has host+path.
 - **Volumes** — every entry has an absolute `path`; `type ∈ {"", "tmpfs"}`; `size` if set must parse as a byte-size string; `mode` if set must be octal.
 - **PublishedPorts** — `container` in 1..65535; `protocol ∈ {"", "tcp", "udp"}`.

--- a/skills/kit-author/topics/pitfalls.md
+++ b/skills/kit-author/topics/pitfalls.md
@@ -146,7 +146,7 @@ The CLI catches this up front: a kit whose `setup.files[i].path` resolves at or 
 
 `*.example.com` matches **exactly one** DNS label — `api.example.com` ✓, `cdn.example.com` ✓; `example.com` ✗ (zero labels), `a.b.example.com` ✗ (two labels).
 
-`**.example.com` (matches one or more labels, crossing dots) is **P3 — deferred**, pending sbx support. Until it ships, multi-label wildcards aren't usable.
+`**.example.com` matches one or more labels, crossing dots, and is enforced.
 
 Middle-position wildcards like `bedrock-runtime.*.amazonaws.com` aren't part of the spec at all. List the regions explicitly until the spec adds an entry format for them.
 

--- a/skills/kit-author/topics/spec-anatomy.md
+++ b/skills/kit-author/topics/spec-anatomy.md
@@ -258,7 +258,9 @@ credentials:
 
 `bearer` supplies `header: Authorization` only when you left `header` empty, so writing an explicit `header:` alongside it still wins. `basic` is username-driven at the proxy rather than a header encoding, so it sets no `header` at all — write one yourself if the service needs a specific one.
 
-**Enforcement:** every `apiKey.inject[].domain` MUST appear in `permissions.network.allow`. There is no auto-derived egress from credentials. The spec validator does not cross-check the two lists; the engine enforces the rule, and a missing domain surfaces at load or sandbox-create time (SPEC-v2 §6).
+**Enforcement:** every `apiKey.inject[].domain` MUST appear in `permissions.network.allow`. There is no auto-derived egress from credentials. `sbx kit validate` warns (but does not fail) when it detects an uncovered domain; the engine performs the authoritative enforcement, and a missing domain surfaces at load or sandbox-create time (SPEC-v2 §6).
+
+An inject entry MUST also set at least one of `header` or `username` — one with neither has nothing for the proxy to inject and fails `sbx kit validate`.
 
 ### OAuth shape
 

--- a/skills/kit-author/topics/spec-anatomy.md
+++ b/skills/kit-author/topics/spec-anatomy.md
@@ -260,7 +260,7 @@ credentials:
 
 **Enforcement:** every `apiKey.inject[].domain` MUST appear in `permissions.network.allow`. There is no auto-derived egress from credentials. `sbx kit validate` warns (but does not fail) when it detects an uncovered domain; the engine performs the authoritative enforcement, and a missing domain surfaces at load or sandbox-create time (SPEC-v2 §6).
 
-An inject entry MUST also set at least one of `header` or `username` — one with neither has nothing for the proxy to inject and fails `sbx kit validate`.
+An inject entry MUST also set at least one of `header` or `username` — one with neither has nothing for the proxy to inject and fails `sbx kit validate`. `username` MUST NOT contain `:` — HTTP Basic (RFC 7617) treats the first colon as the user/password delimiter, so a colon-bearing username can't authenticate as declared; `sbx kit validate` rejects it.
 
 ### OAuth shape
 

--- a/skills/kit-author/topics/spec-anatomy.md
+++ b/skills/kit-author/topics/spec-anatomy.md
@@ -319,7 +319,7 @@ Entry formats:
 
 | Pattern | Example | Matches | Status |
 |---|---|---|---|
-| `<domain>` | `api.example.com` | Exact host, default port 443 | **P2 — implemented** |
+| `<domain>` | `api.example.com` | Exact host, no port — matches any port | **P2 — implemented** |
 | `<domain>:<port>` | `api.example.com:8080` | Exact host, specific port | **P2 — implemented** |
 | `*.<domain>` | `*.example.com` | Exactly one DNS label (e.g. `api.example.com`, `cdn.example.com`). Does **not** match `example.com` itself or `a.b.example.com`. | **P2 — implemented** |
 | `**.<domain>` | `**.example.com` | One or more DNS labels (e.g. `api.example.com`, `a.b.example.com`). | **Enforced** |

--- a/skills/kit-author/topics/spec-anatomy.md
+++ b/skills/kit-author/topics/spec-anatomy.md
@@ -260,7 +260,9 @@ credentials:
 
 **Enforcement:** every `apiKey.inject[].domain` MUST appear in `permissions.network.allow`. There is no auto-derived egress from credentials. `sbx kit validate` warns (but does not fail) when it detects an uncovered domain; the engine performs the authoritative enforcement, and a missing domain surfaces at load or sandbox-create time (SPEC-v2 §6).
 
-An inject entry MUST also set at least one of `header` or `username` — one with neither has nothing for the proxy to inject and fails `sbx kit validate`. `username` MUST NOT contain `:` — HTTP Basic (RFC 7617) treats the first colon as the user/password delimiter, so a colon-bearing username can't authenticate as declared; `sbx kit validate` rejects it.
+An inject entry MUST also set at least one of `header` or `username` — one with neither has nothing for the proxy to inject and fails `sbx kit validate`. A `header`-bearing entry with no `username` MUST also set `format`, or there is no template to substitute the credential into. `username` MUST NOT contain `:` — HTTP Basic (RFC 7617) treats the first colon as the user/password delimiter, so a colon-bearing username can't authenticate as declared; `sbx kit validate` rejects it.
+
+`apiKey.name` is REQUIRED on a v2 spec, and whenever it's set (v1 or v2) it MUST be a valid shell identifier — letters, digits, underscores, not starting with a digit — since the engine uses it as an environment-variable name.
 
 ### OAuth shape
 

--- a/skills/kit-author/topics/spec-anatomy.md
+++ b/skills/kit-author/topics/spec-anatomy.md
@@ -322,9 +322,9 @@ Entry formats:
 | `<domain>` | `api.example.com` | Exact host, default port 443 | **P2 — implemented** |
 | `<domain>:<port>` | `api.example.com:8080` | Exact host, specific port | **P2 — implemented** |
 | `*.<domain>` | `*.example.com` | Exactly one DNS label (e.g. `api.example.com`, `cdn.example.com`). Does **not** match `example.com` itself or `a.b.example.com`. | **P2 — implemented** |
-| `**.<domain>` | `**.example.com` | One or more DNS labels (e.g. `api.example.com`, `a.b.example.com`). | **P3 — pending** |
-| `<domain>:<lo>-<hi>` | `api.example.com:80-443` | Port range | **P3 — pending** |
-| `<domain>:*` | `api.example.com:*` | Port wildcard | **P3 — pending** |
+| `**.<domain>` | `**.example.com` | One or more DNS labels (e.g. `api.example.com`, `a.b.example.com`). | **Enforced** |
+| `<domain>:<lo>-<hi>` | `api.example.com:80-443` | Port range | **P3 — pending**; never matches a request |
+| `<domain>:*` | `api.example.com:*` | Port wildcard | **Enforced** — identical to omitting the port |
 | CIDR | `10.0.0.0/8` | IP block | **P3 — pending** |
 
 **Deny precedence.** When the same host matches both `allow` and `deny`, **deny wins** — the request is rejected. Overlap is legal (and intentional: a parent kit can allow `*.example.com` while a child or mixin denies `telemetry.example.com`).

--- a/spec/SPEC-v2.md
+++ b/spec/SPEC-v2.md
@@ -627,7 +627,7 @@ credentials:
 | `inject[].domain` | string | REQUIRED. MUST appear in `permissions.network.allow`. |
 | `inject[].header` | string | The HTTP header to set. |
 | `inject[].format` | string | Header value format; MUST contain exactly one `%s`. Mutually exclusive with `scheme`. |
-| `inject[].username` | string | HTTP Basic username (proxy uses it as the username, the credential as the password). |
+| `inject[].username` | string | HTTP Basic username (proxy uses it as the username, the credential as the password). MUST NOT contain `:` — HTTP Basic (RFC 7617) treats the first colon as the user/password delimiter. |
 | `inject[].scheme` | string | Decode-time sugar (see below). Mutually exclusive with `format`. Always empty on the normalized artifact. |
 
 An inject entry MUST set at least one of `header` or `username`; one with
@@ -832,7 +832,8 @@ the per-field rules above:
   with no name, so that shape stays accepted on the `schemaVersion "1"` path;
   each `inject[].domain` non-empty; `inject[].format`, when set, contains
   exactly one `%s`; each inject entry sets at least one of `header` or
-  `username` (one with neither injects nothing). Separately, `ValidateArtifact`
+  `username` (one with neither injects nothing); `username`, when set, does
+  not contain `:` (HTTP Basic's user/password delimiter). Separately, `ValidateArtifact`
   emits a non-fatal warning — it does not reject the kit — when an inject
   domain is absent from `permissions.network.allow`; the engine still
   performs the authoritative enforcement at load or sandbox-create time.

--- a/spec/SPEC-v2.md
+++ b/spec/SPEC-v2.md
@@ -549,7 +549,7 @@ Entry formats:
 
 | Pattern | Example | Status |
 |---|---|---|
-| exact host | `api.example.com` (default port 443) | **Enforced** |
+| exact host | `api.example.com` (no port — matches any port) | **Enforced** |
 | exact host + port | `api.example.com:8080` | **Enforced** |
 | single-label wildcard | `*.example.com` (exactly one label; not `example.com`, not `a.b.example.com`) | **Enforced** |
 | multi-label wildcard | `**.example.com` | **Enforced** — matches one or more labels |

--- a/spec/SPEC-v2.md
+++ b/spec/SPEC-v2.md
@@ -68,7 +68,7 @@ a load-time warning where noted:
 | `sandbox.build` | Accepted; the runtime does **not** build images this release. A kit using `build:` **MUST** also set `sandbox.image`. |
 | `mixins:` | Accepted; mixin composition is **not** applied by the runtime this release. |
 | `sandbox.resources` | Accepted; enforcement is best-effort / pending. |
-| `permissions.network` extended patterns | `**.` wildcards, CIDR, and port ranges are declared but **not** enforced this release (see [§5.2](#52-permissionsnetwork)). |
+| `permissions.network` extended patterns | CIDR and port ranges are declared but **not** enforced this release; `**.` wildcards and `:*` port wildcards are enforced (see [§5.2](#52-permissionsnetwork)). |
 
 ---
 
@@ -552,9 +552,9 @@ Entry formats:
 | exact host | `api.example.com` (default port 443) | **Enforced** |
 | exact host + port | `api.example.com:8080` | **Enforced** |
 | single-label wildcard | `*.example.com` (exactly one label; not `example.com`, not `a.b.example.com`) | **Enforced** |
-| multi-label wildcard | `**.example.com` | Declared; **not enforced** this release |
-| port range | `api.example.com:80-443` | Declared; **not enforced** this release |
-| port wildcard | `api.example.com:*` | Declared; **not enforced** this release |
+| multi-label wildcard | `**.example.com` | **Enforced** — matches one or more labels |
+| port range | `api.example.com:80-443` | Declared; **not enforced** this release — never matches a request |
+| port wildcard | `api.example.com:*` | **Enforced** — identical to omitting the port |
 | CIDR | `10.0.0.0/8` | Declared; **not enforced** this release |
 
 Rules:

--- a/spec/SPEC-v2.md
+++ b/spec/SPEC-v2.md
@@ -630,6 +630,9 @@ credentials:
 | `inject[].username` | string | HTTP Basic username (proxy uses it as the username, the credential as the password). |
 | `inject[].scheme` | string | Decode-time sugar (see below). Mutually exclusive with `format`. Always empty on the normalized artifact. |
 
+An inject entry MUST set at least one of `header` or `username`; one with
+neither has nothing for the proxy to inject and is invalid.
+
 **`scheme` sugar:**
 
 | `scheme` | Expands to | Constraints |
@@ -823,6 +826,16 @@ the per-field rules above:
   derives service keys from env-var names and keeps underscores
   (`SAMPLE_PROXY_TOKEN` → `sample_proxy`), so enforcing it would reject v1
   kits that load today.
+- **credentials[].apiKey** (when present): `name` non-empty on a
+  `schemaVersion "2"` spec — the v1 `network.serviceDomains` +
+  `network.serviceAuth` fold can legitimately produce a header-only inject
+  with no name, so that shape stays accepted on the `schemaVersion "1"` path;
+  each `inject[].domain` non-empty; `inject[].format`, when set, contains
+  exactly one `%s`; each inject entry sets at least one of `header` or
+  `username` (one with neither injects nothing). Separately, `ValidateArtifact`
+  emits a non-fatal warning — it does not reject the kit — when an inject
+  domain is absent from `permissions.network.allow`; the engine still
+  performs the authoritative enforcement at load or sandbox-create time.
 - **credentials[].oauth** (when present): `tokenEndpoint.host` and
   `tokenEndpoint.path` non-empty; `sentinels.accessToken` and
   `sentinels.refreshToken` non-empty **unless** `passthrough: true`;
@@ -845,9 +858,12 @@ the per-field rules above:
 - **files/**: target `home` or `workspace`; relative, non-escaping paths.
 
 Rules stated as **MUST** in this document that are enforced by the engine rather
-than by `ValidateArtifact` (e.g. inject-domain ⊆ `permissions.network.allow`,
-reserved env prefixes, `sandbox.build` requiring `image`) surface at load or
-sandbox-create time.
+than by `ValidateArtifact` (e.g. reserved env prefixes, `sandbox.build`
+requiring `image`) surface at load or sandbox-create time. inject-domain ⊆
+`permissions.network.allow` is the partial exception: `ValidateArtifact` warns
+when it detects an uncovered domain, but the engine still performs the
+authoritative enforcement at load or sandbox-create time — the warning does
+not reject the kit.
 
 Validation **never** errors on legacy v1 fields — that is the normalize layer's
 job, and it only runs on the `schemaVersion: "1"` path.

--- a/spec/SPEC-v2.md
+++ b/spec/SPEC-v2.md
@@ -622,7 +622,7 @@ credentials:
 
 | Field | Type | Rules |
 |---|---|---|
-| `name` | string | REQUIRED. Env-var name. The engine sets it to the literal `proxy-managed` sentinel in-container when the credential is wired. |
+| `name` | string | REQUIRED. Env-var name — MUST be a valid shell identifier when set, on both v1 and v2 specs. The engine sets it to the literal `proxy-managed` sentinel in-container when the credential is wired. |
 | `proxyManaged` | bool | When `true`, the sentinel is set in-container (re-expresses the removed v1 `environment.proxyManaged`). |
 | `inject[].domain` | string | REQUIRED. MUST appear in `permissions.network.allow`. |
 | `inject[].header` | string | The HTTP header to set. |
@@ -631,7 +631,9 @@ credentials:
 | `inject[].scheme` | string | Decode-time sugar (see below). Mutually exclusive with `format`. Always empty on the normalized artifact. |
 
 An inject entry MUST set at least one of `header` or `username`; one with
-neither has nothing for the proxy to inject and is invalid.
+neither has nothing for the proxy to inject and is invalid. A `header`-bearing
+entry with no `username` MUST also set `format` — without one there is no
+template to substitute the credential into.
 
 **`scheme` sugar:**
 
@@ -830,9 +832,13 @@ the per-field rules above:
   `schemaVersion "2"` spec — the v1 `network.serviceDomains` +
   `network.serviceAuth` fold can legitimately produce a header-only inject
   with no name, so that shape stays accepted on the `schemaVersion "1"` path;
+  whenever `name` is non-empty (v1 or v2) it MUST be a valid shell identifier —
+  only the non-empty requirement is v2-gated, the shape requirement is not;
   each `inject[].domain` non-empty; `inject[].format`, when set, contains
   exactly one `%s`; each inject entry sets at least one of `header` or
-  `username` (one with neither injects nothing); `username`, when set, does
+  `username` (one with neither injects nothing), and a `header`-bearing entry
+  with no `username` also requires `format` (otherwise there is no template to
+  substitute the credential into); `username`, when set, does
   not contain `:` (HTTP Basic's user/password delimiter). Separately, `ValidateArtifact`
   emits a non-fatal warning — it does not reject the kit — when an inject
   domain is absent from `permissions.network.allow`; the engine still

--- a/spec/artifact_test.go
+++ b/spec/artifact_test.go
@@ -80,7 +80,7 @@ func TestLoadFromDirectory(t *testing.T) {
 		// Egress under caps.network (not the removed network block).
 		require.NotNil(t, a.Caps)
 		require.NotNil(t, a.Caps.Network)
-		require.ElementsMatch(t, []string{"api.anthropic.com", "api.openai.com:443", "*.example.com"}, a.Caps.Network.Allow)
+		require.ElementsMatch(t, []string{"api.anthropic.com", "api.openai.com:443", "api.github.com", "github.com", "*.example.com"}, a.Caps.Network.Allow)
 		require.ElementsMatch(t, []string{"telemetry.example.com"}, a.Caps.Network.Deny)
 
 		// Unified credentials[].

--- a/spec/testdata/sample-agent-v2/spec.yaml
+++ b/spec/testdata/sample-agent-v2/spec.yaml
@@ -34,6 +34,8 @@ permissions:
     allow:
       - api.anthropic.com
       - api.openai.com:443
+      - api.github.com
+      - github.com
       - "*.example.com"
     deny:
       - telemetry.example.com

--- a/spec/types.go
+++ b/spec/types.go
@@ -460,8 +460,8 @@ type Caps struct {
 //   - exact:port:            api.example.com:443
 //   - single-label wildcard: *.example.com
 //
-// P3 entry formats (deferred): double wildcards (**.example.com), CIDR
-// (10.0.0.0/8), port ranges (api.example.com:8000-9000).
+// P3-labeled but enforced: double wildcards (**.example.com), port wildcard
+// (host:*). Still not enforced: CIDR (10.0.0.0/8), port ranges (host:8000-9000).
 type CapsNetwork struct {
 	Allow []string `json:"allow,omitempty" yaml:"allow,omitempty"`
 	Deny  []string `json:"deny,omitempty" yaml:"deny,omitempty"`

--- a/spec/types.go
+++ b/spec/types.go
@@ -735,9 +735,8 @@ type Artifact struct {
 	// warning.
 	AgentContext string `json:"agentContext,omitempty"`
 
-	// Warnings is the list of non-fatal validation issues collected during
-	// load (typically v1 → v2 deprecation warnings). Empty slice when the
-	// spec uses only canonical v2 fields.
+	// Warnings lists non-fatal issues from load and validation — v1 → v2
+	// deprecations plus validator findings (e.g. an uncovered credential domain).
 	Warnings []string `json:"warnings,omitempty"`
 }
 

--- a/spec/validate.go
+++ b/spec/validate.go
@@ -550,6 +550,9 @@ func ValidateApiKey(a *ApiKey, schemaVersion string) error {
 		if inj.Header == "" && inj.Username == "" {
 			return fmt.Errorf("apiKey: inject[%d] sets neither header nor username, so it injects nothing", j)
 		}
+		if strings.Contains(inj.Username, ":") {
+			return fmt.Errorf("apiKey: inject[%d].username must not contain \":\" (HTTP Basic treats the first colon as the user/password delimiter)", j)
+		}
 	}
 	return nil
 }

--- a/spec/validate.go
+++ b/spec/validate.go
@@ -310,12 +310,6 @@ func ValidateArtifact(a *Artifact) error {
 	if err := ValidatePublishedPorts(a.PublishedPorts); err != nil {
 		return err
 	}
-	if err := ValidateEnvironmentPolicy(a.Environment); err != nil {
-		return err
-	}
-	if err := ValidateCommandsPolicy(a.Commands); err != nil {
-		return err
-	}
 	var allowedDomains []string
 	if a.Caps != nil && a.Caps.Network != nil {
 		allowedDomains = a.Caps.Network.Allow
@@ -331,6 +325,9 @@ func ValidateArtifact(a *Artifact) error {
 	}
 	a.Warnings = retained
 
+	// Credentials validate before Environment: a v2 apiKey.proxyManaged: true
+	// copies its name into Environment.ProxyManaged, so an author must see a
+	// malformed name as "apiKey: name ...", not "environment: proxyManaged ...".
 	for i, c := range a.Credentials {
 		// SPEC-v2 §5.4 makes service REQUIRED on every credential entry: it is
 		// the identity the user-side bindings file matches on. For OAuth it
@@ -362,6 +359,13 @@ func ValidateArtifact(a *Artifact) error {
 				}
 			}
 		}
+	}
+
+	if err := ValidateEnvironmentPolicy(a.Environment); err != nil {
+		return err
+	}
+	if err := ValidateCommandsPolicy(a.Commands); err != nil {
+		return err
 	}
 
 	for i, f := range a.Files {
@@ -563,6 +567,9 @@ func ValidateApiKey(a *ApiKey, schemaVersion string) error {
 		}
 		if inj.Header == "" && inj.Username == "" {
 			return fmt.Errorf("apiKey: inject[%d] sets neither header nor username, so it injects nothing", j)
+		}
+		if inj.Header != "" && inj.Username == "" && inj.Format == "" {
+			return fmt.Errorf("apiKey: inject[%d] sets header but no format, so it injects nothing", j)
 		}
 		if strings.Contains(inj.Username, ":") {
 			return fmt.Errorf("apiKey: inject[%d].username must not contain \":\" (HTTP Basic treats the first colon as the user/password delimiter)", j)

--- a/spec/validate.go
+++ b/spec/validate.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/docker/go-units"
@@ -557,11 +558,14 @@ func ValidateApiKey(a *ApiKey, schemaVersion string) error {
 	return nil
 }
 
-// allowListCovers matches domain against the exact, host:port, *., and **.
-// forms permissions.network.allow documents — no other pattern semantics.
+// allowListCovers mirrors sbx's runtime enforcement: a port range or other
+// non-numeric, non-"*" port never matches, so it doesn't count as coverage.
 func allowListCovers(domain string, allow []string) bool {
 	for _, entry := range allow {
-		host, _, _ := strings.Cut(entry, ":")
+		host, port, hasPort := strings.Cut(entry, ":")
+		if hasPort && port != "*" && !isNumericPort(port) {
+			continue
+		}
 		if host == domain {
 			return true
 		}
@@ -575,6 +579,12 @@ func allowListCovers(domain string, allow []string) bool {
 		}
 	}
 	return false
+}
+
+// isNumericPort reports whether s is a valid 0-65535 decimal port.
+func isNumericPort(s string) bool {
+	_, err := strconv.ParseUint(s, 10, 16)
+	return err == nil
 }
 
 // ValidateOAuthPolicy validates the oauth policy if present.

--- a/spec/validate.go
+++ b/spec/validate.go
@@ -315,6 +315,11 @@ func ValidateArtifact(a *Artifact) error {
 	if err := ValidateCommandsPolicy(a.Commands); err != nil {
 		return err
 	}
+	var allowedDomains []string
+	if a.Caps != nil && a.Caps.Network != nil {
+		allowedDomains = a.Caps.Network.Allow
+	}
+
 	for i, c := range a.Credentials {
 		// SPEC-v2 §5.4 makes service REQUIRED on every credential entry: it is
 		// the identity the user-side bindings file matches on. For OAuth it
@@ -331,8 +336,20 @@ func ValidateArtifact(a *Artifact) error {
 		if c.Service == "" {
 			return fmt.Errorf("artifact: credentials[%d]: service is required", i)
 		}
+		if err := ValidateApiKey(c.ApiKey, a.Manifest.SchemaVersion); err != nil {
+			return fmt.Errorf("artifact: credentials[%d] (service %q): %w", i, c.Service, err)
+		}
 		if err := ValidateOAuth(c.OAuth); err != nil {
 			return fmt.Errorf("artifact: credentials[%d] (service %q): %w", i, c.Service, err)
+		}
+		if c.ApiKey != nil {
+			for j, inj := range c.ApiKey.Inject {
+				if inj.Domain != "" && !allowListCovers(inj.Domain, allowedDomains) {
+					a.Warnings = append(a.Warnings, fmt.Sprintf(
+						"credentials[%d] (service %q): apiKey.inject[%d].domain %q is not covered by permissions.network.allow",
+						i, c.Service, j, inj.Domain))
+				}
+			}
 		}
 	}
 
@@ -512,6 +529,49 @@ func compileArgPattern(pat string) (*regexp.Regexp, error) {
 		return nil, err
 	}
 	return regexp.Compile(`\A(?:` + pat + `)\z`)
+}
+
+// ValidateApiKey requires inject[].domain and header or username on every
+// entry (SPEC-v2 §5.4.1); name itself is required only for schemaVersion "2".
+func ValidateApiKey(a *ApiKey, schemaVersion string) error {
+	if a == nil {
+		return nil
+	}
+	if a.Name == "" && schemaVersion == "2" {
+		return fmt.Errorf("apiKey: name is required")
+	}
+	for j, inj := range a.Inject {
+		if inj.Domain == "" {
+			return fmt.Errorf("apiKey: inject[%d].domain is required", j)
+		}
+		if inj.Format != "" && strings.Count(inj.Format, "%s") != 1 {
+			return fmt.Errorf("apiKey: inject[%d].format must contain exactly one %%s placeholder (got %q)", j, inj.Format)
+		}
+		if inj.Header == "" && inj.Username == "" {
+			return fmt.Errorf("apiKey: inject[%d] sets neither header nor username, so it injects nothing", j)
+		}
+	}
+	return nil
+}
+
+// allowListCovers matches domain against the exact, host:port, *., and **.
+// forms permissions.network.allow documents — no other pattern semantics.
+func allowListCovers(domain string, allow []string) bool {
+	for _, entry := range allow {
+		host, _, _ := strings.Cut(entry, ":")
+		if host == domain {
+			return true
+		}
+		if label, ok := strings.CutPrefix(host, "**."); ok && strings.HasSuffix(domain, "."+label) {
+			return true
+		}
+		if label, ok := strings.CutPrefix(host, "*."); ok {
+			if sub := strings.TrimSuffix(domain, "."+label); sub != domain && sub != "" && !strings.Contains(sub, ".") {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // ValidateOAuthPolicy validates the oauth policy if present.

--- a/spec/validate.go
+++ b/spec/validate.go
@@ -321,6 +321,16 @@ func ValidateArtifact(a *Artifact) error {
 		allowedDomains = a.Caps.Network.Allow
 	}
 
+	// This class of warning is validator-owned: drop every prior instance so
+	// revalidation reflects the artifact's current state, not its history.
+	retained := make([]string, 0, len(a.Warnings))
+	for _, w := range a.Warnings {
+		if !strings.HasPrefix(w, uncoveredDomainWarningPrefix) {
+			retained = append(retained, w)
+		}
+	}
+	a.Warnings = retained
+
 	for i, c := range a.Credentials {
 		// SPEC-v2 §5.4 makes service REQUIRED on every credential entry: it is
 		// the identity the user-side bindings file matches on. For OAuth it
@@ -346,13 +356,9 @@ func ValidateArtifact(a *Artifact) error {
 		if c.ApiKey != nil {
 			for j, inj := range c.ApiKey.Inject {
 				if inj.Domain != "" && !allowListCovers(inj.Domain, allowedDomains) {
-					msg := fmt.Sprintf(
-						"credentials[%d] (service %q): apiKey.inject[%d].domain %q is not covered by permissions.network.allow",
-						i, c.Service, j, inj.Domain)
-					// A caller may revalidate the same artifact; don't re-append.
-					if !slices.Contains(a.Warnings, msg) {
-						a.Warnings = append(a.Warnings, msg)
-					}
+					a.Warnings = append(a.Warnings, fmt.Sprintf(
+						"%scredentials[%d] (service %q) inject[%d].domain %q",
+						uncoveredDomainWarningPrefix, i, c.Service, j, inj.Domain))
 				}
 			}
 		}
@@ -561,6 +567,10 @@ func ValidateApiKey(a *ApiKey, schemaVersion string) error {
 	}
 	return nil
 }
+
+// uncoveredDomainWarningPrefix tags a validator-owned warning class so
+// ValidateArtifact can find and drop its own prior instances on revalidation.
+const uncoveredDomainWarningPrefix = "apiKey inject domain not covered by permissions.network.allow: "
 
 // allowListCovers mirrors sbx's runtime enforcement: a port range or other
 // non-numeric, non-"*" port never matches, so it doesn't count as coverage.

--- a/spec/validate.go
+++ b/spec/validate.go
@@ -551,6 +551,9 @@ func ValidateApiKey(a *ApiKey, schemaVersion string) error {
 	if a.Name == "" && schemaVersion == "2" {
 		return fmt.Errorf("apiKey: name is required")
 	}
+	if a.Name != "" && !shellIdentifierPattern.MatchString(a.Name) {
+		return fmt.Errorf("apiKey: name %q is not a valid shell identifier (letters, digits, underscores; can't start with a digit)", a.Name)
+	}
 	for j, inj := range a.Inject {
 		if inj.Domain == "" {
 			return fmt.Errorf("apiKey: inject[%d].domain is required", j)

--- a/spec/validate.go
+++ b/spec/validate.go
@@ -346,9 +346,13 @@ func ValidateArtifact(a *Artifact) error {
 		if c.ApiKey != nil {
 			for j, inj := range c.ApiKey.Inject {
 				if inj.Domain != "" && !allowListCovers(inj.Domain, allowedDomains) {
-					a.Warnings = append(a.Warnings, fmt.Sprintf(
+					msg := fmt.Sprintf(
 						"credentials[%d] (service %q): apiKey.inject[%d].domain %q is not covered by permissions.network.allow",
-						i, c.Service, j, inj.Domain))
+						i, c.Service, j, inj.Domain)
+					// A caller may revalidate the same artifact; don't re-append.
+					if !slices.Contains(a.Warnings, msg) {
+						a.Warnings = append(a.Warnings, msg)
+					}
 				}
 			}
 		}

--- a/spec/validate_test.go
+++ b/spec/validate_test.go
@@ -596,6 +596,14 @@ func TestValidateApiKey(t *testing.T) {
 		require.NoError(t, ValidateApiKey(a, "2"))
 	})
 
+	// header alone has no template to substitute the credential into, so it
+	// never actually injects at runtime — only the username/Basic path can
+	// omit format.
+	t.Run("header_without_format_rejected", func(t *testing.T) {
+		a := &ApiKey{Name: "TOKEN", Inject: []ApiKeyInject{{Domain: "d.example.com", Header: "x-api-key"}}}
+		require.ErrorContains(t, ValidateApiKey(a, "2"), "sets header but no format")
+	})
+
 	t.Run("username_only_valid", func(t *testing.T) {
 		a := &ApiKey{Name: "TOKEN", Inject: []ApiKeyInject{{Domain: "d.example.com", Username: "x-access-token", Format: "%s"}}}
 		require.NoError(t, ValidateApiKey(a, "2"))
@@ -834,6 +842,40 @@ func TestValidateArtifact(t *testing.T) {
 			Credentials: []Credential{{Service: "sample_proxy", ApiKey: &ApiKey{Name: "SAMPLE_PROXY_TOKEN"}}},
 		}
 		require.NoError(t, ValidateArtifact(a))
+	})
+
+	// proxyManaged: true copies apiKey.name into the derived
+	// Environment.ProxyManaged list; a malformed name must still be
+	// attributed to the credential, not to that derived list.
+	t.Run("proxymanaged_malformed_name_errors_as_apikey_not_environment", func(t *testing.T) {
+		yamlBytes := []byte(`
+schemaVersion: "2"
+kind: mixin
+name: creds-proxy-managed
+permissions:
+  network:
+    allow:
+      - api.example.com
+credentials:
+  - service: svc
+    apiKey:
+      name: bad-name
+      proxyManaged: true
+      inject:
+        - domain: api.example.com
+          header: x-api-key
+          format: "%s"
+`)
+		art, err := LoadArtifactFromBytes(yamlBytes)
+		require.NoError(t, err)
+		require.Equal(t, []string{"bad-name"}, art.Environment.ProxyManaged,
+			"precondition: the name must have propagated to the derived environment list")
+
+		err = ValidateArtifact(art)
+		require.ErrorContains(t, err, "apiKey: name")
+		require.ErrorContains(t, err, "not a valid shell identifier")
+		require.NotContains(t, err.Error(), "environment: proxyManaged",
+			"error must be attributed to the credential, not the derived environment list")
 	})
 
 	t.Run("apikey_explicit_header_and_format_valid", func(t *testing.T) {

--- a/spec/validate_test.go
+++ b/spec/validate_test.go
@@ -580,6 +580,13 @@ func TestValidateApiKey(t *testing.T) {
 		a := &ApiKey{Name: "TOKEN", Inject: []ApiKeyInject{{Domain: "d.example.com", Username: "x-access-token", Format: "%s"}}}
 		require.NoError(t, ValidateApiKey(a, "2"))
 	})
+
+	// HTTP Basic (RFC 7617) parses everything after the first colon as the
+	// password, so a colon-bearing username can never authenticate as declared.
+	t.Run("username_with_colon_rejected", func(t *testing.T) {
+		a := &ApiKey{Name: "TOKEN", Inject: []ApiKeyInject{{Domain: "d.example.com", Username: "a:b", Format: "%s"}}}
+		require.ErrorContains(t, ValidateApiKey(a, "2"), `username must not contain ":"`)
+	})
 }
 
 func TestValidateOAuth(t *testing.T) {

--- a/spec/validate_test.go
+++ b/spec/validate_test.go
@@ -846,12 +846,12 @@ func TestValidateArtifact(t *testing.T) {
 			}},
 		}
 		require.NoError(t, ValidateArtifact(a), "an uncovered inject domain must warn, not fail validation")
-		require.True(t, hasWarningContaining(a.Warnings, `apiKey.inject[0].domain "svc.example.com" is not covered`),
+		require.True(t, hasWarningContaining(a.Warnings, `credentials[0] (service "svc") inject[0].domain "svc.example.com"`),
 			"expected an uncovered-domain warning, got %v", a.Warnings)
 	})
 
-	// A caller may revalidate the same artifact (e.g. after a streaming
-	// re-check); the warning must not accumulate a duplicate per call.
+	// Coverage warnings are validator-owned: revalidating the same artifact
+	// must not accumulate a duplicate per call.
 	t.Run("apikey_inject_domain_warning_is_idempotent_across_revalidation", func(t *testing.T) {
 		a := &Artifact{
 			Manifest: Manifest{SchemaVersion: "2", Kind: KindMixin, Name: "ok"},
@@ -868,11 +868,33 @@ func TestValidateArtifact(t *testing.T) {
 		require.NoError(t, ValidateArtifact(a))
 		count := 0
 		for _, w := range a.Warnings {
-			if strings.Contains(w, `apiKey.inject[0].domain "svc.example.com" is not covered`) {
+			if strings.Contains(w, `credentials[0] (service "svc") inject[0].domain "svc.example.com"`) {
 				count++
 			}
 		}
 		require.Equal(t, 1, count, "revalidation must not duplicate the warning, got %v", a.Warnings)
+	})
+
+	// Coverage warnings are also self-healing: once the allow list is fixed,
+	// revalidating the same artifact must drop the now-stale warning.
+	t.Run("apikey_inject_domain_warning_clears_once_allow_list_fixed", func(t *testing.T) {
+		a := &Artifact{
+			Manifest: Manifest{SchemaVersion: "2", Kind: KindMixin, Name: "ok"},
+			Caps:     &Caps{Network: &CapsNetwork{Allow: []string{"other.example.com"}}},
+			Credentials: []Credential{{
+				Service: "svc",
+				ApiKey: &ApiKey{
+					Name:   "SVC_TOKEN",
+					Inject: []ApiKeyInject{{Domain: "svc.example.com", Header: "x-api-key", Format: "%s"}},
+				},
+			}},
+		}
+		require.NoError(t, ValidateArtifact(a))
+		require.NotEmpty(t, a.Warnings, "precondition: the domain must start out uncovered")
+
+		a.Caps.Network.Allow = append(a.Caps.Network.Allow, "svc.example.com")
+		require.NoError(t, ValidateArtifact(a))
+		require.Empty(t, a.Warnings, "the warning must clear once the domain is covered, got %v", a.Warnings)
 	})
 
 	t.Run("apikey_inject_domain_covered_by_wildcard_no_warning", func(t *testing.T) {
@@ -905,7 +927,7 @@ func TestValidateArtifact(t *testing.T) {
 			}},
 		}
 		require.NoError(t, ValidateArtifact(a))
-		require.True(t, hasWarningContaining(a.Warnings, `apiKey.inject[0].domain "api.example.com" is not covered`),
+		require.True(t, hasWarningContaining(a.Warnings, `credentials[0] (service "svc") inject[0].domain "api.example.com"`),
 			"a port-range allow entry never matches, so it must still warn; got %v", a.Warnings)
 	})
 

--- a/spec/validate_test.go
+++ b/spec/validate_test.go
@@ -1,6 +1,7 @@
 package spec
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -847,6 +848,31 @@ func TestValidateArtifact(t *testing.T) {
 		require.NoError(t, ValidateArtifact(a), "an uncovered inject domain must warn, not fail validation")
 		require.True(t, hasWarningContaining(a.Warnings, `apiKey.inject[0].domain "svc.example.com" is not covered`),
 			"expected an uncovered-domain warning, got %v", a.Warnings)
+	})
+
+	// A caller may revalidate the same artifact (e.g. after a streaming
+	// re-check); the warning must not accumulate a duplicate per call.
+	t.Run("apikey_inject_domain_warning_is_idempotent_across_revalidation", func(t *testing.T) {
+		a := &Artifact{
+			Manifest: Manifest{SchemaVersion: "2", Kind: KindMixin, Name: "ok"},
+			Caps:     &Caps{Network: &CapsNetwork{Allow: []string{"other.example.com"}}},
+			Credentials: []Credential{{
+				Service: "svc",
+				ApiKey: &ApiKey{
+					Name:   "SVC_TOKEN",
+					Inject: []ApiKeyInject{{Domain: "svc.example.com", Header: "x-api-key", Format: "%s"}},
+				},
+			}},
+		}
+		require.NoError(t, ValidateArtifact(a))
+		require.NoError(t, ValidateArtifact(a))
+		count := 0
+		for _, w := range a.Warnings {
+			if strings.Contains(w, `apiKey.inject[0].domain "svc.example.com" is not covered`) {
+				count++
+			}
+		}
+		require.Equal(t, 1, count, "revalidation must not duplicate the warning, got %v", a.Warnings)
 	})
 
 	t.Run("apikey_inject_domain_covered_by_wildcard_no_warning", func(t *testing.T) {

--- a/spec/validate_test.go
+++ b/spec/validate_test.go
@@ -534,6 +534,54 @@ func TestValidateOAuthPolicy(t *testing.T) {
 	})
 }
 
+func TestValidateApiKey(t *testing.T) {
+	t.Run("nil_is_valid", func(t *testing.T) {
+		require.NoError(t, ValidateApiKey(nil, "2"))
+	})
+
+	t.Run("v2_missing_name_rejected", func(t *testing.T) {
+		a := &ApiKey{Inject: []ApiKeyInject{{Domain: "api.example.com", Header: "x-api-key", Format: "%s"}}}
+		require.ErrorContains(t, ValidateApiKey(a, "2"), "name is required")
+	})
+
+	// v1's serviceDomains+serviceAuth fold can yield a header-only inject
+	// with no name that still injects, so schemaVersion "1" must accept it.
+	t.Run("v1_missing_name_grandfathered", func(t *testing.T) {
+		a := &ApiKey{Inject: []ApiKeyInject{{Domain: "api.example.com", Header: "x-api-key", Format: "%s"}}}
+		require.NoError(t, ValidateApiKey(a, "1"))
+	})
+
+	t.Run("empty_inject_domain_rejected", func(t *testing.T) {
+		a := &ApiKey{Name: "TOKEN", Inject: []ApiKeyInject{{Header: "x-api-key", Format: "%s"}}}
+		require.ErrorContains(t, ValidateApiKey(a, "2"), "inject[0].domain is required")
+	})
+
+	t.Run("format_with_zero_placeholders_rejected", func(t *testing.T) {
+		a := &ApiKey{Name: "TOKEN", Inject: []ApiKeyInject{{Domain: "d.example.com", Header: "h", Format: "static"}}}
+		require.ErrorContains(t, ValidateApiKey(a, "2"), "exactly one %s placeholder")
+	})
+
+	t.Run("format_with_two_placeholders_rejected", func(t *testing.T) {
+		a := &ApiKey{Name: "TOKEN", Inject: []ApiKeyInject{{Domain: "d.example.com", Header: "h", Format: "%s-%s"}}}
+		require.ErrorContains(t, ValidateApiKey(a, "2"), "exactly one %s placeholder")
+	})
+
+	t.Run("inert_inject_rejected", func(t *testing.T) {
+		a := &ApiKey{Name: "TOKEN", Inject: []ApiKeyInject{{Domain: "d.example.com", Format: "%s"}}}
+		require.ErrorContains(t, ValidateApiKey(a, "2"), "sets neither header nor username")
+	})
+
+	t.Run("header_only_valid", func(t *testing.T) {
+		a := &ApiKey{Name: "TOKEN", Inject: []ApiKeyInject{{Domain: "d.example.com", Header: "x-api-key", Format: "%s"}}}
+		require.NoError(t, ValidateApiKey(a, "2"))
+	})
+
+	t.Run("username_only_valid", func(t *testing.T) {
+		a := &ApiKey{Name: "TOKEN", Inject: []ApiKeyInject{{Domain: "d.example.com", Username: "x-access-token", Format: "%s"}}}
+		require.NoError(t, ValidateApiKey(a, "2"))
+	})
+}
+
 func TestValidateOAuth(t *testing.T) {
 	t.Run("nil_is_valid", func(t *testing.T) {
 		require.NoError(t, ValidateOAuth(nil))
@@ -759,6 +807,108 @@ func TestValidateArtifact(t *testing.T) {
 			Credentials: []Credential{{Service: "sample_proxy", ApiKey: &ApiKey{Name: "SAMPLE_PROXY_TOKEN"}}},
 		}
 		require.NoError(t, ValidateArtifact(a))
+	})
+
+	t.Run("apikey_explicit_header_and_format_valid", func(t *testing.T) {
+		a := &Artifact{
+			Manifest: Manifest{SchemaVersion: "2", Kind: KindMixin, Name: "ok"},
+			Caps:     &Caps{Network: &CapsNetwork{Allow: []string{"api.anthropic.com"}}},
+			Credentials: []Credential{{
+				Service: "anthropic",
+				ApiKey: &ApiKey{
+					Name:   "ANTHROPIC_API_KEY",
+					Inject: []ApiKeyInject{{Domain: "api.anthropic.com", Header: "x-api-key", Format: "%s"}},
+				},
+			}},
+		}
+		require.NoError(t, ValidateArtifact(a))
+		require.Empty(t, a.Warnings)
+	})
+
+	t.Run("apikey_inject_domain_not_allowed_warns_not_errors", func(t *testing.T) {
+		a := &Artifact{
+			Manifest: Manifest{SchemaVersion: "2", Kind: KindMixin, Name: "ok"},
+			Caps:     &Caps{Network: &CapsNetwork{Allow: []string{"other.example.com"}}},
+			Credentials: []Credential{{
+				Service: "svc",
+				ApiKey: &ApiKey{
+					Name:   "SVC_TOKEN",
+					Inject: []ApiKeyInject{{Domain: "svc.example.com", Header: "x-api-key", Format: "%s"}},
+				},
+			}},
+		}
+		require.NoError(t, ValidateArtifact(a), "an uncovered inject domain must warn, not fail validation")
+		require.True(t, hasWarningContaining(a.Warnings, `apiKey.inject[0].domain "svc.example.com" is not covered`),
+			"expected an uncovered-domain warning, got %v", a.Warnings)
+	})
+
+	t.Run("apikey_inject_domain_covered_by_wildcard_no_warning", func(t *testing.T) {
+		a := &Artifact{
+			Manifest: Manifest{SchemaVersion: "2", Kind: KindMixin, Name: "ok"},
+			Caps:     &Caps{Network: &CapsNetwork{Allow: []string{"*.example.com"}}},
+			Credentials: []Credential{{
+				Service: "svc",
+				ApiKey: &ApiKey{
+					Name:   "SVC_TOKEN",
+					Inject: []ApiKeyInject{{Domain: "svc.example.com", Header: "x-api-key", Format: "%s"}},
+				},
+			}},
+		}
+		require.NoError(t, ValidateArtifact(a))
+		require.Empty(t, a.Warnings)
+	})
+
+	// scheme: basic expands to Username set, Header empty (SPEC-v2 §5.4.1);
+	// this shape must validate clean despite the empty header.
+	t.Run("scheme_basic_post_fold_shape_is_clean", func(t *testing.T) {
+		yamlBytes := []byte(`
+schemaVersion: "2"
+kind: mixin
+name: creds-basic
+permissions:
+  network:
+    allow:
+      - github.com
+credentials:
+  - service: github
+    apiKey:
+      name: GITHUB_TOKEN
+      inject:
+        - domain: github.com
+          scheme: basic
+          username: x-access-token
+`)
+		art, err := LoadArtifactFromBytes(yamlBytes)
+		require.NoError(t, err)
+		require.NoError(t, ValidateArtifact(art))
+		require.Empty(t, art.Credentials[0].ApiKey.Inject[0].Header, "scheme: basic sets no header")
+		require.Equal(t, "x-access-token", art.Credentials[0].ApiKey.Inject[0].Username)
+		require.Empty(t, art.Warnings)
+	})
+
+	// Regression: the v1 serviceDomains+serviceAuth fold can produce a
+	// no-name, header-only apiKey that already injects; it must stay valid.
+	t.Run("v1_serviceDomains_fold_without_name_stays_valid", func(t *testing.T) {
+		yamlBytes := []byte(`
+schemaVersion: "1"
+kind: agent
+name: routing-only
+agent:
+  image: x
+network:
+  allowedDomains: [api.anthropic.com]
+  serviceDomains:
+    api.anthropic.com: anthropic
+  serviceAuth:
+    anthropic:
+      headerName: x-api-key
+      valueFormat: "%s"
+`)
+		art, err := LoadArtifactFromBytes(yamlBytes)
+		require.NoError(t, err)
+		require.NoError(t, ValidateArtifact(art))
+		require.Empty(t, art.Credentials[0].ApiKey.Name, "no credentials.sources entry means no envName")
+		require.Equal(t, "x-api-key", art.Credentials[0].ApiKey.Inject[0].Header)
 	})
 
 	t.Run("oauth_credential_file_structure_only_accepted", func(t *testing.T) {

--- a/spec/validate_test.go
+++ b/spec/validate_test.go
@@ -559,6 +559,13 @@ func TestValidateApiKey(t *testing.T) {
 		require.ErrorContains(t, ValidateApiKey(a, "2"), "not a valid shell identifier")
 	})
 
+	// The shell-identifier shape check is not v2-gated: only the
+	// non-empty requirement is, so a malformed v1 name is rejected too.
+	t.Run("malformed_name_rejected_v1", func(t *testing.T) {
+		a := &ApiKey{Name: "bad-name", Inject: []ApiKeyInject{{Domain: "api.example.com", Header: "x-api-key", Format: "%s"}}}
+		require.ErrorContains(t, ValidateApiKey(a, "1"), "not a valid shell identifier")
+	})
+
 	t.Run("valid_underscore_leading_name_accepted", func(t *testing.T) {
 		a := &ApiKey{Name: "_OK_NAME2", Inject: []ApiKeyInject{{Domain: "api.example.com", Header: "x-api-key", Format: "%s"}}}
 		require.NoError(t, ValidateApiKey(a, "2"))
@@ -605,7 +612,7 @@ func TestValidateApiKey(t *testing.T) {
 	})
 
 	t.Run("username_only_valid", func(t *testing.T) {
-		a := &ApiKey{Name: "TOKEN", Inject: []ApiKeyInject{{Domain: "d.example.com", Username: "x-access-token", Format: "%s"}}}
+		a := &ApiKey{Name: "TOKEN", Inject: []ApiKeyInject{{Domain: "d.example.com", Username: "x-access-token"}}}
 		require.NoError(t, ValidateApiKey(a, "2"))
 	})
 

--- a/spec/validate_test.go
+++ b/spec/validate_test.go
@@ -865,6 +865,56 @@ func TestValidateArtifact(t *testing.T) {
 		require.Empty(t, a.Warnings)
 	})
 
+	// A port range never matches a request, so it doesn't cover the domain.
+	t.Run("apikey_inject_domain_port_range_allow_still_warns", func(t *testing.T) {
+		a := &Artifact{
+			Manifest: Manifest{SchemaVersion: "2", Kind: KindMixin, Name: "ok"},
+			Caps:     &Caps{Network: &CapsNetwork{Allow: []string{"api.example.com:80-443"}}},
+			Credentials: []Credential{{
+				Service: "svc",
+				ApiKey: &ApiKey{
+					Name:   "SVC_TOKEN",
+					Inject: []ApiKeyInject{{Domain: "api.example.com", Header: "x-api-key", Format: "%s"}},
+				},
+			}},
+		}
+		require.NoError(t, ValidateArtifact(a))
+		require.True(t, hasWarningContaining(a.Warnings, `apiKey.inject[0].domain "api.example.com" is not covered`),
+			"a port-range allow entry never matches, so it must still warn; got %v", a.Warnings)
+	})
+
+	t.Run("apikey_inject_domain_port_wildcard_allow_no_warning", func(t *testing.T) {
+		a := &Artifact{
+			Manifest: Manifest{SchemaVersion: "2", Kind: KindMixin, Name: "ok"},
+			Caps:     &Caps{Network: &CapsNetwork{Allow: []string{"api.example.com:*"}}},
+			Credentials: []Credential{{
+				Service: "svc",
+				ApiKey: &ApiKey{
+					Name:   "SVC_TOKEN",
+					Inject: []ApiKeyInject{{Domain: "api.example.com", Header: "x-api-key", Format: "%s"}},
+				},
+			}},
+		}
+		require.NoError(t, ValidateArtifact(a))
+		require.Empty(t, a.Warnings)
+	})
+
+	t.Run("apikey_inject_domain_multilabel_wildcard_allow_no_warning", func(t *testing.T) {
+		a := &Artifact{
+			Manifest: Manifest{SchemaVersion: "2", Kind: KindMixin, Name: "ok"},
+			Caps:     &Caps{Network: &CapsNetwork{Allow: []string{"**.example.com"}}},
+			Credentials: []Credential{{
+				Service: "svc",
+				ApiKey: &ApiKey{
+					Name:   "SVC_TOKEN",
+					Inject: []ApiKeyInject{{Domain: "a.b.example.com", Header: "x-api-key", Format: "%s"}},
+				},
+			}},
+		}
+		require.NoError(t, ValidateArtifact(a))
+		require.Empty(t, a.Warnings)
+	})
+
 	// scheme: basic expands to Username set, Header empty (SPEC-v2 §5.4.1);
 	// this shape must validate clean despite the empty header.
 	t.Run("scheme_basic_post_fold_shape_is_clean", func(t *testing.T) {

--- a/spec/validate_test.go
+++ b/spec/validate_test.go
@@ -552,6 +552,25 @@ func TestValidateApiKey(t *testing.T) {
 		require.NoError(t, ValidateApiKey(a, "1"))
 	})
 
+	// name is an env-var name; a non-empty malformed one always loads clean
+	// today but the value is never actually reachable in-container.
+	t.Run("malformed_name_rejected", func(t *testing.T) {
+		a := &ApiKey{Name: "bad-name", Inject: []ApiKeyInject{{Domain: "api.example.com", Header: "x-api-key", Format: "%s"}}}
+		require.ErrorContains(t, ValidateApiKey(a, "2"), "not a valid shell identifier")
+	})
+
+	t.Run("valid_underscore_leading_name_accepted", func(t *testing.T) {
+		a := &ApiKey{Name: "_OK_NAME2", Inject: []ApiKeyInject{{Domain: "api.example.com", Header: "x-api-key", Format: "%s"}}}
+		require.NoError(t, ValidateApiKey(a, "2"))
+	})
+
+	// The shell-identifier check only applies to a non-empty name; an empty
+	// one stays governed solely by the v1/v2 name-required gate above.
+	t.Run("v1_empty_name_not_subject_to_shell_identifier_check", func(t *testing.T) {
+		a := &ApiKey{Inject: []ApiKeyInject{{Domain: "api.example.com", Header: "x-api-key", Format: "%s"}}}
+		require.NoError(t, ValidateApiKey(a, "1"))
+	})
+
 	t.Run("empty_inject_domain_rejected", func(t *testing.T) {
 		a := &ApiKey{Name: "TOKEN", Inject: []ApiKeyInject{{Header: "x-api-key", Format: "%s"}}}
 		require.ErrorContains(t, ValidateApiKey(a, "2"), "inject[0].domain is required")


### PR DESCRIPTION
## Summary

Follow-up from the #179 review ([@ilopezluna's finding](https://github.com/docker/sbx-kits-contrib/pull/179#pullrequestreview-4895306950)): malformed `apiKey` shapes load clean and fail silently at runtime. `ValidateArtifact` now rejects: missing `name` (v2 specs only — the v1 `serviceDomains` fold legitimately omits it), a non-empty `name` that isn't a valid shell identifier (it's an env-var name), empty `inject[].domain`, `format` without exactly one `%s`, an inject with neither `header` nor `username`, and a colon in `username` (HTTP Basic reads the first colon as the user/password delimiter). An inject domain missing from `permissions.network.allow` warns instead of erroring.

Post-fold `scheme: basic` (username set, no header) stays valid. §5.4.1 and the kit-author topic are updated to match. Sweeping all 46 kits surfaced two real defects, fixed here: `amp`'s empty `apiKey.name` and `sample-agent-v2`'s uncovered inject domains.

Behavior change: spec-violating kits that load today start failing `sbx kit validate`. They were already broken at runtime, so nothing working regresses — release-note it at the next module tag.

All checks mutation-checked; full suite green.

Authored by Claude (Sonnet 5) on behalf of @mdelapenya.
