### PR TITLE
Add gitea kit

### DIFF
--- a/gitea/README.md
+++ b/gitea/README.md
@@ -1,0 +1,86 @@
+# gitea — Gitea instance auth
+
+A mixin kit that wires a [Gitea](https://about.gitea.com/) access token into the sandbox proxy, so an agent can use **git over HTTPS**, the **Gitea REST API**, and the **`tea` CLI** against your instance — self-hosted or `gitea.com` — without the token ever entering the container. Pairs with any base agent (claude, codex, gemini, …).
+
+Gitea is not one of sbx's built-in auto-sign-on services (GitHub is), so out of the box a sandbox has no Gitea credentials and `sbx secret set gitea` alone has nothing to bind to. This kit closes that gap: it declares a `gitea` credential and injects it into outbound requests to your instance at the proxy. The container only ever sees a proxy-managed placeholder in `GITEA_TOKEN`.
+
+## Usage
+
+Store a Gitea access token once on the host. It needs the `write:repository` scope, plus `write:issue` if the agent should work with issues and pull requests:
+
+```console
+sbx secret set gitea
+```
+
+Then create a sandbox with the kit, naming your instance:
+
+```console
+sbx run --kit "docker.io/sbx/gitea-kit:latest" --kit-arg gitea.host=git.example.com claude
+```
+
+Or target this repo directly over git, or a local clone:
+
+```console
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=gitea" --kit-arg gitea.host=git.example.com claude
+sbx run --kit ./gitea/ --kit-arg gitea.host=git.example.com claude
+```
+
+`gitea.host` defaults to `gitea.com`, so you can drop `--kit-arg` entirely if that is the instance you use.
+
+Verify inside the sandbox:
+
+```console
+tea login ls                                              # already logged in
+curl -s https://git.example.com/api/v1/user               # no auth header needed
+git clone https://git.example.com/<owner>/<private-repo>.git
+```
+
+## How auth works
+
+The kit declares a `gitea` credential with `proxyManaged: true`. Inside the container `GITEA_TOKEN` is a sentinel; on any request to your instance the proxy sets `Authorization: token <your-real-token>`. The real token never enters the sandbox filesystem or environment.
+
+The proxy injects that header on **every** request to the host, including one that carries no `Authorization` header of its own. That is what makes plain `curl` work with no auth argument — and it is also what makes git work, because git's first `GET /info/refs` arrives at Gitea already authenticated instead of coming back 401. No credential helper, no SSH key, no token in the remote URL.
+
+### The `tea` CLI
+
+[`tea`](https://gitea.com/gitea/tea) is installed from a version- and SHA256-pinned release (no `curl | sh`), and its login is seeded at install time pointing at your instance.
+
+The stored token is the same sentinel that lives in `GITEA_TOKEN`, so `tea` sends `Authorization: token <sentinel>` — and the proxy replaces that header wholesale before the request leaves the sandbox. The proxy deliberately overrides any client-supplied credential on a managed host rather than trusting it, which is what makes seeding a placeholder login safe.
+
+The login is written directly rather than through `tea login add`, because `tea login add` calls the instance to validate the token and would fail sandbox creation whenever no credential is bound.
+
+To bump the pinned version, change `TEA_VERSION` and both per-arch checksums in `spec.yaml`, sourced from `https://dl.gitea.com/tea/<version>/tea-<version>-linux-<arch>.sha256`.
+
+### Why git over HTTPS works here, but not in the `gitlab` kit
+
+The sibling [`gitlab`](../gitlab/) kit cannot do this and tells users to fall back to SSH. The difference is on the Gitea side, and it is worth spelling out because it is the one non-obvious decision in this spec.
+
+The engine builds a service's auth config from **`credentials[].apiKey.inject[0]` only** — one header per credential, later inject entries are never read. So a kit gets exactly one `Authorization` format for a host, and it has to serve both the API and git smart-HTTP, which GitLab serves from that same host. GitLab's git endpoint wants Basic; its API wants Bearer; one rule cannot be both.
+
+Gitea does not force the choice. `Authorization: token <t>` is handled by Gitea's `OAuth2` auth method, and Gitea registers its git-over-HTTP routes with that method enabled — see [`routers/web/web.go`](https://github.com/go-gitea/gitea/blob/main/routers/web/web.go), where `addOwnerRepoGitHTTPRouters` is passed `webAuth.AllowOAuth2` alongside `AllowBasic`, under a comment noting that sessionless auth exists precisely for "accessing git via http". One `token %s` rule therefore authenticates both surfaces.
+
+### Why not `scheme: basic`
+
+The spec documents a `scheme: basic` sugar with a `username` field, which looks like the obvious fit for git-over-HTTPS. Do not use it: it is a decode-time sugar with no runtime behind it. Normalization expands it to `Format: "%s"` and leaves `Header` empty; that empty header name is carried through to the proxy's service detector, which discards any auth config without a header name — and the request then goes out unauthenticated, silently. `inject[].username` has no consumer at all. (GitHub's Basic git auth is a hardcoded special case in the proxy for `github.com`, not something a kit can ask for.)
+
+## If auth does not seem to be applied
+
+The engine injects a credential only into a domain that appears in **both** the kit's `inject[].domain` and *your* `allowedDomains` for the service in `~/.config/sbx/credentials.yaml`. Because this kit's domain is whatever you passed to `--kit-arg gitea.host=…`, sandbox creation prompts you to approve it the first time. Declining is not an error — the credential is simply not injected, and requests go out unauthenticated.
+
+`sbx policy log <sandbox>` is the authoritative view of what the proxy actually evaluated.
+
+## Instances not on port 443
+
+`gitea.host` accepts a port, so an instance running without a reverse proxy can be named directly:
+
+```console
+sbx run --kit ./gitea/ --kit-arg gitea.host=git.example.com:3000 claude
+```
+
+The value flows into both the network allow-list entry and the credential's inject domain, and the proxy's domain matcher does rank a port-specific pattern above a port-agnostic one. This path is less travelled than the plain-443 one — if injection does not fire, `sbx policy log` will show it.
+
+## Cleanup
+
+```console
+sbx secret rm -g --service gitea
+```

--- a/gitea/spec.yaml
+++ b/gitea/spec.yaml
@@ -1,0 +1,177 @@
+# Docker Sandboxes kit for a Gitea instance.
+# Usage, prerequisites and design notes: see README.md in this directory.
+schemaVersion: "2"
+kind: mixin
+name: gitea
+version: "0.1.0"
+displayName: Gitea
+description: Wires a Gitea access token into the sandbox proxy so git-over-HTTPS and the Gitea API both authenticate against your instance, self-hosted or gitea.com. The token stays on the host.
+licenses:
+  - MIT
+
+# Which Gitea instance this sandbox talks to. Overridable at install time:
+#   sbx run --kit docker.io/sbx/gitea-kit:latest --kit-arg gitea.host=git.example.com claude
+args:
+  host:
+    default: "gitea.com"
+    description: >-
+      Hostname of the Gitea instance, without a scheme or path (for example
+      git.example.com). Defaults to gitea.com, Gitea's own hosted instance.
+    # A bare hostname, optionally with a port for an instance that is not
+    # behind a reverse proxy on 443 (the common `:3000` deployment).
+    pattern: '^[A-Za-z0-9]([A-Za-z0-9.-]*[A-Za-z0-9])?(:[0-9]{1,5})?$'
+
+credentials:
+  # One credential, one inject rule -- deliberately. The engine reads
+  # ApiKey.Inject[0] and nothing else (sandboxlib/kit/agent.go,
+  # GetServiceAuthConfig: "multi-header services should have one credential per
+  # header"), so a second rule on the same domain would be silently ignored.
+  # That, not auth-scheme sniffing, is why the sibling `gitlab` kit could not
+  # cover git-over-HTTPS and the API at once. Gitea does not need two rules --
+  # see README, "How auth works".
+  - service: gitea
+    description: Gitea access token with the `write:repository` scope (add `write:issue` for issue/PR work). Stored on the host; the sandbox only sees a placeholder and the proxy injects the real value on requests to the instance.
+    required: true
+    apiKey:
+      # proxyManaged sets GITEA_TOKEN to the sentinel inside the container. The
+      # proxy replaces the Authorization header with the real token on outbound
+      # requests to the instance, and on no other host.
+      name: GITEA_TOKEN
+      proxyManaged: true
+      inject:
+        - domain: "${{ kit.args.host }}"
+          # `token %s` rather than the `scheme: bearer` sugar: this is Gitea's
+          # own documented header form, and Gitea's OAuth2 auth method accepts
+          # it on the API *and* on the git-over-HTTP routes.
+          #
+          # Do NOT reach for `scheme: basic` here. It is a decode-time sugar
+          # with no runtime behind it: normalizeV2 expands it to Format "%s"
+          # and leaves Header empty, GetServiceAuthConfig copies that empty
+          # header through, and the proxy's SetAuthHeaderFormat discards a
+          # config with an empty header name -- the request then goes out
+          # unauthenticated. `inject[].username` has no consumer at all.
+          header: Authorization
+          format: "token %s"
+
+# Every destination the kit needs. e2e runs under deny-all, so a host that is
+# not listed here is blocked. SPEC-v2 5.2 also requires every inject domain to
+# appear in this list; the engine does not derive egress from credentials.
+permissions:
+  network:
+    allow:
+      - "${{ kit.args.host }}"
+      # The pinned `tea` binary and its checksum, fetched once at install time.
+      - dl.gitea.com
+
+environment:
+  variables:
+    # Never block on a git credential prompt in a non-interactive session. The
+    # proxy injects the Authorization header before the request leaves the
+    # sandbox, so git never sees a 401 and never needs a credential helper --
+    # but if the host is ever misconfigured, failing beats hanging.
+    GIT_TERMINAL_PROMPT: "0"
+
+agentInstructions:
+  content: |
+    ## Gitea
+
+    This sandbox is wired to the Gitea instance at `${{ kit.args.host }}`.
+
+    `GITEA_TOKEN` holds a sentinel value, not the real token: the sandbox proxy
+    swaps it for the real one on requests to that host, and nowhere else. Do
+    not read, print, or reconfigure it, and do not put it in a remote URL.
+
+    **Git over HTTPS works directly.** Clone, pull, and push with plain HTTPS
+    remotes -- no SSH key, no credential helper, no token in the URL:
+
+        git clone https://${{ kit.args.host }}/<owner>/<repo>.git
+        git push origin <branch>
+
+    The proxy adds the `Authorization` header on the way out, including on
+    git's first unauthenticated request, so private repositories work the same
+    as public ones.
+
+    **The REST API needs no auth header from you.** Send the request without
+    one and the proxy fills it in:
+
+        curl -s https://${{ kit.args.host }}/api/v1/user
+        curl -s https://${{ kit.args.host }}/api/v1/repos/<owner>/<repo>/pulls
+
+    Setting your own `Authorization` header is harmless -- the proxy replaces
+    it -- but it is never necessary.
+
+    **`tea`, Gitea's CLI, is installed and already logged in** against this
+    host. Use it for the things it models well -- `tea pr`, `tea issue`,
+    `tea repo`, `tea login ls` -- and `tea api` or `curl` for anything it does
+    not cover. Its stored token is the same sentinel; do not try to "fix" it.
+
+setup:
+  install:
+    # Install tea from a pinned, digest-verified Gitea release (same pattern as
+    # the sibling `gitlab` kit: no curl|sh, version AND SHA256 pinned in git).
+    # To bump: change TEA_VERSION plus the per-arch SHA256 below, sourced from
+    # https://dl.gitea.com/tea/<version>/tea-<version>-linux-<arch>.sha256
+    - command: |
+        set -euo pipefail
+        TEA_VERSION=0.15.1
+        ARCH=$(dpkg --print-architecture)
+        case "$ARCH" in
+          amd64)
+            SHA256="aac99cc6e650a81ae7b5061f8c75bc0eade4509c828d97b6072e1f0a3bd24357"
+            ;;
+          arm64)
+            SHA256="0db109df6696bfe01f9203402f503404692404d4ea9c16a540ecaeecc8e6bab2"
+            ;;
+          *)
+            echo "unsupported sandbox arch: $ARCH (expected amd64 or arm64)" >&2
+            exit 1
+            ;;
+        esac
+        URL="https://dl.gitea.com/tea/${TEA_VERSION}/tea-${TEA_VERSION}-linux-${ARCH}"
+        curl --proto '=https' --tlsv1.2 -fsSL -o /tmp/tea "$URL"
+        echo "${SHA256}  /tmp/tea" | sha256sum -c -
+        install -m 0755 /tmp/tea /usr/local/bin/tea
+        rm -f /tmp/tea
+        tea --version
+      user: "0"
+      description: "Install tea v0.15.1, version+digest pinned"
+
+    # Seed tea's login so it starts out authenticated. Written directly rather
+    # than via `tea login add`, which calls the instance to validate the token
+    # and would fail sandbox creation whenever no credential is bound (the e2e
+    # case). Runs as the agent user so the file needs no chown afterwards, and
+    # writes the literal home path because $HOME is not guaranteed here.
+    #
+    # The token written here is whatever GITEA_TOKEN holds -- the proxy-managed
+    # sentinel -- so tea sends `Authorization: token <sentinel>` and the proxy
+    # replaces it. Nothing secret is on disk.
+    #
+    # printf rather than a heredoc: this is a YAML block scalar, so a heredoc
+    # body would have to stay indented and tea would read back a config that is
+    # itself indented into nonsense.
+    - command: |
+        set -euo pipefail
+        if [ -z "${GITEA_TOKEN:-}" ]; then
+          echo "GITEA_TOKEN unset (mode=${SBX_CRED_GITEA_MODE:-none}); skipping tea login" >&2
+          exit 0
+        fi
+        mkdir -p /home/agent/.config/tea
+        cfg=/home/agent/.config/tea/config.yml
+        : > "$cfg"
+        chmod 0600 "$cfg"
+        printf 'logins:\n' >> "$cfg"
+        printf '  - name: sbx\n' >> "$cfg"
+        printf '    url: https://%s\n' '${{ kit.args.host }}' >> "$cfg"
+        printf '    token: %s\n' "$GITEA_TOKEN" >> "$cfg"
+        printf '    default: true\n' >> "$cfg"
+        printf '    ssh_host: ""\n' >> "$cfg"
+        printf '    ssh_key: ""\n' >> "$cfg"
+        printf '    insecure: false\n' >> "$cfg"
+        printf '    ssh_agent: false\n' >> "$cfg"
+        # No self-update check: unrelated egress, and the version is whatever
+        # this kit pinned above.
+        printf '    version_check: false\n' >> "$cfg"
+        printf '    user: ""\n' >> "$cfg"
+        printf '    created: 0\n' >> "$cfg"
+      user: "1000"
+      description: "Point tea at the instance, authenticated with the proxy-managed sentinel"


### PR DESCRIPTION
## Summary

Adds `gitea/`, a `kind: mixin` kit that wires a Gitea access token into the sandbox proxy so an agent can use **git over HTTPS**, the **Gitea REST API**, and the **`tea` CLI** against a Gitea instance — self-hosted or `gitea.com` — with the token never entering the container.

The instance hostname is a kit argument (`--kit-arg gitea.host=git.example.com`, defaulting to `gitea.com`), so one kit serves any deployment.

## Spec choices worth flagging for review

**1. One inject rule covers git-over-HTTPS *and* the API — unlike the sibling `gitlab` kit.**

`gitlab/README.md` documents that it can only do API auth and pushes users to SSH for git. That limitation does not carry over, and the reason is on Gitea's side rather than the proxy's: `Authorization: token <t>` is handled by Gitea's `OAuth2` auth method, and Gitea registers its git-over-HTTP routes with that method enabled — [`routers/web/web.go`](https://github.com/go-gitea/gitea/blob/main/routers/web/web.go) passes `webAuth.AllowOAuth2` into `addOwnerRepoGitHTTPRouters`, under a comment noting sessionless auth exists precisely for "accessing git via http". So a single `header: Authorization` / `format: "token %s"` rule authenticates both surfaces, and no `gitea-ssh` companion kit is needed.

This has now been confirmed against a running self-hosted instance (see test plan), not just read out of the router source.

**2. Deliberately *not* using `scheme: basic`.**

`scheme: basic` plus `username` looks like the natural fit for git-over-HTTPS, but it is a decode-time sugar with nothing behind it. Normalization expands it to `Format: "%s"` and leaves `Header` empty; that empty header name is carried through into the proxy's service detector, which discards any auth config without one — so the request goes out **unauthenticated, silently**. `inject[].username` has no consumer. GitHub's Basic git auth is a hardcoded proxy special case for `github.com`, not something a kit can request.

Both the spec comments and the README say so, so the next author doesn't rediscover it the hard way. Arguably the spec should reject `scheme: basic` at validation time rather than accept it into a no-op — happy to file that separately if maintainers agree.

**3. `tea`'s login is seeded by writing its config file, not by `tea login add`.**

`tea login add` contacts the instance to validate the token, so it would 401 and fail `sbx create` whenever no credential is bound. The e2e run under `deny-all` exercises exactly that path and confirms the guard: the step exits 0 in 11ms with `mode=none` and sandbox creation proceeds.

The config is written with `printf` rather than a heredoc because the command is a YAML block scalar and a heredoc body would have to stay indented.

**4. Single inject entry is load-bearing, not incidental.** The engine reads `ApiKey.Inject[0]` and nothing else, so a second rule on the same domain would be silently ignored. Called out in a comment so nobody "helpfully" adds one.

## Test plan

`scripts/test-kit.sh` and `scripts/test-kit-e2e.sh` both pass locally on macOS/arm64. Since CI skips the e2e legs on fork PRs, the local e2e run is the only place those assertions have executed — it is green.

What the e2e run establishes beyond the standard assertions:

- **Network contract under `deny-all`**: the pinned `tea` download completes, so `dl.gitea.com` is the complete install-time egress set — nothing silently blocked.
- **Graceful no-credential path**: with no binding, the login-seeding step skips cleanly and `sbx create` still succeeds.
- `agentContext` lands at `kits-agent-context/gitea.md`.

Verified against a **live self-hosted instance** with a real token bound:

- `GITEA_TOKEN` inside the container holds the sentinel, not the token.
- `curl https://<host>/api/v1/user` authenticates with **no** auth header set by the client.
- `tea repos ls` authenticates — the proxy replaces tea's own `Authorization: token <sentinel>`.
- `git clone` of a **private** repo over HTTPS, and `git push`, both succeed with no credential helper, no SSH key, and no token in the remote URL. (A public repo was deliberately not used as the test: it would clone unauthenticated and prove nothing.)

Also checked while authoring:

- Arg substitution against a non-default host, including the `host:port` form (`git.example.com:3000`).
- `tea` 0.15.1 checksums verified out of band; the generated config parses (`tea login ls`, `tea login default` resolve).
- Captured the raw request `tea` emits against a local listener to confirm it sends `Authorization: token <token>` — i.e. exactly the header the inject rule targets, so no sentinel can leak upstream.

## Origin

Written against the repo's `spec/SPEC-v2.md` and the `kit-author` skill, using `gitlab/` as the structural template. The auth design came from reading Gitea's auth chain and the sbx proxy's credential-injection path rather than from trial and error.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
