### PR TITLE
fix(tck): make e2e create invocation kind-aware for sandbox kits

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,8 +213,10 @@ The default TCK runs every kit assertion against a fabricated `testcontainers-go
 
 `tck/e2e_test.go` (build-tag `e2e`, function `TestE2ECreateSandbox`) drives one kit per run:
 
-1. Loads the kit at `$KIT_UNDER_TEST` and picks the agent argument — kit name for `kind: agent`, `claude` for `kind: mixin`.
-2. Runs `sbx create --kit <kit> --name <unique> <agent> <tmpdir>` against a temporary workspace.
+1. Loads the kit at `$KIT_UNDER_TEST`.
+2. Runs `sbx create`, shaped by the kit's manifest kind, against a temporary workspace:
+   - `kind: sandbox` → `sbx create <kit> --name <unique> <tmpdir>` — the kit's own directory is the first positional. `sbx create --kit` rejects a `kind: sandbox` spec, and a bare agent name resolves to a published kit rather than this local checkout, so no `--kit` flag or agent argument is passed.
+   - `kind: mixin` → `sbx create --kit <kit> --name <unique> <agent> <tmpdir>`, composing the mixin onto `<agent>` (`claude`, or the mixin's declared base-agent affinity).
 3. Verifies, via `sbx exec`, that the running sandbox contains:
    - every `environment.variables` entry,
    - every file under `files/home` and every `commands.initFiles` (with `${WORKDIR}` resolved to `/home/agent/workspace`, the real sandbox workdir),

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ The default TCK runs every kit assertion against a fabricated `testcontainers-go
 
 1. Loads the kit at `$KIT_UNDER_TEST`.
 2. Runs `sbx create`, shaped by the kit's manifest kind, against a temporary workspace:
-   - `kind: sandbox` → `sbx create <kit> --name <unique> <tmpdir>` — the kit's own directory is the first positional. `sbx create --kit` rejects a `kind: sandbox` spec, and a bare agent name resolves to a published kit rather than this local checkout, so no `--kit` flag or agent argument is passed.
+   - `kind: sandbox` → `sbx create <kit> --name <unique> <tmpdir>` — the kit's own directory is the first positional, no `--kit` flag or agent argument. `sbx create --kit <sandbox-kit> ... <agent>` still works with a deprecation warning when `<agent>` doesn't name a built-in, but hard-fails as `must be kind "mixin", got "sandbox"` when it does, since the positional then resolves to the built-in rather than this kit; the positional form drops that deprecation warning for every sandbox kit, not only the built-in-shadowed ones.
    - `kind: mixin` → `sbx create --kit <kit> --name <unique> <agent> <tmpdir>`, composing the mixin onto `<agent>` (`claude`, or the mixin's declared base-agent affinity).
 3. Verifies, via `sbx exec`, that the running sandbox contains:
    - every `environment.variables` entry,

--- a/tck/e2e.go
+++ b/tck/e2e.go
@@ -462,10 +462,8 @@ const promptMessage = "what version are you running"
 // shape is kind-aware:
 //
 //   - kind:sandbox: `create <absKit> --name <name> [kit-arg flags] <workspace>`.
-//     sbx rejects --kit for a kind:sandbox spec ("must be kind \"mixin\""),
-//     and resolves a bare agent name to a published kit rather than this
-//     local checkout — so the kit's own directory is the first positional,
-//     with no separate agent argument.
+//     Passing the kit's own directory as the positional avoids sbx's
+//     deprecated --kit path entirely, including its built-in-name failure.
 //   - kind:mixin: `create --kit <absKit> --name <name> [kit-arg flags] <agent> <workspace>`,
 //     composing the mixin onto agent (the default agent or its declared
 //     base-agent affinity).

--- a/tck/e2e.go
+++ b/tck/e2e.go
@@ -50,10 +50,7 @@ type E2EOptions struct {
 //	  agentContext — all kits (skipped when agentContext is absent)
 //	  prompt       — kind:sandbox only, skipped when tck.yaml/promptArgs absent
 //
-// The agent passed to `sbx create` depends on the kit's manifest:
-//
-//	kind: sandbox → the kit's own name (sbx enforces this match).
-//	kind: mixin   → "claude" (the default agent the kit is exercised against).
+// `sbx create`'s argv depends on the kit's manifest kind — see buildCreateArgs.
 //
 // Exported so any module that imports this package can drive the same
 // real-sandbox e2e assertions this repo's own e2e-tagged test uses — see
@@ -88,7 +85,7 @@ func RunE2EKit(t *testing.T, kitPath string, opts E2EOptions) {
 
 		checkHostCredentials(t, ctx, td, opts.AppName)
 
-		name := createSbx(t, ctx, absKit, suite.Artifact.Manifest.Name, agent, td, opts.AppName)
+		name := createSbx(t, ctx, absKit, suite.Artifact.Manifest.Kind, suite.Artifact.Manifest.Name, agent, td, opts.AppName)
 
 		// Verify kit content landed inside the running container. Files are
 		// re-derived here so `${WORKDIR}` resolves to the real sandbox workdir
@@ -461,12 +458,34 @@ func checkHostCredentials(t *testing.T, ctx context.Context, td *kitTCKData, app
 // agent rejects the call with an authentication error.
 const promptMessage = "what version are you running"
 
+// buildCreateArgs renders the `sbx create` argv for a kit under test. The
+// shape is kind-aware:
+//
+//   - kind:sandbox: `create <absKit> --name <name> [kit-arg flags] <workspace>`.
+//     sbx rejects --kit for a kind:sandbox spec ("must be kind \"mixin\""),
+//     and resolves a bare agent name to a published kit rather than this
+//     local checkout — so the kit's own directory is the first positional,
+//     with no separate agent argument.
+//   - kind:mixin: `create --kit <absKit> --name <name> [kit-arg flags] <agent> <workspace>`,
+//     composing the mixin onto agent (the default agent or its declared
+//     base-agent affinity).
+func buildCreateArgs(kind, absKit, name, agent, workspace string, kitArgFlags []string) []string {
+	if kind == spec.KindSandbox {
+		args := []string{"create", absKit, "--name", name}
+		args = append(args, kitArgFlags...)
+		return append(args, workspace)
+	}
+	args := []string{"create", "--kit", absKit, "--name", name}
+	args = append(args, kitArgFlags...)
+	return append(args, agent, workspace)
+}
+
 // createSbx creates a sandbox for the kit using `sbx create`, registers a
 // t.Cleanup that force-removes it, and returns the sandbox name. A fresh temp
 // dir is used as the workspace.
 // td may be nil (no testdata/tck.yaml); see kitTCKData.ExtractedFromBuiltin for
 // the one failure this tolerates.
-func createSbx(t *testing.T, ctx context.Context, absKit, kitName, agent string, td *kitTCKData, appName string) string {
+func createSbx(t *testing.T, ctx context.Context, absKit, kind, kitName, agent string, td *kitTCKData, appName string) string {
 	t.Helper()
 	workspace := t.TempDir()
 	name := sandboxName(t, absKit)
@@ -510,13 +529,14 @@ func createSbx(t *testing.T, ctx context.Context, absKit, kitName, agent string,
 			t.Logf("cleanup `sbx rm -f %s` failed: %v\n%s", name, err, out)
 		}
 	})
-	createArgs := []string{"create", "--kit", absKit, "--name", name}
+	var kitArgFlags []string
 	if td != nil {
-		createArgs = append(createArgs, KitArgFlags(kitName, td.Args)...)
+		kitArgFlags = KitArgFlags(kitName, td.Args)
 	}
-	createArgs = append(createArgs, agent, workspace)
-	createOut, err := runSbx(t, ctx, appName, createArgs...)
+	createOut, err := runSbx(t, ctx, appName, buildCreateArgs(kind, absKit, name, agent, workspace, kitArgFlags)...)
 
+	// Matches on stdout text alone, so it fires regardless of which
+	// buildCreateArgs shape produced it.
 	if err != nil && strings.Contains(createOut, builtinCollisionMarker) {
 		if td != nil && td.ExtractedFromBuiltin {
 			t.Skipf("kit %q is still shadowed by the built-in %q agent in this sbx build, and "+
@@ -585,11 +605,14 @@ func waitForAgentReady(t *testing.T, ctx context.Context, name, readyFile, appNa
 	}
 }
 
-// agentForKit picks the positional agent argument for `sbx create`. Sandbox
-// kits must be invoked with their own name as the agent. A mixin that declares
-// base-agent affinity (requires.agent) must be exercised on that agent —
-// composing it onto any other base is a hard error, since affinity is enforced
-// at compose time. Mixins without affinity default to claude.
+// agentForKit returns the agent label used in log messages and collision
+// diagnostics, and — for kind:mixin only — the positional `sbx create`
+// composes the mixin onto (see buildCreateArgs; a kind:sandbox kit's own
+// directory fills that slot instead, so its label is never sent as an
+// argument). A mixin that declares base-agent affinity (requires.agent) must
+// be exercised on that agent — composing it onto any other base is a hard
+// error, since affinity is enforced at compose time. Mixins without affinity
+// default to claude.
 func agentForKit(a *spec.Artifact) string {
 	if a.Manifest.Kind == spec.KindSandbox {
 		return a.Manifest.Name

--- a/tck/e2e_args_test.go
+++ b/tck/e2e_args_test.go
@@ -1,0 +1,54 @@
+package tck
+
+import (
+	"testing"
+
+	"github.com/docker/sbx-kits-contrib/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildCreateArgsSandbox(t *testing.T) {
+	got := buildCreateArgs(spec.KindSandbox, "/abs/kiro", "e2e-kiro-1234", "kiro", "/tmp/workspace", nil)
+
+	require.Equal(t,
+		[]string{"create", "/abs/kiro", "--name", "e2e-kiro-1234", "/tmp/workspace"},
+		got,
+		"kind:sandbox must pass the kit's own directory as the first positional, with no --kit and no agent argument")
+}
+
+func TestBuildCreateArgsSandboxWithKitArgFlags(t *testing.T) {
+	got := buildCreateArgs(spec.KindSandbox, "/abs/kiro", "e2e-kiro-1234", "kiro", "/tmp/workspace",
+		[]string{"--kit-arg", "kiro.model=fast"})
+
+	require.Equal(t,
+		[]string{
+			"create", "/abs/kiro", "--name", "e2e-kiro-1234",
+			"--kit-arg", "kiro.model=fast",
+			"/tmp/workspace",
+		},
+		got,
+		"kit-arg flags must land between --name and the workspace, which stays last")
+}
+
+func TestBuildCreateArgsMixin(t *testing.T) {
+	got := buildCreateArgs(spec.KindMixin, "/abs/aidlc-claude", "e2e-aidlc-1234", "claude", "/tmp/workspace", nil)
+
+	require.Equal(t,
+		[]string{"create", "--kit", "/abs/aidlc-claude", "--name", "e2e-aidlc-1234", "claude", "/tmp/workspace"},
+		got,
+		"kind:mixin must keep composing via --kit, with the base agent and workspace as trailing positionals")
+}
+
+func TestBuildCreateArgsMixinWithKitArgFlags(t *testing.T) {
+	got := buildCreateArgs(spec.KindMixin, "/abs/aidlc-claude", "e2e-aidlc-1234", "claude", "/tmp/workspace",
+		[]string{"--kit-arg", "aidlc-claude.affinity=bedrock"})
+
+	require.Equal(t,
+		[]string{
+			"create", "--kit", "/abs/aidlc-claude", "--name", "e2e-aidlc-1234",
+			"--kit-arg", "aidlc-claude.affinity=bedrock",
+			"claude", "/tmp/workspace",
+		},
+		got,
+		"kit-arg flags must land between --name and the agent/workspace positionals")
+}

--- a/tck/e2e_args_test.go
+++ b/tck/e2e_args_test.go
@@ -52,3 +52,8 @@ func TestBuildCreateArgsMixinWithKitArgFlags(t *testing.T) {
 		got,
 		"kit-arg flags must land between --name and the agent/workspace positionals")
 }
+
+func TestBuildCreateArgsTreatsOnlyKindSandboxAsBase(t *testing.T) {
+	args := buildCreateArgs(spec.KindAgent, "/abs/k", "n", "claude", "/ws", nil)
+	require.Contains(t, args, "--kit", "an unnormalized v1 kind is not recognized as a base here")
+}


### PR DESCRIPTION
## Summary

Current sbx rejects `--kit` for `kind: sandbox` kits and alias-resolves a bare agent name to the published kit rather than the local checkout, so every agent-kit e2e leg fails on main ([failing run](https://github.com/docker/sbx-kits-contrib/actions/runs/34451367447)). The create invocation is now kind-aware: `kind: sandbox` passes the kit directory as the first positional; `kind: mixin` is unchanged. Doc comments and the README match.

Verified on this PR's own run: copilot, droid and kiro green on both channels (details in the PR comment). Live sbx cannot run in the authoring environment; the new argv unit tests are mutation-checked.

Merge before rerunning e2e on #282/#283.

Authored by Claude (Sonnet 5) on behalf of @mdelapenya.
