### PR TITLE
ci: share sbx downloads across each build

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,7 +33,56 @@ env:
   APP_NAME: sbx-kits-contrib-tck
 
 jobs:
+  prepare-sbx:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      artifact-id: ${{ steps.upload.outputs.artifact-id }}
+    steps:
+      - name: Download sbx (${{ inputs.channel }})
+        env:
+          CHANNEL: ${{ inputs.channel }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          case "$CHANNEL" in
+            nightly) VERSION=nightly ;;
+            rc)
+              VERSION=$(curl -fsSL -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+                https://api.github.com/repos/docker/sbx-releases/releases \
+                | jq -er '[.[] | select(.tag_name | test("-rc[0-9]+$"))][0].tag_name')
+              ;;
+            release)
+              VERSION=$(curl -fsSL -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+                https://api.github.com/repos/docker/sbx-releases/releases/latest \
+                | jq -er .tag_name)
+              ;;
+            *) echo "::error::Unknown sbx channel: ${CHANNEL}"; exit 1 ;;
+          esac
+          if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+            echo "::error::No sbx version found for ${CHANNEL}"
+            exit 1
+          fi
+          echo "Using sbx ${CHANNEL}: ${VERSION}"
+          mkdir -p "${RUNNER_TEMP}/sbx-package"
+          curl -fsSL -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            "https://github.com/docker/sbx-releases/releases/download/${VERSION}/DockerSandboxes-linux.tar.gz" \
+            -o "${RUNNER_TEMP}/sbx-package/DockerSandboxes-linux.tar.gz"
+          tar tzf "${RUNNER_TEMP}/sbx-package/DockerSandboxes-linux.tar.gz" > /dev/null
+          printf '%s\n' "$VERSION" > "${RUNNER_TEMP}/sbx-package/version"
+
+      - name: Share sbx with kit matrix
+        id: upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sbx-${{ inputs.channel }}-linux-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/sbx-package/
+          retention-days: 30
+          compression-level: 0
+          if-no-files-found: error
+
   test-kit-e2e:
+    needs: prepare-sbx
     # End-to-end test: install sbx for the requested channel, authenticate
     # against Docker Hub non-interactively, and run the e2e TCK to prove the
     # kit composes with a real CLI. The caller guards this against fork PRs
@@ -59,46 +108,19 @@ jobs:
           ls -la /dev/kvm
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
-      - name: Download sbx (${{ inputs.channel }})
-        run: |
-          set -euo pipefail
-          if [ "${CHANNEL}" = "nightly" ]; then
-            # Rolling "nightly" build: kits adopting new spec fields are
-            # exercised against the latest sbx instead of the last tag.
-            VERSION=nightly
-            echo "Using rolling nightly sbx build"
-          elif [ "${CHANNEL}" = "rc" ]; then
-            # Latest release candidate: sbx-releases publishes these as
-            # prereleases tagged "*-rcN", which /releases/latest deliberately
-            # excludes. The releases list is newest-first, so the first tag
-            # matching the rc suffix is the most recently cut candidate.
-            VERSION=$(curl -fsSL \
-              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-              https://api.github.com/repos/docker/sbx-releases/releases \
-              | jq -r '[.[] | select(.tag_name | test("-rc[0-9]+$"))][0].tag_name')
-            echo "Resolved latest sbx rc: ${VERSION}"
-          else
-            VERSION=$(curl -fsSL \
-              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-              https://api.github.com/repos/docker/sbx-releases/releases/latest \
-              | jq -r .tag_name)
-            echo "Resolved latest sbx release: ${VERSION}"
-          fi
-          echo "SBX_VERSION=${VERSION}" >> "$GITHUB_ENV"
-
-          curl -fsSL \
-            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-            "https://github.com/docker/sbx-releases/releases/download/${VERSION}/DockerSandboxes-linux.tar.gz" \
-            -o /tmp/DockerSandboxes-linux.tar.gz
-          tar xzf /tmp/DockerSandboxes-linux.tar.gz -C /tmp
-        env:
-          CHANNEL: ${{ inputs.channel }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download prepared sbx
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.prepare-sbx.outputs.artifact-id }}
+          path: ${{ runner.temp }}/sbx-package
+          merge-multiple: true
 
       - name: Install sbx
         run: |
           set -euo pipefail
-          sudo PREFIX="${HOME}/.docker/sbx" /tmp/docker-sbx/install.sh
+          tar xzf "${RUNNER_TEMP}/sbx-package/DockerSandboxes-linux.tar.gz" -C "${RUNNER_TEMP}/sbx-package"
+          echo "SBX_VERSION=$(cat "${RUNNER_TEMP}/sbx-package/version")" >> "$GITHUB_ENV"
+          sudo PREFIX="${HOME}/.docker/sbx" "${RUNNER_TEMP}/sbx-package/docker-sbx/install.sh"
           echo "${HOME}/.docker/sbx/bin" >> "$GITHUB_PATH"
 
       - name: Verify sbx installation

--- a/.github/workflows/tck.yml
+++ b/.github/workflows/tck.yml
@@ -37,6 +37,8 @@ jobs:
           # Add filters for shared packages that should trigger all kits
           filters=$(printf '%s\ntck: "tck/**"\nspec: "spec/**"\nscripts: "scripts/**"' "$filters")
 
+          filters=$(printf '%s\nworkflows: [".github/workflows/e2e.yml", ".github/workflows/tck.yml"]' "$filters")
+
           echo "filters<<EOF" >> "$GITHUB_OUTPUT"
           echo "$filters" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
@@ -53,16 +55,18 @@ jobs:
       - name: Collect kits to test
         id: collect
         run: |
-          # If tck/ or spec/ changed, run all kits
+          # Shared code or workflow changes run all kits
           tck_changed="${{ steps.filter.outputs.tck }}"
           spec_changed="${{ steps.filter.outputs.spec }}"
 
-          if [ "$tck_changed" = "true" ] || [ "$spec_changed" = "true" ]; then
+          workflows_changed="${{ steps.filter.outputs.workflows }}"
+
+          if [ "$tck_changed" = "true" ] || [ "$spec_changed" = "true" ] || [ "$workflows_changed" = "true" ]; then
             kits=$(for f in */spec.yaml */spec.yml; do [ -f "$f" ] && dirname "$f"; done | sort -u | jq -R . | jq -sc .)
           else
             # Only kits that changed
             changes='${{ steps.filter.outputs.changes }}'
-            kits=$(echo "$changes" | jq -r '.[]' | grep -vE '^(tck|spec|scripts)$' | jq -R . | jq -sc .)
+            kits=$(echo "$changes" | jq -r '.[]' | grep -vE '^(tck|spec|scripts|workflows)$' | jq -R . | jq -sc .)
           fi
 
           echo "kits=${kits:-[]}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
Download sbx once per channel per build, then share the archive across kit matrix legs. Failed-leg reruns reuse the prepared artifact; new builds fetch fresh packages.

Workflow changes now trigger all kits. Release gating remains unchanged.

## Test plan
- Workflow syntax, e2e lint, and seven mocked cases passed.
- CI: three archives shared across 141 successful e2e downloads/installations; release gate passed.
- ECC nightly/RC failures also occur on main. CodeQL JavaScript/TypeScript reports no source code.
