### PR TITLE
Add Cloudsmith repository, CLI, and dependency firewall kits

### DIFF
--- a/cloudsmith-cli/README.md
+++ b/cloudsmith-cli/README.md
@@ -7,7 +7,7 @@ Installs the [`cloudsmith` CLI](https://github.com/cloudsmith-io/cloudsmith-cli)
 Store the API key once (optional; without it the CLI installs and `cloudsmith whoami` reports no user):
 
 ```console
-sbx secret set cloudsmith-api-key -t <api-key>
+sbx secret set cloudsmith-api-key
 ```
 
 Create a sandbox, usually with the pull kit:
@@ -15,6 +15,8 @@ Create a sandbox, usually with the pull kit:
 ```console
 sbx run claude --kit "docker.io/sbx/cloudsmith-repo-kit:latest" --kit "docker.io/sbx/cloudsmith-cli-kit:latest" --kit-arg cloudsmith-repo.path=/acme/prod .
 ```
+
+The Git examples require `github.com/docker/` in Docker's `kit.allowedSources` setting. Preserve any existing allowed sources when adding it; see [Restrict kit sources](https://docs.docker.com/ai/sandboxes/customize/kits/#restrict-kit-sources).
 
 Or from git or a local clone:
 
@@ -39,32 +41,48 @@ cloudsmith list packages ORG/REPO
 | --- | --- | --- |
 | `cli-version` | `1.27.0` | A release number, or `latest` |
 
+## Authentication
+
+On first use, approve `api.cloudsmith.io` in the credential-binding prompt. For unattended runs, create the binding beforehand by running interactively once or configuring [credential bindings](https://docs.docker.com/ai/sandboxes/configuration/credentials/#credential-bindings). Without an approved binding, the API key is withheld.
+
+The optional `cloudsmith-api-key` is stored on the host as shown in [Usage](#usage). The proxy adds `X-Api-Key: <key>` to requests to `api.cloudsmith.io`, from the CLI or any other process. Inside the sandbox, `CLOUDSMITH_API_KEY` holds `proxy-managed`.
+
+Bind a least-privilege service-account key: every process in the sandbox can exercise its permissions. Without a key, the CLI still installs, but authenticated API operations are unavailable. API access is separate from the repository entitlement token used by `cloudsmith-repo`.
+
 ## How it works
 
 ```mermaid
 flowchart TB
-    subgraph sandbox["Sandbox"]
-        direction TB
-        kit["cloudsmith-cli kit"]
-        args["args: cli-version<br/>(pinned default, or latest)"]
-        auth["auth: API key<br/>added by the sandbox proxy on api.cloudsmith.io"]
-        s1["Downloads the pinned installer script<br/>and checks its SHA256"]
-        s2["Installer fetches the release manifest<br/>for the requested version"]
-        s3["Verifies the archive against the manifest<br/>and installs the CLI"]
-        s4["cloudsmith CLI ready<br/>cloudsmith whoami works, no key in the sandbox"]
-        kit --> s1 --> s2 --> s3 --> s4
-        kit ~~~ args
-        kit ~~~ auth
+    subgraph SETUP["SETUP · Sandbox creation"]
+        direction LR
+        FETCH("Download installer<br/>Verify SHA256")
+        INSTALL("Install CLI<br/>Verify release archive")
+        READY(["CLI ready<br/>cloudsmith --version"])
+        FETCH --> INSTALL --> READY
     end
-    style sandbox stroke:#e03131,stroke-width:2px,fill:#ffffff
-    style kit stroke:#e03131,stroke-width:2px,fill:#ffffff
-    style args stroke:#1971c2,stroke-width:2px,fill:#ffffff
-    style auth stroke:#2f9e44,stroke-width:2px,fill:#ffffff
+
+    subgraph REQUEST["RUNTIME · API command"]
+        direction LR
+        CLI("cloudsmith command")
+        PROXY("Sandbox proxy<br/>Inject bound API key")
+        API("Cloudsmith API<br/>Apply key permissions")
+        RESULT(["API response"])
+        CLI --> PROXY --> API --> RESULT
+    end
+
+    SETUP --> REQUEST
+
+    classDef neutral fill:#f8fafc,stroke:#94a3b8,color:#0f172a;
+    classDef accent fill:#ecfdf5,stroke:#10b981,color:#065f46,stroke-width:2px;
+    classDef success fill:#ecfdf5,stroke:#34d399,color:#065f46;
+    class FETCH,CLI neutral;
+    class INSTALL,PROXY,API accent;
+    class READY,RESULT success;
+    style SETUP fill:transparent,stroke:#94a3b8,stroke-dasharray:4 4
+    style REQUEST fill:transparent,stroke:#94a3b8,stroke-dasharray:4 4
 ```
 
 - **Install.** The kit downloads Cloudsmith's [installer script](https://github.com/cloudsmith-io/cloudsmith-cli-install-script) (version and SHA256 pinned in the spec) to a file and checks the digest. The script fetches the release manifest for `cli-version` from the public `cloudsmith/cli` repository, verifies the archive against it, and installs under `/opt/cloudsmith-cli`. The kit symlinks `/usr/local/bin/cloudsmith`. Nothing is piped into `sh`, nothing comes from PyPI.
-- **Auth.** The proxy adds `X-Api-Key: <key>` to every request to `api.cloudsmith.io`, from the CLI or any other process. Inside the sandbox `CLOUDSMITH_API_KEY` holds `proxy-managed`.
-- **Authority.** Whatever the key may do (publish, delete, change policies), the sandbox may do. Bind a least-privilege service-account key. This is why the kit is separate: `cloudsmith-repo` alone has no API host and no API credential.
 - **Bumping.** Installer: change `INSTALLER_VERSION` and `INSTALLER_SHA256` from its `SHA256SUMS`. CLI: change the `cli-version` default.
 
 ### Why these domains

--- a/cloudsmith-cli/README.md
+++ b/cloudsmith-cli/README.md
@@ -1,0 +1,93 @@
+# cloudsmith-cli
+
+Installs the [`cloudsmith` CLI](https://github.com/cloudsmith-io/cloudsmith-cli) and sends a Cloudsmith API key to `api.cloudsmith.io` through the sandbox proxy. Companion to [`cloudsmith-repo`](https://github.com/docker/sbx-kits-contrib/tree/main/cloudsmith-repo), which pulls packages and carries no API access. Compose this kit only when the agent needs the API (list, inspect, publish). Works with any base agent.
+
+## Usage
+
+Store the API key once (optional; without it the CLI installs and `cloudsmith whoami` reports no user):
+
+```console
+sbx secret set cloudsmith-api-key -t <api-key>
+```
+
+Create a sandbox, usually with the pull kit:
+
+```console
+sbx run claude --kit "docker.io/sbx/cloudsmith-repo-kit:latest" --kit "docker.io/sbx/cloudsmith-cli-kit:latest" --kit-arg cloudsmith-repo.path=/acme/prod .
+```
+
+Or from git or a local clone:
+
+```console
+sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=cloudsmith-cli" .
+sbx run claude --kit ./cloudsmith-cli/ .
+```
+
+Inside the sandbox:
+
+```console
+cloudsmith --version
+cloudsmith whoami
+cloudsmith list packages ORG/REPO
+```
+
+## Arguments
+
+`--kit-arg cloudsmith-cli.<name>=<value>`.
+
+| Argument | Default | Value |
+| --- | --- | --- |
+| `cli-version` | `1.27.0` | A release number, or `latest` |
+
+## How it works
+
+```mermaid
+flowchart TB
+    subgraph sandbox["Sandbox"]
+        direction TB
+        kit["cloudsmith-cli kit"]
+        args["args: cli-version<br/>(pinned default, or latest)"]
+        auth["auth: API key<br/>added by the sandbox proxy on api.cloudsmith.io"]
+        s1["Downloads the pinned installer script<br/>and checks its SHA256"]
+        s2["Installer fetches the release manifest<br/>for the requested version"]
+        s3["Verifies the archive against the manifest<br/>and installs the CLI"]
+        s4["cloudsmith CLI ready<br/>cloudsmith whoami works, no key in the sandbox"]
+        kit --> s1 --> s2 --> s3 --> s4
+        kit ~~~ args
+        kit ~~~ auth
+    end
+    style sandbox stroke:#e03131,stroke-width:2px,fill:#ffffff
+    style kit stroke:#e03131,stroke-width:2px,fill:#ffffff
+    style args stroke:#1971c2,stroke-width:2px,fill:#ffffff
+    style auth stroke:#2f9e44,stroke-width:2px,fill:#ffffff
+```
+
+- **Install.** The kit downloads Cloudsmith's [installer script](https://github.com/cloudsmith-io/cloudsmith-cli-install-script) (version and SHA256 pinned in the spec) to a file and checks the digest. The script fetches the release manifest for `cli-version` from the public `cloudsmith/cli` repository, verifies the archive against it, and installs under `/opt/cloudsmith-cli`. The kit symlinks `/usr/local/bin/cloudsmith`. Nothing is piped into `sh`, nothing comes from PyPI.
+- **Auth.** The proxy adds `X-Api-Key: <key>` to every request to `api.cloudsmith.io`, from the CLI or any other process. Inside the sandbox `CLOUDSMITH_API_KEY` holds `proxy-managed`.
+- **Authority.** Whatever the key may do (publish, delete, change policies), the sandbox may do. Bind a least-privilege service-account key. This is why the kit is separate: `cloudsmith-repo` alone has no API host and no API credential.
+- **Bumping.** Installer: change `INSTALLER_VERSION` and `INSTALLER_SHA256` from its `SHA256SUMS`. CLI: change the `cli-version` default.
+
+### Why these domains
+
+| Domain | Why |
+| --- | --- |
+| `api.cloudsmith.io` | Cloudsmith API, key added as `X-Api-Key` |
+| `dl.cloudsmith.io` | Installer script, release manifest and CLI archive from Cloudsmith's public repositories |
+
+`dl.cloudsmith.io` is a literal so the install works when the pull kit uses a custom download domain. It is shared by every public Cloudsmith repository.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `cloudsmith whoami` shows no user | No key bound, or the key was rejected | `sbx secret set cloudsmith-api-key -t <api-key>`, recreate |
+| CLI commands fail to connect | `api.cloudsmith.io` denied by a policy above the kit | `sbx policy log <sandbox>` |
+| Install step exits 1 | Download or checksum failure, or `cli-version` does not exist | `sbx policy log <sandbox>`; check the version under `https://dl.cloudsmith.io/public/cloudsmith/cli/` |
+
+## Cleanup
+
+```console
+sbx secret rm cloudsmith-api-key -f
+```
+
+`/opt/cloudsmith-cli` disappears with `sbx rm <sandbox>`.

--- a/cloudsmith-cli/spec.yaml
+++ b/cloudsmith-cli/spec.yaml
@@ -1,0 +1,89 @@
+schemaVersion: "2"
+kind: mixin
+name: cloudsmith-cli
+displayName: Cloudsmith CLI
+description: Installs the cloudsmith CLI via Cloudsmith's verified installer, with a proxy-injected API key.
+
+# `--kit-arg cloudsmith-cli.cli-version=<value>` is substituted textually into
+# the install script, so the pattern is the shell-safety boundary.
+args:
+  cli-version:
+    default: "1.27.0"   # or latest
+    description: cloudsmith CLI version to install, a release number or "latest"
+    pattern: '^(latest|[0-9]+\.[0-9]+\.[0-9]+)$'
+
+# Companion to the `cloudsmith-repo` kit, kept separate on purpose: the pull kit
+# carries only a read-only entitlement token and the download/format hosts,
+# while this kit adds the API host and an API key whose authority is whatever
+# the key's owner can do (publish, delete, manage). Compose it only when the
+# agent should talk to the Cloudsmith API, and bind a least-privilege
+# service-account key: `sbx secret set cloudsmith-api-key`.
+
+permissions:
+  network:
+    allow:
+      # cloudsmith CLI API traffic (`cloudsmith whoami`, `cloudsmith list ...`).
+      - api.cloudsmith.io
+      # Install-time download of the pinned CLI tarball from Cloudsmith's own
+      # public cloudsmith/cli repository. A literal host: it must work even
+      # when the pull kit is configured for a custom download domain.
+      - dl.cloudsmith.io
+
+credentials:
+  # Optional: the CLI installs without it and `cloudsmith whoami` reports
+  # unauthenticated. The container only sees the placeholder in
+  # CLOUDSMITH_API_KEY; the proxy adds the real key to every request that
+  # reaches api.cloudsmith.io, whether or not it came from the CLI.
+  - service: cloudsmith-api-key
+    description: Cloudsmith API key for the cloudsmith CLI (use a least-privilege service account)
+    required: false
+    apiKey:
+      name: CLOUDSMITH_API_KEY
+      proxyManaged: true
+      inject:
+        # cloudsmith-cli sends the API key in X-Api-Key (cloudsmith_cli/core/api/init.py).
+        - domain: api.cloudsmith.io
+          header: X-Api-Key
+          format: "%s"
+
+agentInstructions:
+  content: |
+    ## Cloudsmith CLI
+
+    The `cloudsmith` CLI is installed. `CLOUDSMITH_API_KEY` holds a
+    placeholder; the sandbox proxy adds the real API key to requests to
+    api.cloudsmith.io, so run the CLI directly and do not pass `-k`.
+
+    Quick checks: `cloudsmith --version`, `cloudsmith whoami`,
+    `cloudsmith list packages ORG/REPO`. Whether pushes work depends on
+    the permissions of the key the host bound. If `cloudsmith whoami`
+    reports no user, either no key is bound or the key was rejected: report
+    that instead of supplying one.
+
+setup:
+  install:
+    # Cloudsmith's own standalone installer (cloudsmith-io/cloudsmith-cli-install-script),
+    # pinned by version and SHA256 and run from a file, never piped into sh. It
+    # detects the target, fetches the release manifest for the requested
+    # version from the same public repository, verifies the archive checksum
+    # against it and installs into a versioned directory under /opt. The kit
+    # then symlinks the binary into PATH, which the script deliberately does
+    # not do. Only dl.cloudsmith.io is contacted. To bump the installer: change
+    # INSTALLER_VERSION plus INSTALLER_SHA256, from the release's SHA256SUMS in
+    # the same repository. The CLI version is the `cli-version` argument.
+    - command: |
+        set -euo pipefail
+        INSTALLER_VERSION=0.1.2
+        INSTALLER_SHA256="b2183b9e245ca1cf0685a9090cfc6d0bba7266c4e4c43d8c3be0f17aa00bc5be"
+        curl --proto '=https' --tlsv1.2 -fsSL -o /tmp/cloudsmith-cli-install.sh \
+          "https://dl.cloudsmith.io/public/cloudsmith/cloudsmith-cli-install-script/raw/versions/${INSTALLER_VERSION}/cli.sh"
+        echo "${INSTALLER_SHA256}  /tmp/cloudsmith-cli-install.sh" | sha256sum -c -
+        sh /tmp/cloudsmith-cli-install.sh --version '${{ kit.args.cli-version }}' \
+          --install-root /opt/cloudsmith-cli --output-file /tmp/cloudsmith-cli-install.env
+        exe=$(awk -F= '$1 == "executable" { sub(/^[^=]*=/, ""); print; exit }' /tmp/cloudsmith-cli-install.env)
+        [ -x "$exe" ] || { echo "installer reported no executable" >&2; exit 1; }
+        ln -sfn "$exe" /usr/local/bin/cloudsmith
+        rm -f /tmp/cloudsmith-cli-install.sh /tmp/cloudsmith-cli-install.env
+        cloudsmith --version
+      user: "0"
+      description: Install the cloudsmith CLI with Cloudsmith's pinned installer script

--- a/cloudsmith-dependency-firewall/README.md
+++ b/cloudsmith-dependency-firewall/README.md
@@ -85,6 +85,15 @@ Docker Hub is denied too, so `docker run alpine` inside the sandbox fails unless
 
 To deny more hosts, add rules on the host with `sbx policy deny network <host>` (add `--sandbox <name>` to scope them) or fork the kit and extend `permissions.network.deny`.
 
+### Composing with other kits
+
+Deny wins over every kit's allowlist, so kits that fetch from a public registry during install or startup change behavior:
+
+- Kits that `npm install` or `pip install` at install time (in this repo: `t3code`, `playwright`, `kernel`, `ecc`, `claude-mem`, `smolagents`) fail `sbx create` with the firewall alone. List `cloudsmith-repo` before them and give the repository npm and PyPI upstreams; their installs then go through the repository (verified: a later kit's install step sees `NPM_CONFIG_REGISTRY` and `PIP_INDEX_URL`, as root and as agent).
+- Kits that pull images from Docker Hub (`qemu`, `openclaw`, `nanoclaw`) break. Image names are not redirected; mirror the images in Cloudsmith or leave the firewall out.
+- Runtime `npx` launchers (`claude-acp`, `codex-acp`) work only with `cloudsmith-repo` composed.
+- `packages-through-sfw` replaces the `npm` and `pip` binaries with shims; stacking it with these kits is untested.
+
 ### Why these domains
 
 The kit allows nothing. It denies:
@@ -97,7 +106,7 @@ The kit allows nothing. It denies:
 | `index.crates.io`, `static.crates.io`, `crates.io` | crates.io index, downloads, legacy site |
 | `repo1.maven.org`, `repo.maven.apache.org` | Maven Central |
 | `api.nuget.org`, `www.nuget.org`, `globalcdn.nuget.org`, `azuresearch-usnc.nuget.org`, `azuresearch-ussc.nuget.org` | nuget.org v3 feed, legacy v2 feed, download CDN, search hosts |
-| `registry-1.docker.io`, `auth.docker.io`, `production.cloudflare.docker.com`, `index.docker.io` | Docker Hub registry, token endpoint, blob CDN, legacy index |
+| `registry-1.docker.io`, `auth.docker.io`, `production.cloudfront.docker.com`, `production.cloudflare.docker.com`, `index.docker.io` | Docker Hub registry, token endpoint, both blob CDN names, legacy index |
 
 ## Cleanup
 

--- a/cloudsmith-dependency-firewall/README.md
+++ b/cloudsmith-dependency-firewall/README.md
@@ -10,6 +10,8 @@ Compose it with `cloudsmith-repo`:
 sbx run claude --kit "docker.io/sbx/cloudsmith-repo-kit:latest" --kit "docker.io/sbx/cloudsmith-dependency-firewall-kit:latest" --kit-arg cloudsmith-repo.path=/acme/prod .
 ```
 
+The Git examples require `github.com/docker/` in Docker's `kit.allowedSources` setting. Preserve any existing allowed sources when adding it; see [Restrict kit sources](https://docs.docker.com/ai/sandboxes/customize/kits/#restrict-kit-sources).
+
 Or from git or a local clone:
 
 ```console
@@ -28,25 +30,43 @@ On the host, `sbx policy log <sandbox>` shows `pypi.org` as `denied: rule "kit:<
 
 ## How it works
 
+This kit takes no arguments and carries no credentials. Configure the repository and its authentication through `cloudsmith-repo` using the [usage examples](#usage). The flow below shows the named registry hosts this kit denies and the Cloudsmith hosts allowed by the composed policy; other hosts remain subject to that policy.
+
 ```mermaid
 flowchart TB
-    subgraph sandbox["Sandbox"]
-        direction TB
-        kit["cloudsmith-dependency-firewall kit"]
-        args["args: none"]
-        auth["auth: none"]
-        s1["Adds deny rules for the public registries:<br/>PyPI, npmjs, Go mirror, crates.io,<br/>Maven Central, nuget.org, Docker Hub"]
-        s2["Sandbox proxy: a deny rule wins<br/>over any allow from other kits"]
-        s3["A tool falling back to a public registry<br/>is blocked, visible in sbx policy log"]
-        s4["Pulls through the Cloudsmith repository<br/>(cloudsmith-repo kit) keep working"]
-        kit --> s1 --> s2 --> s3 --> s4
-        kit ~~~ args
-        kit ~~~ auth
+    subgraph SETUP["SETUP · Sandbox creation"]
+        direction LR
+        COMPOSE("Compose kits<br/>Repository + firewall")
+        RULES("Add registry deny rules")
+        POLICY(["Policy active<br/>Deny overrides allow"])
+        COMPOSE --> RULES --> POLICY
     end
-    style sandbox stroke:#e03131,stroke-width:2px,fill:#ffffff
-    style kit stroke:#e03131,stroke-width:2px,fill:#ffffff
-    style args stroke:#1971c2,stroke-width:2px,fill:#ffffff
-    style auth stroke:#2f9e44,stroke-width:2px,fill:#ffffff
+
+    subgraph REQUEST["RUNTIME · Package request"]
+        direction LR
+        CLIENT("Package client")
+        PROXY{"Sandbox proxy<br/>Destination host?"}
+        CLOUDSMITH(["Cloudsmith<br/>Repository policy applies"])
+        BLOCK("403 · Blocked<br/>Record in policy log")
+        REPORT("Report failure<br/>Keep registry settings")
+        CLIENT --> PROXY
+        PROXY -->|Allowed| CLOUDSMITH
+        PROXY -->|Denied registry| BLOCK
+        BLOCK --> REPORT
+    end
+
+    SETUP --> REQUEST
+
+    classDef neutral fill:#f8fafc,stroke:#94a3b8,color:#0f172a;
+    classDef accent fill:#faf5ff,stroke:#a855f7,color:#581c87,stroke-width:2px;
+    classDef success fill:#ecfdf5,stroke:#34d399,color:#065f46;
+    classDef failure fill:#fff7ed,stroke:#fb923c,color:#9a3412;
+    class COMPOSE,CLIENT neutral;
+    class RULES,POLICY,PROXY accent;
+    class CLOUDSMITH success;
+    class BLOCK,REPORT failure;
+    style SETUP fill:transparent,stroke:#94a3b8,stroke-dasharray:4 4
+    style REQUEST fill:transparent,stroke:#94a3b8,stroke-dasharray:4 4
 ```
 
 - **Deny wins.** `permissions.network.deny` beats any `allow` from the base agent or another kit, and lists only append across kits. A stale lockfile, a project `.npmrc` or a `--index-url` flag hits a policy block instead of a public registry.

--- a/cloudsmith-dependency-firewall/README.md
+++ b/cloudsmith-dependency-firewall/README.md
@@ -1,0 +1,84 @@
+# cloudsmith-dependency-firewall
+
+Denies the public package registries at the sandbox proxy: PyPI, npm, the Go mirror, crates.io, Maven Central, nuget.org and Docker Hub. Package clients cannot fall back to them and must use the repository that [`cloudsmith-repo`](https://github.com/docker/sbx-kits-contrib/tree/main/cloudsmith-repo) configured. No arguments, no credentials, no install steps.
+
+## Usage
+
+Compose it with `cloudsmith-repo`:
+
+```console
+sbx run claude --kit "docker.io/sbx/cloudsmith-repo-kit:latest" --kit "docker.io/sbx/cloudsmith-dependency-firewall-kit:latest" --kit-arg cloudsmith-repo.path=/acme/prod .
+```
+
+Or from git or a local clone:
+
+```console
+sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=cloudsmith-repo" --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=cloudsmith-dependency-firewall" --kit-arg cloudsmith-repo.path=/acme/prod .
+sbx run claude --kit ./cloudsmith-repo/ --kit ./cloudsmith-dependency-firewall/ --kit-arg cloudsmith-repo.path=/acme/prod .
+```
+
+Inside the sandbox, a public registry is blocked and the same install works through Cloudsmith:
+
+```console
+curl -sS -o /dev/null -w '%{http_code}\n' https://pypi.org/simple/     # 403
+pip download --no-deps -d /tmp <package-in-the-repo>                   # served by Cloudsmith
+```
+
+On the host, `sbx policy log <sandbox>` shows `pypi.org` as `denied: rule "kit:<sandbox>:deny"`.
+
+## How it works
+
+```mermaid
+flowchart TB
+    subgraph sandbox["Sandbox"]
+        direction TB
+        kit["cloudsmith-dependency-firewall kit"]
+        args["args: none"]
+        auth["auth: none"]
+        s1["Adds deny rules for the public registries:<br/>PyPI, npmjs, Go mirror, crates.io,<br/>Maven Central, nuget.org, Docker Hub"]
+        s2["Sandbox proxy: a deny rule wins<br/>over any allow from other kits"]
+        s3["A tool falling back to a public registry<br/>is blocked, visible in sbx policy log"]
+        s4["Pulls through the Cloudsmith repository<br/>(cloudsmith-repo kit) keep working"]
+        kit --> s1 --> s2 --> s3 --> s4
+        kit ~~~ args
+        kit ~~~ auth
+    end
+    style sandbox stroke:#e03131,stroke-width:2px,fill:#ffffff
+    style kit stroke:#e03131,stroke-width:2px,fill:#ffffff
+    style args stroke:#1971c2,stroke-width:2px,fill:#ffffff
+    style auth stroke:#2f9e44,stroke-width:2px,fill:#ffffff
+```
+
+- **Deny wins.** `permissions.network.deny` beats any `allow` from the base agent or another kit, and lists only append across kits. A stale lockfile, a project `.npmrc` or a `--index-url` flag hits a policy block instead of a public registry.
+- **Separate on purpose.** `cloudsmith-repo` alone is a redirect; the public registries stay reachable if the base agent allows them. This kit removes that network path. Adopt the redirect first, add enforcement with one extra `--kit`.
+- **Agent note** (`kits-agent-context/cloudsmith-dependency-firewall.md`): report a package that cannot be installed (ecosystem, name, version, host, status) instead of changing registry settings or fetching from a URL.
+
+### What it does not block
+
+sbx policy is per hostname. The kit blocks the named endpoints, not "everything except one repository":
+
+- Other public repositories on a shared Cloudsmith host such as `dl.cloudsmith.io`. Custom download domains narrow this to one organization.
+- Anything the base agent or another kit allows: GitHub archives, `go get` with `GOPROXY=direct`, apt mirrors, ecosystems the pull kit does not configure (RubyGems, Conda, Composer, Hex).
+- Warm local caches (`~/.npm`, `GOMODCACHE`, `~/.cargo/registry`).
+
+Docker Hub is denied too, so `docker run alpine` inside the sandbox fails unless the image is mirrored in Cloudsmith, and kits whose startup pulls from Docker Hub (for example `qemu`) break.
+
+To deny more hosts, add rules on the host with `sbx policy deny network <host>` (add `--sandbox <name>` to scope them) or fork the kit and extend `permissions.network.deny`.
+
+### Why these domains
+
+The kit allows nothing. It denies:
+
+| Denied | Why |
+| --- | --- |
+| `pypi.org`, `files.pythonhosted.org` | PyPI index and file host |
+| `registry.npmjs.org`, `registry.npmjs.com`, `registry.yarnpkg.com` | npm registry, the `.com` alias Cloudsmith redirects unknown packages to, Yarn classic's default |
+| `proxy.golang.org` | Go module mirror |
+| `index.crates.io`, `static.crates.io`, `crates.io` | crates.io index, downloads, legacy site |
+| `repo1.maven.org`, `repo.maven.apache.org` | Maven Central |
+| `api.nuget.org`, `www.nuget.org`, `globalcdn.nuget.org`, `azuresearch-usnc.nuget.org`, `azuresearch-ussc.nuget.org` | nuget.org v3 feed, legacy v2 feed, download CDN, search hosts |
+| `registry-1.docker.io`, `auth.docker.io`, `production.cloudflare.docker.com`, `index.docker.io` | Docker Hub registry, token endpoint, blob CDN, legacy index |
+
+## Cleanup
+
+Nothing on the host. The deny rules disappear with `sbx rm <sandbox>`. Rules added with `sbx policy deny network` are removed with `sbx policy rm`.

--- a/cloudsmith-dependency-firewall/spec.yaml
+++ b/cloudsmith-dependency-firewall/spec.yaml
@@ -1,0 +1,85 @@
+schemaVersion: "2"
+kind: mixin
+name: cloudsmith-dependency-firewall
+displayName: Cloudsmith dependency firewall
+description: Denies the public package registries at the proxy so clients cannot fall back from Cloudsmith.
+
+# Enforcement half of the Cloudsmith pair. Compose it after the
+# `cloudsmith-repo` kit, which points pip/uv, npm, Go, cargo, Maven, NuGet, Docker and curl at a
+# Cloudsmith repository:
+#
+#   sbx run claude --kit <cloudsmith> --kit <cloudsmith-dependency-firewall> .
+#
+# `permissions.network.deny` wins over any `allow` from the base agent or other
+# kits, and the lists only append across kits, so a tool that silently falls
+# back to a public registry (a stale lockfile, a per-project .npmrc, an
+# unpinned `pip install` in a script) hits a policy block visible in
+# `sbx policy log` instead of bypassing Cloudsmith. Kept as its own mixin so
+# `cloudsmith-repo` alone stays permissive for teams that only want the redirect.
+# The `cloudsmith-cli` kit's install is unaffected: it downloads from
+# dl.cloudsmith.io, which this kit does not deny.
+
+permissions:
+  network:
+    deny:
+      # PyPI simple index. Blocks `pip`/`uv` resolving against the public index
+      # when a --index-url flag or a project config overrides the kit's PIP_INDEX_URL.
+      - pypi.org
+      # PyPI file host. Wheels and sdists are served from here, not pypi.org,
+      # so denying only the index would still let direct-URL downloads through.
+      - files.pythonhosted.org
+      # npm public registry. Blocks npm/pnpm/yarn falling back to it via a
+      # per-project .npmrc or a lockfile with hard-coded public resolved URLs.
+      - registry.npmjs.org
+      # Same registry under its .com alias. Cloudsmith answers a request for a
+      # package its npm repository does not hold (and has no upstream for)
+      # with a 302 to https://registry.npmjs.com/<pkg>; verified in-sandbox.
+      - registry.npmjs.com
+      # Yarn classic's default registry, a mirror of registry.npmjs.org that
+      # yarn v1 uses unless told otherwise.
+      - registry.yarnpkg.com
+      # Go module mirror. Blocks the `GOPROXY` default and the `,direct`
+      # fallback chain's first hop when GOPROXY is unset in a subshell.
+      - proxy.golang.org
+      # crates.io: the sparse index, the crate download host and the legacy
+      # site cargo falls back to when a project overrides the kit's source
+      # replacement.
+      - index.crates.io
+      - static.crates.io
+      - crates.io
+      # Maven Central under both of its names (a pom.xml <repository> or a
+      # settings.xml without the kit's mirror would reach them).
+      - repo1.maven.org
+      - repo.maven.apache.org
+      # nuget.org v3 feed and its flat-container CDN.
+      - api.nuget.org
+      # nuget.org legacy v2 feed (www.nuget.org/api/v2, still served) and the
+      # CDN its package downloads 302 to; both verified from the host. The v3
+      # service index also names the two Azure search hosts.
+      - www.nuget.org
+      - globalcdn.nuget.org
+      - azuresearch-usnc.nuget.org
+      - azuresearch-ussc.nuget.org
+      # Docker Hub: registry, token endpoint, blob CDN and legacy index.
+      - registry-1.docker.io
+      - auth.docker.io
+      - production.cloudflare.docker.com
+      - index.docker.io
+
+agentInstructions:
+  content: |
+    ## Cloudsmith: public registries denied
+
+    The public package registries (PyPI, npmjs, yarnpkg, the Go mirror,
+    crates.io, Maven Central, nuget.org, Docker Hub) are denied by sandbox
+    policy; a request to one fails with "Blocked by network policy". Package
+    and image traffic must go through the Cloudsmith repository the
+    `cloudsmith-repo` kit configured.
+
+    When a package cannot be installed, do not change registry or index
+    settings (`pip.conf`, `uv.toml`, `.npmrc`, `GOPROXY`, `--index-url`,
+    `--registry`) or fetch it from a direct URL or git instead. Report the
+    ecosystem, package, version, the host contacted and the status: 403 with
+    "quarantined" is a Cloudsmith policy decision, 404 means the repository
+    and its upstreams do not have it, "Blocked by network policy" means a
+    tool fell back to a denied host. Do not paste URLs that carry tokens.

--- a/cloudsmith-dependency-firewall/spec.yaml
+++ b/cloudsmith-dependency-firewall/spec.yaml
@@ -60,9 +60,11 @@ permissions:
       - globalcdn.nuget.org
       - azuresearch-usnc.nuget.org
       - azuresearch-ussc.nuget.org
-      # Docker Hub: registry, token endpoint, blob CDN and legacy index.
+      # Docker Hub: registry, token endpoint, both blob CDN names seen in
+      # redirects (cloudfront verified live on 2026-09-10), and the legacy index.
       - registry-1.docker.io
       - auth.docker.io
+      - production.cloudfront.docker.com
       - production.cloudflare.docker.com
       - index.docker.io
 

--- a/cloudsmith-repo/README.md
+++ b/cloudsmith-repo/README.md
@@ -1,6 +1,6 @@
 # cloudsmith-repo
 
-Points the sandbox's package managers at one [Cloudsmith](https://cloudsmith.com) repository. pip/uv, npm/pnpm/yarn, Go, cargo, Maven, NuGet, Docker and raw downloads all pull through it. The repository's vulnerability, license and deny policies decide what the agent gets. The read-only [entitlement token](https://docs.cloudsmith.com/software-distribution/entitlement-tokens) stays on the host and the sandbox proxy adds it to each request. Works with any base agent.
+Points the sandbox's package managers at one [Cloudsmith](https://cloudsmith.com) repository. pip/uv, npm/pnpm/yarn, Go, cargo, Maven, NuGet, Docker and raw downloads all pull through it. The repository's vulnerability, license and deny policies decide what the agent gets. The sandbox proxy authenticates requests using a read-only [entitlement token](https://docs.cloudsmith.com/software-distribution/entitlement-tokens) stored on the host. Works with any base agent.
 
 Companions: [`cloudsmith-cli`](https://github.com/docker/sbx-kits-contrib/tree/main/cloudsmith-cli) (the `cloudsmith` command and an API key), [`cloudsmith-dependency-firewall`](https://github.com/docker/sbx-kits-contrib/tree/main/cloudsmith-dependency-firewall) (deny the public registries).
 
@@ -9,7 +9,7 @@ Companions: [`cloudsmith-cli`](https://github.com/docker/sbx-kits-contrib/tree/m
 Store the repository's entitlement token once (skip for a public repository):
 
 ```console
-sbx secret set cloudsmith-entitlement-token -t <token>
+sbx secret set cloudsmith-entitlement-token
 ```
 
 Create a sandbox pointed at the repository:
@@ -18,6 +18,8 @@ Create a sandbox pointed at the repository:
 sbx run claude --kit "docker.io/sbx/cloudsmith-repo-kit:latest" --kit-arg cloudsmith-repo.path=/acme/prod .
 ```
 
+The Git examples require `github.com/docker/` in Docker's `kit.allowedSources` setting. Preserve any existing allowed sources when adding it; see [Restrict kit sources](https://docs.docker.com/ai/sandboxes/customize/kits/#restrict-kit-sources).
+
 Or from git or a local clone:
 
 ```console
@@ -25,12 +27,12 @@ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=cloudsmith
 sbx run claude --kit ./cloudsmith-repo/ --kit-arg cloudsmith-repo.path=/acme/prod .
 ```
 
-On the first create, sbx asks `[A]pprove all · [R]eview each · [N]o` for the hosts the token may be sent to. Answer `A`. Without a terminal there is no prompt: the credential is not sent and the install probe fails with 401.
+On first use, approve the configured Cloudsmith hosts in the credential-binding prompt. For unattended runs, create the binding beforehand by running interactively once or configuring [credential bindings](https://docs.docker.com/ai/sandboxes/configuration/credentials/#credential-bindings). Without an approved binding, the token is withheld and private repository access fails.
 
 Prerequisites:
 
 - The repository has [upstreams](https://docs.cloudsmith.com/repositories/upstreams) for the formats in use. Without them it serves only what was pushed.
-- Compose at create time with `--kit`. `sbx kit add` does not write the agent note.
+- Apply this kit when creating a sandbox with `--kit`. Recreate an existing sandbox to add it.
 - The base image has `npm` (all standard templates do). `~/.cargo/config.toml`, `~/.m2/settings.xml` and `~/.nuget/NuGet/NuGet.Config` are overwritten on every start.
 - Tested with sbx 0.42.x.
 
@@ -88,30 +90,53 @@ Per-format notes:
 
 Not covered: RubyGems, Conda, Composer, Hex, Dart, Swift, Conan, Terraform, apt, rpm. Same auth model, client setup not verified.
 
+## Authentication
+
+Private repositories use the `cloudsmith-entitlement-token` stored in the [usage steps](#usage); public repositories need no token. The sandbox proxy adds `Authorization: Bearer <token>` to requests to the configured Cloudsmith hosts. Inside the sandbox, `CLOUDSMITH_ENTITLEMENT_TOKEN` holds `proxy-managed`, and Cargo uses a placeholder token.
+
+Use a read-only token scoped to the repository. See [Security](#security) for the raw-download redirect limitation and token rotation guidance.
+
 ## How it works
 
 ```mermaid
 flowchart TB
-    subgraph sandbox["Sandbox"]
-        direction TB
-        kit["cloudsmith-repo kit"]
-        args["args: repository path,<br/>one host per format (custom domains)"]
-        auth["auth: entitlement token, read-only<br/>added by the sandbox proxy, never inside"]
-        s1["Points pip, npm, go, cargo, mvn,<br/>dotnet, docker at the repository<br/>(env vars + config files)"]
-        s2["Probe: is the repository reachable?<br/>no ⇒ sandbox creation stops with a reason"]
-        s3["Every download goes through the proxy<br/>to the Cloudsmith repository"]
-        s4["Repository policies apply<br/>quarantined version ⇒ 403, reported by the agent"]
-        kit --> s1 --> s2 --> s3 --> s4
-        kit ~~~ args
-        kit ~~~ auth
+    subgraph SETUP["SETUP · Sandbox creation"]
+        direction LR
+        CONFIG("Configure clients<br/>Repository URLs")
+        CHECK("Check access<br/>Python index · HEAD")
+        READY(["Agent ready"])
+        CONFIG --> CHECK
+        CHECK -->|200| READY
     end
-    style sandbox stroke:#e03131,stroke-width:2px,fill:#ffffff
-    style kit stroke:#e03131,stroke-width:2px,fill:#ffffff
-    style args stroke:#1971c2,stroke-width:2px,fill:#ffffff
-    style auth stroke:#2f9e44,stroke-width:2px,fill:#ffffff
+
+    subgraph REQUEST["RUNTIME · Package download"]
+        direction LR
+        CLIENT("Package client")
+        PROXY("Sandbox proxy<br/>Policy + credentials")
+        REPO("Cloudsmith<br/>Repository + upstreams")
+        DONE(["Package received"])
+        REPORT("Report failure<br/>Keep registry settings")
+        CLIENT --> PROXY
+        PROXY -->|Allowed| REPO
+        REPO -->|Success| DONE
+        PROXY -->|Denied| REPORT
+        REPO -->|401 / 403 / 404| REPORT
+    end
+
+    SETUP --> REQUEST
+
+    classDef neutral fill:#f8fafc,stroke:#94a3b8,color:#0f172a;
+    classDef accent fill:#eff6ff,stroke:#3b82f6,color:#1e3a8a,stroke-width:2px;
+    classDef success fill:#ecfdf5,stroke:#34d399,color:#065f46;
+    classDef failure fill:#fff7ed,stroke:#fb923c,color:#9a3412;
+    class CONFIG,CLIENT neutral;
+    class CHECK,PROXY,REPO accent;
+    class READY,DONE success;
+    class REPORT failure;
+    style SETUP fill:transparent,stroke:#94a3b8,stroke-dasharray:4 4
+    style REQUEST fill:transparent,stroke:#94a3b8,stroke-dasharray:4 4
 ```
 
-- **Auth at the proxy.** With the secret bound, the proxy adds `Authorization: Bearer <token>` to every request to the six hosts. That includes anonymous requests, and it overwrites any header the client sent. Inside the sandbox the variable holds `proxy-managed`.
 - **Probe.** The first install step sends `HEAD` to the Python index through the proxy. Anything but 200 stops creation: 401 (no token reached Cloudsmith), 403 (token rejected, or host denied by policy), 404 (wrong `path` for the domain level). It checks the download host only.
 - **Policy.** A version blocked by a [vulnerability](https://docs.cloudsmith.com/policy-management/vulnerability-policy), license or deny policy returns 403. Scanning is asynchronous and the CDN can serve a stale answer for about five minutes after a quarantine.
 - **Agent note** (`kits-agent-context/cloudsmith-repo.md`): report 401/403/404 with package, version, host and status; never switch a tool to a public registry.

--- a/cloudsmith-repo/README.md
+++ b/cloudsmith-repo/README.md
@@ -1,0 +1,159 @@
+# cloudsmith-repo
+
+Points the sandbox's package managers at one [Cloudsmith](https://cloudsmith.com) repository. pip/uv, npm/pnpm/yarn, Go, cargo, Maven, NuGet, Docker and raw downloads all pull through it. The repository's vulnerability, license and deny policies decide what the agent gets. The read-only [entitlement token](https://docs.cloudsmith.com/software-distribution/entitlement-tokens) stays on the host and the sandbox proxy adds it to each request. Works with any base agent.
+
+Companions: [`cloudsmith-cli`](https://github.com/docker/sbx-kits-contrib/tree/main/cloudsmith-cli) (the `cloudsmith` command and an API key), [`cloudsmith-dependency-firewall`](https://github.com/docker/sbx-kits-contrib/tree/main/cloudsmith-dependency-firewall) (deny the public registries).
+
+## Usage
+
+Store the repository's entitlement token once (skip for a public repository):
+
+```console
+sbx secret set cloudsmith-entitlement-token -t <token>
+```
+
+Create a sandbox pointed at the repository:
+
+```console
+sbx run claude --kit "docker.io/sbx/cloudsmith-repo-kit:latest" --kit-arg cloudsmith-repo.path=/acme/prod .
+```
+
+Or from git or a local clone:
+
+```console
+sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=cloudsmith-repo" --kit-arg cloudsmith-repo.path=/acme/prod claude
+sbx run claude --kit ./cloudsmith-repo/ --kit-arg cloudsmith-repo.path=/acme/prod .
+```
+
+On the first create, sbx asks `[A]pprove all · [R]eview each · [N]o` for the hosts the token may be sent to. Answer `A`. Without a terminal there is no prompt: the credential is not sent and the install probe fails with 401.
+
+Prerequisites:
+
+- The repository has [upstreams](https://docs.cloudsmith.com/repositories/upstreams) for the formats in use. Without them it serves only what was pushed.
+- Compose at create time with `--kit`. `sbx kit add` does not write the agent note.
+- The base image has `npm` (all standard templates do). `~/.cargo/config.toml`, `~/.m2/settings.xml` and `~/.nuget/NuGet/NuGet.Config` are overwritten on every start.
+- Tested with sbx 0.42.x.
+
+## Arguments
+
+`--kit-arg cloudsmith-repo.<name>=<value>`. Values are substituted textually, so each pattern also keeps shell metacharacters out.
+
+| Argument | Default | Value |
+| --- | --- | --- |
+| `path` | `/cloudsmith/cli` | `/ORG/REPO` on `*.cloudsmith.io`; `/REPO` on a namespace-level [custom domain](https://docs.cloudsmith.com/workspaces/custom-domains); empty on a repository-level one |
+| `dl-host` | `dl.cloudsmith.io` | Download host: Python index, raw, Maven, NuGet packages, and every blob redirect |
+| `npm-host` | `npm.cloudsmith.io` | npm registry |
+| `go-host` | `golang.cloudsmith.io` | Go module proxy and checksum database |
+| `cargo-host` | `cargo.cloudsmith.io` | Cargo sparse index |
+| `nuget-host` | `nuget.cloudsmith.io` | NuGet v3 feed |
+| `docker-host` | `docker.cloudsmith.io` | Docker registry |
+
+The default `path` is Cloudsmith's public CLI repository, so the kit validates and installs with no inputs. Always set it.
+
+Custom domains: set `path` to the shorter form and override every host, all at the same level. Cloudsmith redirects npm, Go, cargo and Docker blobs to the organization's primary download domain, so a custom `dl-host` alone breaks the default hosts. Copy the hosts from the repository's setup page.
+
+```console
+sbx run claude --kit "docker.io/sbx/cloudsmith-repo-kit:latest" \
+  --kit-arg cloudsmith-repo.path=/prod \
+  --kit-arg cloudsmith-repo.dl-host=dl.acme.com --kit-arg cloudsmith-repo.npm-host=npm.acme.com \
+  --kit-arg cloudsmith-repo.go-host=go.acme.com --kit-arg cloudsmith-repo.cargo-host=cargo.acme.com \
+  --kit-arg cloudsmith-repo.nuget-host=nuget.acme.com --kit-arg cloudsmith-repo.docker-host=docker.acme.com .
+```
+
+## Supported formats
+
+`<dl>`, `<npm>`, `<go>`, `<cargo>`, `<nuget>` and `<docker>` stand for the host arguments, `<path>` for the `path` argument. No setting contains a credential. The proxy adds it.
+
+| Format | Tools | Configured by | Repository URL | Check inside the sandbox |
+| --- | --- | --- | --- | --- |
+| Python | pip, uv | `PIP_INDEX_URL`, `UV_DEFAULT_INDEX`, `PIP_NO_INPUT=1` | `https://<dl>/basic<path>/python/simple/` | `pip download --no-deps -d /tmp <pkg>` |
+| npm | npm, Yarn Classic, Yarn Berry, pnpm | `NPM_CONFIG_REGISTRY`, `YARN_NPM_REGISTRY_SERVER`, `~/.npmrc` (pnpm) | `https://<npm><path>/` | `npm view <pkg> version` |
+| Go | go | `GOPROXY` (no `,direct`) | `https://<go><path>/` | `GONOSUMDB=<prefix> go get <module>@<ver>` |
+| Cargo | cargo | `~/.cargo/config.toml` (crates.io replaced), dummy `CARGO_REGISTRIES_CLOUDSMITH_TOKEN` | `sparse+https://<cargo><path>/` | `cargo add <crate> && cargo fetch` |
+| Maven | mvn | `~/.m2/settings.xml` (`mirrorOf *`) | `https://<dl>/basic<path>/maven/` | `mvn -q dependency:resolve` |
+| NuGet | dotnet | `~/.nuget/NuGet/NuGet.Config` (`<clear/>`, one source) | `https://<nuget><path>/v3/index.json` | `dotnet restore` |
+| Docker | docker | nothing; host is in the image name | `<docker><path>/<image>:<tag>` | `docker pull <docker><path>/<image>:<tag>` |
+| Raw | curl | nothing | `https://<dl>/basic<path>/raw/names/<n>/versions/<v>/<file>` | `curl -fsSL -o f <url>` |
+
+Per-format notes:
+
+- **Python**: pip prints "No matching distribution found" for both 401 and 404; `pip -vvv` shows the status. uv reports 401, 403 and 404 distinctly.
+- **npm**: quarantine is `E403 Package is quarantined`; `npm view` still lists the version. A project `.npmrc` with `@scope:registry=` wins over the env var.
+- **Go**: the Go host answers 404, not 401, for a bad token or path. Private modules need `GONOSUMDB=<prefix>`; do not use `GOPRIVATE`, which bypasses the proxy.
+- **Cargo**: cargo needs some local token when the registry says `auth-required`; the kit sets a dummy and the proxy replaces the header.
+- **Maven**: uses the download host mirror (`/basic<path>/maven/`), which serves artifacts inline. Keep that mirror; `maven.cloudsmith.io` redirects every file to a signed URL.
+- **NuGet**: a 401 surfaces as `NU1301` on `repository-signatures/5.0.0/index.json`.
+- **Docker**: pull only. `docker push` needs an API key login.
+- **Raw**: pin versions. `versions/latest/` redirects with the entitlement token in the URL (see Security).
+
+Not covered: RubyGems, Conda, Composer, Hex, Dart, Swift, Conan, Terraform, apt, rpm. Same auth model, client setup not verified.
+
+## How it works
+
+```mermaid
+flowchart TB
+    subgraph sandbox["Sandbox"]
+        direction TB
+        kit["cloudsmith-repo kit"]
+        args["args: repository path,<br/>one host per format (custom domains)"]
+        auth["auth: entitlement token, read-only<br/>added by the sandbox proxy, never inside"]
+        s1["Points pip, npm, go, cargo, mvn,<br/>dotnet, docker at the repository<br/>(env vars + config files)"]
+        s2["Probe: is the repository reachable?<br/>no ⇒ sandbox creation stops with a reason"]
+        s3["Every download goes through the proxy<br/>to the Cloudsmith repository"]
+        s4["Repository policies apply<br/>quarantined version ⇒ 403, reported by the agent"]
+        kit --> s1 --> s2 --> s3 --> s4
+        kit ~~~ args
+        kit ~~~ auth
+    end
+    style sandbox stroke:#e03131,stroke-width:2px,fill:#ffffff
+    style kit stroke:#e03131,stroke-width:2px,fill:#ffffff
+    style args stroke:#1971c2,stroke-width:2px,fill:#ffffff
+    style auth stroke:#2f9e44,stroke-width:2px,fill:#ffffff
+```
+
+- **Auth at the proxy.** With the secret bound, the proxy adds `Authorization: Bearer <token>` to every request to the six hosts. That includes anonymous requests, and it overwrites any header the client sent. Inside the sandbox the variable holds `proxy-managed`.
+- **Probe.** The first install step sends `HEAD` to the Python index through the proxy. Anything but 200 stops creation: 401 (no token reached Cloudsmith), 403 (token rejected, or host denied by policy), 404 (wrong `path` for the domain level). It checks the download host only.
+- **Policy.** A version blocked by a [vulnerability](https://docs.cloudsmith.com/policy-management/vulnerability-policy), license or deny policy returns 403. Scanning is asynchronous and the CDN can serve a stale answer for about five minutes after a quarantine.
+- **Agent note** (`kits-agent-context/cloudsmith-repo.md`): report 401/403/404 with package, version, host and status; never switch a tool to a public registry.
+- **Scope.** sbx policy is per hostname. This kit allows hosts and configures clients; it does not prove every artifact came from the repository (pre-installed tools, caches, hosts other kits allow). For blocking the public registries, compose [`cloudsmith-dependency-firewall`](https://github.com/docker/sbx-kits-contrib/tree/main/cloudsmith-dependency-firewall).
+
+### Why these domains
+
+`permissions.network.allow` is the kit's complete outbound contract; CI runs e2e under `deny-all`.
+
+| Domain | Why |
+| --- | --- |
+| `<dl-host>` | Python index and wheels, raw, Maven, NuGet packages, and the pre-signed `/signed/...` redirects for npm, Go, cargo and Docker blobs |
+| `<npm-host>` | npm metadata |
+| `<go-host>` | Go module proxy and proxied `sum.golang.org` |
+| `<cargo-host>` | Cargo sparse index |
+| `<nuget-host>` | NuGet v3 service index, signatures, registration |
+| `<docker-host>` | Docker registry `/v2/` |
+
+Not allowed: `sum.golang.org` (proxied by Cloudsmith), `python.cloudsmith.io` (no read endpoints), `api.cloudsmith.io` (lives in `cloudsmith-cli`). `dl.cloudsmith.io` is shared by every public Cloudsmith repository; host-level policy cannot narrow it to one.
+
+## Security
+
+- The token is read-only and repository-scoped. Use one token per trust context.
+- One Cloudsmith endpoint leaks it: a raw `versions/latest/<file>` request returns a 302 whose `Location` contains the token. The kit cannot block a URL, so treat the token as extractable by a hostile agent. Rotation order: revoke in Cloudsmith, `sbx secret set` the new value, recreate sandboxes.
+- Pre-signed download URLs are short-lived bearer capabilities; keep them out of logs.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `sbx create` fails at the first install step with `exit 1` | Probe did not get 200; sbx hides the output and rolls the sandbox back | Create with `--name`, read `[cloudsmith-repo]` in the sandboxd daemon log, and `sbx policy log <name>` (survives the rollback) |
+| Probe 401 | No token reached Cloudsmith, or the approval prompt was declined | `sbx secret set cloudsmith-entitlement-token -t <token>`, recreate in a terminal, answer `A` |
+| Probe 403 | Token not valid for this repository, or `dl-host` denied by a policy above the kit | `sbx policy log <name>` first; then test the token from the host with `curl -I -H "Authorization: Bearer <token>" https://<dl>/basic<path>/python/simple/` |
+| Probe 404 | Wrong `path` for the domain level | `/ORG/REPO`, `/REPO` or empty |
+| Metadata works, downloads blocked on `dl.<custom>` | Organization has a custom download domain | Set every host argument to the custom domain |
+| 403 with "quarantined" | Repository policy | Check the package in Cloudsmith; do not use a public registry |
+| 404 for a package that exists publicly | No upstream for that format | Add a Cache and Proxy upstream |
+
+## Cleanup
+
+```console
+sbx secret rm cloudsmith-entitlement-token -f
+```
+
+Config files inside the sandbox disappear with `sbx rm <sandbox>`. Rotate the token when retiring a sandbox that ran untrusted code.

--- a/cloudsmith-repo/README.md
+++ b/cloudsmith-repo/README.md
@@ -33,6 +33,7 @@ Prerequisites:
 
 - The repository has [upstreams](https://docs.cloudsmith.com/repositories/upstreams) for the formats in use. Without them it serves only what was pushed.
 - Apply this kit when creating a sandbox with `--kit`. Recreate an existing sandbox to add it.
+- List this kit before kits whose install runs `npm` or `pip`; their installs then go through the repository. `bun` is not configured.
 - The base image has `npm` (all standard templates do). `~/.cargo/config.toml`, `~/.m2/settings.xml` and `~/.nuget/NuGet/NuGet.Config` are overwritten on every start.
 - Tested with sbx 0.42.x.
 

--- a/cloudsmith-repo/files/home/.cargo/config.toml
+++ b/cloudsmith-repo/files/home/.cargo/config.toml
@@ -1,0 +1,18 @@
+# Cargo config (added by sbx-kits-contrib/cloudsmith-repo). Replaces crates.io with the Cloudsmith
+# sparse registry so plain `cargo add` / `cargo build` resolve through the
+# repository. The token cargo requires locally comes from the environment
+# (CARGO_REGISTRIES_CLOUDSMITH_TOKEN, a placeholder the sandbox proxy
+# replaces); nothing secret lives in this file.
+
+[registries.cloudsmith]
+index = "sparse+https://${{ kit.args.cargo-host }}${{ kit.args.path }}/"
+credential-provider = "cargo:token"
+
+[source.crates-io]
+replace-with = "cloudsmith"
+
+[source.cloudsmith]
+registry = "sparse+https://${{ kit.args.cargo-host }}${{ kit.args.path }}/"
+
+[registry]
+global-credential-providers = ["cargo:token"]

--- a/cloudsmith-repo/files/home/.m2/settings.xml
+++ b/cloudsmith-repo/files/home/.m2/settings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Maven settings (added by sbx-kits-contrib/cloudsmith-repo). One mirror for everything (central,
+  plugin repositories and every <repository> declared in transitive POMs)
+  pointing at the Cloudsmith repository on its download host, which serves
+  Maven artifacts inline. Authentication is added by the sandbox proxy, so
+  there is no <servers> block and nothing secret in this file.
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 https://maven.apache.org/xsd/settings-1.2.0.xsd">
+  <mirrors>
+    <mirror>
+      <id>cloudsmith</id>
+      <name>Cloudsmith (mirror of everything)</name>
+      <mirrorOf>*</mirrorOf>
+      <url>https://${{ kit.args.dl-host }}/basic${{ kit.args.path }}/maven/</url>
+    </mirror>
+  </mirrors>
+</settings>

--- a/cloudsmith-repo/files/home/.nuget/NuGet/NuGet.Config
+++ b/cloudsmith-repo/files/home/.nuget/NuGet/NuGet.Config
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  NuGet config (added by sbx-kits-contrib/cloudsmith-repo). <clear /> removes the nuget.org source
+  dotnet would otherwise add, leaving the Cloudsmith v3 feed as the only one.
+  Authentication is added by the sandbox proxy; no credentials in this file.
+-->
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="cloudsmith" value="https://${{ kit.args.nuget-host }}${{ kit.args.path }}/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>

--- a/cloudsmith-repo/spec.yaml
+++ b/cloudsmith-repo/spec.yaml
@@ -1,0 +1,222 @@
+schemaVersion: "2"
+kind: mixin
+name: cloudsmith-repo
+displayName: Cloudsmith repository
+description: Pulls pip/uv, npm, Go, cargo, Maven, NuGet, Docker and raw artifacts through a Cloudsmith repo.
+
+# Arguments (`--kit-arg cloudsmith.<name>=<value>`) are substituted textually
+# into this file, files/ and the setup scripts before decoding, so each
+# `pattern` is also the shell-safety boundary: no accepted value can contain
+# quotes, whitespace, `$`, `;`, `&`, `|` or backticks.
+args:
+  path:
+    default: /cloudsmith/cli   # e.g. /acme/prod
+    description: >-
+      Repository path with a leading slash: /ORG/REPO on the *.cloudsmith.io
+      hosts, /REPO on a namespace-level custom domain, empty on a
+      repository-level one. The default is Cloudsmith's public CLI repository
+      so the kit validates and installs without credentials (see README).
+    pattern: '^(/[a-z0-9]([a-z0-9-]*[a-z0-9])?){0,2}$'
+  dl-host:
+    default: dl.cloudsmith.io
+    description: >-
+      Download host: Python index, raw files, Maven mirror, NuGet downloads and
+      every pre-signed blob redirect. Set to the custom download domain if the
+      organization has one; all hosts must then sit at the same domain level.
+    pattern: '^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$'
+  npm-host:
+    default: npm.cloudsmith.io
+    description: npm registry host
+    pattern: '^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$'
+  go-host:
+    default: golang.cloudsmith.io
+    description: Go module proxy host
+    pattern: '^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$'
+  cargo-host:
+    default: cargo.cloudsmith.io
+    description: Cargo sparse registry host
+    pattern: '^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$'
+  nuget-host:
+    default: nuget.cloudsmith.io
+    description: NuGet v3 feed host
+    pattern: '^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$'
+  docker-host:
+    default: docker.cloudsmith.io
+    description: Docker registry host
+    pattern: '^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$'
+
+permissions:
+  network:
+    allow:
+      # Python simple index and wheels, raw files, the Maven mirror (served
+      # inline here), NuGet package downloads, and the pre-signed `/signed/...`
+      # URLs that npm tarballs, Go zips, cargo crates and Docker blobs are
+      # redirected to. Verified under deny-all e2e for every format.
+      - "${{ kit.args.dl-host }}"
+      # npm registry metadata; tarballs redirect to the download host.
+      - "${{ kit.args.npm-host }}"
+      # Go module proxy plus the proxied checksum database
+      # (<go-host><path>/sumdb/sum.golang.org/...), so sum.golang.org itself
+      # is never contacted and is deliberately not allowed.
+      - "${{ kit.args.go-host }}"
+      # Cargo sparse index (config.json + index files); crates redirect to dl.
+      - "${{ kit.args.cargo-host }}"
+      # NuGet v3 service index, repository signatures, registration, search.
+      - "${{ kit.args.nuget-host }}"
+      # Docker registry /v2/ API: ping, token endpoint, manifests; blobs
+      # redirect to the download host.
+      - "${{ kit.args.docker-host }}"
+
+credentials:
+  # Entitlement tokens are Cloudsmith's read-only, repository-scoped download
+  # tokens: the right shape for a sandbox that only pulls. Optional, because
+  # a public repository (including the default) needs none. The proxy adds the
+  # header to every request it forwards to these hosts, anonymous ones
+  # included, so no tool inside the sandbox handles a credential.
+  #
+  # Bearer, not Basic: Cloudsmith accepts both, but sbx (0.42.x) flattens a
+  # Basic credential to a bare token, which Cloudsmith answers with 401. See
+  # README "Authentication happens at the proxy".
+  - service: cloudsmith-entitlement-token
+    description: Cloudsmith entitlement token (read-only, repository-scoped) for private repositories
+    required: false
+    apiKey:
+      name: CLOUDSMITH_ENTITLEMENT_TOKEN
+      proxyManaged: true
+      inject:
+        - domain: "${{ kit.args.dl-host }}"
+          header: Authorization
+          format: Bearer %s
+        - domain: "${{ kit.args.npm-host }}"
+          header: Authorization
+          format: Bearer %s
+        - domain: "${{ kit.args.go-host }}"
+          header: Authorization
+          format: Bearer %s
+        - domain: "${{ kit.args.cargo-host }}"
+          header: Authorization
+          format: Bearer %s
+        - domain: "${{ kit.args.nuget-host }}"
+          header: Authorization
+          format: Bearer %s
+        # The registry accepts a plain entitlement Bearer on /v2/, so the
+        # daemon never needs the /login flow.
+        - domain: "${{ kit.args.docker-host }}"
+          header: Authorization
+          format: Bearer %s
+
+environment:
+  # Static, argument-substituted values: the tools are told WHERE to look,
+  # never how to log in. Last-wins across composed kits.
+  variables:
+    # pip 26 prompts for a username on 401 and dies with EOFError without a
+    # TTY; PIP_NO_INPUT makes it fail cleanly instead.
+    PIP_NO_INPUT: "1"
+    PIP_INDEX_URL: "https://${{ kit.args.dl-host }}/basic${{ kit.args.path }}/python/simple/"
+    # uv ignores PIP_INDEX_URL; UV_DEFAULT_INDEX beats the deprecated UV_INDEX_URL.
+    UV_DEFAULT_INDEX: "https://${{ kit.args.dl-host }}/basic${{ kit.args.path }}/python/simple/"
+    # npm and Yarn Classic read this; pnpm reads ~/.npmrc (written at install
+    # below); Yarn Berry needs its own variable.
+    NPM_CONFIG_REGISTRY: "https://${{ kit.args.npm-host }}${{ kit.args.path }}/"
+    YARN_NPM_REGISTRY_SERVER: "https://${{ kit.args.npm-host }}${{ kit.args.path }}/"
+    # npm otherwise fetches <registry>/npm on most commands for its update check.
+    NPM_CONFIG_UPDATE_NOTIFIER: "false"
+    # Single URL on purpose: a `,direct` fallback would route modules to public
+    # sources whenever Cloudsmith answers 404 (also what a bad token looks like
+    # on the Go host).
+    GOPROXY: "https://${{ kit.args.go-host }}${{ kit.args.path }}/"
+    # Cloudsmith's cargo config.json says auth-required: true, so cargo refuses
+    # the registry unless SOME token is configured locally, and sends it
+    # verbatim in the Authorization header. Verified: the proxy overwrites that
+    # header with the real Bearer token for the cargo host regardless of the
+    # value; the value is a dummy. Registry name matches files/home/.cargo/config.toml.
+    CARGO_REGISTRIES_CLOUDSMITH_TOKEN: proxy-managed
+
+agentInstructions:
+  content: |
+    ## Cloudsmith repository
+
+    Package pulls go through a Cloudsmith repository (path `${{ kit.args.path }}`)
+    instead of the public registries. These tools are already pointed at it:
+
+    - **pip / uv**: `PIP_INDEX_URL`, `UV_DEFAULT_INDEX` (`https://${{ kit.args.dl-host }}/basic${{ kit.args.path }}/python/simple/`)
+    - **npm, Yarn Classic**: `NPM_CONFIG_REGISTRY`; **pnpm**: `~/.npmrc`; **Yarn Berry**: `YARN_NPM_REGISTRY_SERVER` (`https://${{ kit.args.npm-host }}${{ kit.args.path }}/`)
+    - **go**: `GOPROXY=https://${{ kit.args.go-host }}${{ kit.args.path }}/`
+    - **cargo**: `~/.cargo/config.toml` replaces crates.io with `sparse+https://${{ kit.args.cargo-host }}${{ kit.args.path }}/`; `cargo add` needs no `registry =` key
+    - **Maven**: `~/.m2/settings.xml` mirrors everything to `https://${{ kit.args.dl-host }}/basic${{ kit.args.path }}/maven/`
+    - **NuGet**: `~/.nuget/NuGet/NuGet.Config` has the single source `https://${{ kit.args.nuget-host }}${{ kit.args.path }}/v3/index.json`
+    - **Docker**: `docker pull ${{ kit.args.docker-host }}${{ kit.args.path }}/IMAGE:TAG`, no `docker login`
+    - **Raw files**: `curl -fsSL -o FILE https://${{ kit.args.dl-host }}/basic${{ kit.args.path }}/raw/names/NAME/versions/VERSION/FILE`. Do not use `versions/latest/`: its redirect copies the access token into the URL.
+
+    A failed download is not permission to change the source. Do not add
+    `--extra-index-url`, `@scope:registry`, `,direct` GOPROXY or extra NuGet
+    sources, and do not fetch packages from public registries, mirrors, direct
+    URLs or git dependencies instead. Read the status, then report it:
+
+    - 403 "quarantined" or "blocked": a Cloudsmith policy refused that version.
+    - 403 "Blocked by network policy": the host is outside the sandbox allowlist.
+    - 404: not in the repository or its upstreams; on the Go host also what a wrong path or token looks like.
+    - 401: no working token reached Cloudsmith. Do not supply one.
+
+    Report ecosystem, package, version, the host contacted and the status line.
+    Do not paste `Location` headers, pre-signed URLs or anything that looks like
+    a token. Useful next steps: pick an already-allowed version, propose a
+    dependency change, or ask the repository owner to check the policy.
+
+    The sandbox proxy adds authentication to every request to these hosts.
+    `CLOUDSMITH_ENTITLEMENT_TOKEN` and `CARGO_REGISTRIES_CLOUDSMITH_TOKEN` hold
+    placeholders. Do not put a token into a URL or config file, and do not pass
+    `-u`, `--token` or `docker login`: send nothing, the proxy does the rest.
+
+    Private Go modules (ones only this repository holds) need
+    `GONOSUMDB=<module prefix>`; do not use `GOPRIVATE`, which bypasses the proxy.
+    A project-level config (`.npmrc`, `.cargo/config.toml`, `nuget.config`,
+    `.mvn/`) that points elsewhere defeats the repository. Change it only when
+    the user asks for the project to move to Cloudsmith; otherwise report it.
+    The `cloudsmith` CLI comes from the `cloudsmith-cli` kit.
+
+setup:
+  install:
+    # Fail early when the repository is not reachable with the credentials the
+    # sandbox actually has, instead of the first `pip install` failing with an
+    # opaque 401 minutes later. A sandbox that cannot reach its only package
+    # source cannot do its job. HEAD on the Python simple index: every
+    # repository serves it (an empty index is still 200) and, with a PyPI
+    # upstream, a GET is a 52 MB merged listing. curl sends no credentials;
+    # the proxy adds the Bearer header, which is the path every later request
+    # takes. This checks the download host and index only, not the other
+    # format hosts or blob redirects. `sbx create` does not show this output;
+    # see README Troubleshooting.
+    - command: |
+        set -euo pipefail
+        URL='https://${{ kit.args.dl-host }}/basic${{ kit.args.path }}/python/simple/'
+        [ '${{ kit.args.path }}' = /cloudsmith/cli ] && echo "[cloudsmith-repo] Using the default public repository cloudsmith/cli. Set --kit-arg cloudsmith-repo.path=/ORG/REPO to use another repository." >&2
+        code=$(curl -sS -I -o /dev/null --max-time 30 --retry 2 --retry-connrefused -w '%{http_code}' "$URL") || code=000
+        case "$code" in
+          200) ;;
+          401)
+            echo "[cloudsmith-repo] HTTP 401 from ${URL}: no entitlement token reached Cloudsmith for this private repository. Run 'sbx secret set cloudsmith-entitlement-token -t <token>' on the host, then recreate the sandbox." >&2
+            exit 1 ;;
+          403)
+            echo "[cloudsmith-repo] HTTP 403 from ${URL}: the bound token was rejected for this repository, or the host is denied by sandbox policy. Run 'sbx policy log <sandbox>' first; if the host was allowed, bind a token that is valid for this repository and recreate the sandbox." >&2
+            exit 1 ;;
+          404)
+            echo "[cloudsmith-repo] HTTP 404 from ${URL}: repository not found. Set --kit-arg cloudsmith-repo.path to /ORG/REPO on *.cloudsmith.io, /REPO on a namespace-level custom domain, or empty on a repository-level one." >&2
+            exit 1 ;;
+          000)
+            echo "[cloudsmith-repo] No response from ${URL}. Check --kit-arg cloudsmith-repo.dl-host, then run 'sbx policy log <sandbox>' to see whether the host was blocked." >&2
+            exit 1 ;;
+          *)
+            echo "[cloudsmith-repo] Unexpected HTTP ${code} from ${URL}. Check the host and path arguments." >&2
+            exit 1 ;;
+        esac
+      user: "0"
+      description: Verify the Cloudsmith repository is reachable through the proxy
+    # pnpm ignores npm_config_registry (verified with pnpm 11) and reads
+    # ~/.npmrc; write the key with npm's own tool so it stays idempotent.
+    - command: |
+        set -euo pipefail
+        command -v npm >/dev/null || { echo "npm not found. This mixin needs a base image with Node.js; all standard agent templates include it." >&2; exit 1; }
+        npm config set registry 'https://${{ kit.args.npm-host }}${{ kit.args.path }}/'
+      user: "1000"
+      description: Point pnpm at the Cloudsmith npm registry via ~/.npmrc


### PR DESCRIPTION
## Summary

Adds three composable mixins for using Cloudsmith as a sandbox's package source, with API access and public-registry blocking available separately:

- `cloudsmith-repo` configures pip/uv, npm/pnpm/Yarn, Go, Cargo, Maven, and NuGet for a repository selected through kit arguments. It also documents Docker and raw-download URLs and uses a proxy-injected entitlement token for private repositories.
- `cloudsmith-cli` installs the Cloudsmith CLI through a pinned, checksum-verified installer and adds a separate proxy-injected API key.
- `cloudsmith-dependency-firewall` denies the named public registries so clients cannot fall back to those endpoints.


Example from a local checkout:

```console
sbx secret set cloudsmith-entitlement-token
sbx run claude \
  --kit ./cloudsmith-repo/ \
  --kit ./cloudsmith-dependency-firewall/ \
  --kit-arg cloudsmith-repo.path=/your-org/your-repo .
```

Add `--kit ./cloudsmith-cli/` and store `cloudsmith-api-key` when API access is needed. Approve the relevant credential bindings on first use.

## Spec choices worth flagging for review

- First kits to use `args` (relies on the TCK substitution from #279) and `permissions.network.deny`.
- Repository credentials and API credentials are separate services. Package downloads need only a read-only, repository-scoped entitlement token; API access carries the permissions of the bound key.
- The repository kit defaults to Cloudsmith's public CLI repository so installation can be tested without credentials. Users select their own repository through `path` and can override the format hosts for custom domains.
- An install-time probe fails sandbox creation when the repository index does not answer 200. `sbx create` does not show the step's output, so the README points at the daemon log.
- The entitlement token is injected as `Authorization: Bearer`. `scheme: basic` is not usable with sbx 0.42.1 (it sends a bare token).
- The firewall enforces hostname rules. It does not restrict shared Cloudsmith hosts to one repository or block every alternative package source. The README describes those boundaries.
- The documented raw `versions/latest` redirect can expose an entitlement token in its response URL. The README retains this limitation, recommends version-pinned raw downloads, and explains rotation. Proxy injection must not be treated as a guarantee that hostile sandbox code cannot recover the token.
- Cargo, Maven, and NuGet home configuration files are replaced by the kit; this is documented as a prerequisite.


## Test plan

- [x] `sbx kit validate` and `sbx kit pack` for all three kits.
- [x] `go test ./spec ./tck` and `./scripts/test-kit.sh <kit>` for each kit, including container installation checks.
- [x] `./scripts/test-kit-e2e.sh <kit>` for each kit under `deny-all`, using the isolated `sbx-kits-contrib-tck` daemon. Every entry in `network.allow` came from `sbx policy log`.
- [x] Manual smoke with real credentials against a private repository on custom domains: pip, npm, Go, raw and Docker pulls succeed with no credential in the sandbox; quarantined versions return 403; with the firewall kit, the public registries return 403 and appear in `sbx policy log` as denied by the kit's rule; `cloudsmith whoami` authenticates through the proxy.
