### PR TITLE
fix(spec): warn instead of reject legitimate apiKey shapes

### DIFF
--- a/skills/kit-author/topics/authoring.md
+++ b/skills/kit-author/topics/authoring.md
@@ -88,6 +88,7 @@ credentials:
     description: "GitHub Personal Access Token"
     apiKey:
       name: GITHUB_TOKEN
+      proxyManaged: true
       inject:
         - domain: api.github.com
           scheme: bearer

--- a/skills/kit-author/topics/lifecycle.md
+++ b/skills/kit-author/topics/lifecycle.md
@@ -212,7 +212,7 @@ Independent of the customizer chain. The proxy runs on the host (or in the VM) a
 - Routes outbound HTTPS by `credentials[].apiKey.inject[].domain` and `credentials[].oauth.tokenEndpoint`.
 - Injects credentials per `credentials[]` using the `inject[].header` / `format` declared in the spec.
 - Enforces `permissions.network.allow` / `deny` at policy-evaluation time. Use `sbx policy log <sandbox>` to see what the proxy blocked and what got through.
-- For sentinel-swap credentials (`apiKey.proxyManaged: true`, the default posture for `apiKey`), the proxy swaps the literal `proxy-managed` value for the real one per request. The container never sees the real credential.
+- For sentinel-swap credentials (opt in with `apiKey.proxyManaged: true`), the proxy swaps the literal `proxy-managed` value for the real one per request. The container never sees the real credential.
 
 The alternative — container-resident credentials — is necessary for signature-based auth (AWS SigV4) where the signature is over canonical headers the proxy doesn't see. Today that means writing the credential to a file inside the container; the kit's `permissions.network.allow` then bounds where the credential can be sent.
 

--- a/skills/kit-author/topics/lifecycle.md
+++ b/skills/kit-author/topics/lifecycle.md
@@ -212,7 +212,7 @@ Independent of the customizer chain. The proxy runs on the host (or in the VM) a
 - Routes outbound HTTPS by `credentials[].apiKey.inject[].domain` and `credentials[].oauth.tokenEndpoint`.
 - Injects credentials per `credentials[]` using the `inject[].header` / `format` declared in the spec.
 - Enforces `permissions.network.allow` / `deny` at policy-evaluation time. Use `sbx policy log <sandbox>` to see what the proxy blocked and what got through.
-- For sentinel-swap credentials (the default for `apiKey`), the proxy swaps the literal `proxy-managed` value for the real one per request. The container never sees the real credential.
+- For sentinel-swap credentials (`apiKey.proxyManaged: true`, the default posture for `apiKey`), the proxy swaps the literal `proxy-managed` value for the real one per request. The container never sees the real credential.
 
 The alternative — container-resident credentials — is necessary for signature-based auth (AWS SigV4) where the signature is over canonical headers the proxy doesn't see. Today that means writing the credential to a file inside the container; the kit's `permissions.network.allow` then bounds where the credential can be sent.
 

--- a/skills/kit-author/topics/pitfalls.md
+++ b/skills/kit-author/topics/pitfalls.md
@@ -92,7 +92,7 @@ When verifying `permissions.network.allow` enforcement, run `sbx policy log <san
 
 Two models:
 
-- **Sentinel-swap (proxy)** — the default for `credentials[].apiKey`. The engine sets `apiKey.name` inside the container to the literal `proxy-managed`; the proxy swaps the real value into the outbound request based on `apiKey.inject[]`. The container never sees the credential. Used by Anthropic, OpenAI, GitHub.
+- **Sentinel-swap (proxy)** — the default for `credentials[].apiKey`, opted into with `apiKey.proxyManaged: true`. The engine sets `apiKey.name` inside the container to the literal `proxy-managed`; the proxy swaps the real value into the outbound request based on `apiKey.inject[]`. The container never sees the credential. Used by Anthropic, OpenAI, GitHub.
 - **Container-resident (egress-bounded)** — the real credential lives in the container, restricted by `permissions.network.allow`. Used when signatures must be computed in-container — **AWS SigV4 forces this**, because the signature is over canonical headers the proxy doesn't see.
 
 Pick the right model for your service. Sentinel-swap is stricter; container-resident is necessary for SigV4-style auth.

--- a/skills/kit-author/topics/pitfalls.md
+++ b/skills/kit-author/topics/pitfalls.md
@@ -92,7 +92,7 @@ When verifying `permissions.network.allow` enforcement, run `sbx policy log <san
 
 Two models:
 
-- **Sentinel-swap (proxy)** — the default for `credentials[].apiKey`, opted into with `apiKey.proxyManaged: true`. The engine sets `apiKey.name` inside the container to the literal `proxy-managed`; the proxy swaps the real value into the outbound request based on `apiKey.inject[]`. The container never sees the credential. Used by Anthropic, OpenAI, GitHub.
+- **Sentinel-swap (proxy)** — opt in with `apiKey.proxyManaged: true`. The engine sets `apiKey.name` inside the container to the literal `proxy-managed`; the proxy swaps the real value into the outbound request based on `apiKey.inject[]`. The container never sees the credential. Used by Anthropic, OpenAI, GitHub.
 - **Container-resident (egress-bounded)** — the real credential lives in the container, restricted by `permissions.network.allow`. Used when signatures must be computed in-container — **AWS SigV4 forces this**, because the signature is over canonical headers the proxy doesn't see.
 
 Pick the right model for your service. Sentinel-swap is stricter; container-resident is necessary for SigV4-style auth.

--- a/skills/kit-author/topics/spec-anatomy.md
+++ b/skills/kit-author/topics/spec-anatomy.md
@@ -260,9 +260,9 @@ credentials:
 
 **Enforcement:** every `apiKey.inject[].domain` MUST appear in `permissions.network.allow`. There is no auto-derived egress from credentials. `sbx kit validate` warns (but does not fail) when it detects an uncovered domain; the engine performs the authoritative enforcement, and a missing domain surfaces at load or sandbox-create time (SPEC-v2 §6).
 
-An inject entry MUST also set at least one of `header` or `username` — one with neither has nothing for the proxy to inject and fails `sbx kit validate`. A `header`-bearing entry with no `username` MUST also set `format`, or there is no template to substitute the credential into. `username` MUST NOT contain `:` — HTTP Basic (RFC 7617) treats the first colon as the user/password delimiter, so a colon-bearing username can't authenticate as declared; `sbx kit validate` rejects it.
+An inject entry SHOULD set at least one of `header` or `username` — one with neither injects nothing into requests and only maps the domain to the credential's service for routing/policy purposes; that's a legitimate shape (e.g. associating a domain with a service without a header to inject), but `sbx kit validate` warns since it usually means a forgotten `header`/`username`. A `header`-bearing entry with no `username` MUST also set `format`, or there is no template to substitute the credential into. `username` MUST NOT contain `:` — HTTP Basic (RFC 7617) treats the first colon as the user/password delimiter, so a colon-bearing username can't authenticate as declared; `sbx kit validate` rejects it.
 
-`apiKey.name` is REQUIRED on a v2 spec, and whenever it's set (v1 or v2) it MUST be a valid shell identifier — letters, digits, underscores, not starting with a digit — since the engine uses it as an environment-variable name.
+Whenever `apiKey.name` is set (v1 or v2) it MUST be a valid shell identifier — letters, digits, underscores, not starting with a digit — since the engine uses it as an environment-variable name. An empty `name` on a v2 spec is a legitimate shape too — the credential is handled entirely proxy-side, with no in-container environment variable — so `sbx kit validate` warns rather than rejects it.
 
 ### OAuth shape
 

--- a/skills/kit-author/topics/spec-anatomy.md
+++ b/skills/kit-author/topics/spec-anatomy.md
@@ -227,7 +227,8 @@ credentials:
     description: "Anthropic API key"           # surfaced in interactive prompts
     required: false                            # resolver fails fast if true and unbound
     apiKey:
-      name: ANTHROPIC_API_KEY                  # env var the proxy populates in-container
+      name: ANTHROPIC_API_KEY                  # env var the engine names
+      proxyManaged: true                       # required for the engine to set the sentinel in-container
       inject:
         - domain: api.anthropic.com
           header: x-api-key
@@ -235,6 +236,7 @@ credentials:
   - service: github
     apiKey:
       name: GITHUB_TOKEN
+      proxyManaged: true
       inject:
         - domain: api.github.com
           scheme: bearer                       # sugar for header: Authorization, format: "Bearer %s"
@@ -243,7 +245,7 @@ credentials:
           username: x-access-token             # required with scheme: basic
 ```
 
-`apiKey.name` is set to the literal `proxy-managed` inside the container by the engine — the sentinel-swap proxy replaces it on outbound requests. Authors **don't** put real values in the spec.
+With `proxyManaged: true`, `apiKey.name` is set to the literal `proxy-managed` inside the container by the engine — the sentinel-swap proxy replaces it on outbound requests. Authors **don't** put real values in the spec.
 
 ### `scheme` — header-encoding sugar (v2)
 
@@ -262,7 +264,7 @@ credentials:
 
 An inject entry SHOULD set at least one of `header` or `username` — one with neither injects nothing into requests and only maps the domain to the credential's service for routing/policy purposes; that's a legitimate shape (e.g. associating a domain with a service without a header to inject), but `sbx kit validate` warns since it usually means a forgotten `header`/`username`. A `header`-bearing entry with no `username` MUST also set `format`, or there is no template to substitute the credential into. `username` MUST NOT contain `:` — HTTP Basic (RFC 7617) treats the first colon as the user/password delimiter, so a colon-bearing username can't authenticate as declared; `sbx kit validate` rejects it.
 
-Whenever `apiKey.name` is set (v1 or v2) it MUST be a valid shell identifier — letters, digits, underscores, not starting with a digit — since the engine uses it as an environment-variable name. An empty `name` on a v2 spec is a legitimate shape too — the credential is handled entirely proxy-side, with no in-container environment variable — so `sbx kit validate` warns rather than rejects it.
+Whenever `apiKey.name` is set (v1 or v2) it MUST be a valid shell identifier — letters, digits, underscores, not starting with a digit — since the engine uses it as an environment-variable name. Setting `name` alone does not populate it in-container: the engine only derives the sentinel when `proxyManaged: true` is also set. An empty `name` on a v2 spec is a legitimate shape too — the credential is handled entirely proxy-side, with no in-container environment variable — so `sbx kit validate` warns rather than rejects it.
 
 ### OAuth shape
 
@@ -356,7 +358,7 @@ Port publishing is **inbound service exposure** — a separate concern from outb
 
 ## `environment` (P2)
 
-The block is **P2** because v2 removed its `proxyManaged` field as part of the credentials redesign — the proxy-managed semantic now lives implicitly on `credentials[].apiKey.name`.
+The block is **P2** because v2 removed its `proxyManaged` field as part of the credentials redesign — the proxy-managed semantic now lives on `credentials[].apiKey.proxyManaged` (paired with `apiKey.name`).
 
 ```yaml
 environment:
@@ -366,7 +368,7 @@ environment:
 
 Composition: `variables` union with last-wins.
 
-The proxy-managed env-var semantic that lived under `environment.proxyManaged` in v1 is now implicit on `credentials[].apiKey.name`. There's no `proxyManaged` list to maintain separately.
+The proxy-managed env-var semantic that lived under `environment.proxyManaged` in v1 now lives on `credentials[].apiKey.proxyManaged`. There's no `proxyManaged` list to maintain separately.
 
 ### Reserved env-var prefixes
 

--- a/skills/kit-author/topics/v1-migration.md
+++ b/skills/kit-author/topics/v1-migration.md
@@ -230,6 +230,7 @@ credentials:
   - service: anthropic
     apiKey:
       name: ANTHROPIC_API_KEY
+      proxyManaged: true           # required to preserve v1's environment.proxyManaged behavior
       inject:
         - domain: api.anthropic.com
           header: x-api-key
@@ -240,7 +241,7 @@ The discovery half (`env: [...]`, `file: {path, parser}`, `priority`) **moves ou
 
 v2 also adds `inject[].scheme` as sugar for `header` + `format`: `scheme: bearer` expands to `header: Authorization`, `format: "Bearer %s"`; `scheme: basic` (with a required `username`) marks the entry as HTTP Basic. It is mutually exclusive with a raw `format`. The migrate script emits the explicit `header`/`format` form; switch to `scheme:` by hand if you prefer the shorthand.
 
-`environment.proxyManaged` is gone — the proxy-managed semantic is implicit on `credentials[].apiKey.name`. The engine sets the env var to the literal `proxy-managed` inside the container, and the sentinel-swap proxy replaces it on outbound requests.
+`environment.proxyManaged` is gone — each listed env var becomes `apiKey.proxyManaged: true` on the credential named by `apiKey.name` (not `name` alone). Only then does the engine set the env var to the literal `proxy-managed` inside the container, with the sentinel-swap proxy replacing it on outbound requests.
 
 ### OAuth folding — Phase 3
 

--- a/spec/SPEC-v2.md
+++ b/spec/SPEC-v2.md
@@ -622,7 +622,7 @@ credentials:
 
 | Field | Type | Rules |
 |---|---|---|
-| `name` | string | REQUIRED. Env-var name — MUST be a valid shell identifier when set, on both v1 and v2 specs. The engine sets it to the literal `proxy-managed` sentinel in-container when the credential is wired. |
+| `name` | string | Env-var name — MUST be a valid shell identifier when set, on both v1 and v2 specs. The engine sets it to the literal `proxy-managed` sentinel in-container when the credential is wired. An empty name on a `schemaVersion "2"` spec is warned, not rejected: it means the credential is handled entirely proxy-side, with no in-container environment variable. |
 | `proxyManaged` | bool | When `true`, the sentinel is set in-container (re-expresses the removed v1 `environment.proxyManaged`). |
 | `inject[].domain` | string | REQUIRED. MUST appear in `permissions.network.allow`. |
 | `inject[].header` | string | The HTTP header to set. |
@@ -630,10 +630,12 @@ credentials:
 | `inject[].username` | string | HTTP Basic username (proxy uses it as the username, the credential as the password). MUST NOT contain `:` — HTTP Basic (RFC 7617) treats the first colon as the user/password delimiter. |
 | `inject[].scheme` | string | Decode-time sugar (see below). Mutually exclusive with `format`. Always empty on the normalized artifact. |
 
-An inject entry MUST set at least one of `header` or `username`; one with
-neither has nothing for the proxy to inject and is invalid. A `header`-bearing
-entry with no `username` MUST also set `format` — without one there is no
-template to substitute the credential into.
+An inject entry SHOULD set at least one of `header` or `username`; one with
+neither injects nothing into requests and only maps the domain to the
+credential's service for routing/policy purposes — a legitimate shape, but
+`ValidateArtifact` warns since it usually signals a forgotten header or
+username. A `header`-bearing entry with no `username` MUST also set `format` —
+without one there is no template to substitute the credential into.
 
 **`scheme` sugar:**
 
@@ -828,21 +830,23 @@ the per-field rules above:
   derives service keys from env-var names and keeps underscores
   (`SAMPLE_PROXY_TOKEN` → `sample_proxy`), so enforcing it would reject v1
   kits that load today.
-- **credentials[].apiKey** (when present): `name` non-empty on a
-  `schemaVersion "2"` spec — the v1 `network.serviceDomains` +
-  `network.serviceAuth` fold can legitimately produce a header-only inject
-  with no name, so that shape stays accepted on the `schemaVersion "1"` path;
-  whenever `name` is non-empty (v1 or v2) it MUST be a valid shell identifier —
-  only the non-empty requirement is v2-gated, the shape requirement is not;
-  each `inject[].domain` non-empty; `inject[].format`, when set, contains
-  exactly one `%s`; each inject entry sets at least one of `header` or
-  `username` (one with neither injects nothing), and a `header`-bearing entry
-  with no `username` also requires `format` (otherwise there is no template to
-  substitute the credential into); `username`, when set, does
-  not contain `:` (HTTP Basic's user/password delimiter). Separately, `ValidateArtifact`
-  emits a non-fatal warning — it does not reject the kit — when an inject
-  domain is absent from `permissions.network.allow`; the engine still
-  performs the authoritative enforcement at load or sandbox-create time.
+- **credentials[].apiKey** (when present): whenever `name` is non-empty (v1 or
+  v2) it MUST be a valid shell identifier; each `inject[].domain` non-empty;
+  `inject[].format`, when set, contains exactly one `%s`; a `header`-bearing
+  entry with no `username` also requires `format` (otherwise there is no
+  template to substitute the credential into); `username`, when set, does not
+  contain `:` (HTTP Basic's user/password delimiter). Separately,
+  `ValidateArtifact` emits non-fatal warnings — it does not reject the kit —
+  for three legitimate-but-worth-a-second-look shapes: an inject domain absent
+  from `permissions.network.allow`; an inject entry with neither `header` nor
+  `username` set, which injects nothing into requests and only maps the domain
+  to the credential's service (the v1 `network.serviceDomains` +
+  `network.serviceAuth` fold can also produce a header-only inject with no
+  name — see below — and that shape has always been accepted); and, on a
+  `schemaVersion "2"` spec, an empty `name`, meaning the credential is handled
+  entirely proxy-side with no in-container environment variable. The engine
+  still performs the authoritative inject-domain-coverage enforcement at load
+  or sandbox-create time.
 - **credentials[].oauth** (when present): `tokenEndpoint.host` and
   `tokenEndpoint.path` non-empty; `sentinels.accessToken` and
   `sentinels.refreshToken` non-empty **unless** `passthrough: true`;

--- a/spec/SPEC-v2.md
+++ b/spec/SPEC-v2.md
@@ -622,7 +622,7 @@ credentials:
 
 | Field | Type | Rules |
 |---|---|---|
-| `name` | string | Env-var name — MUST be a valid shell identifier when set, on both v1 and v2 specs. The engine sets it to the literal `proxy-managed` sentinel in-container when the credential is wired. An empty name on a `schemaVersion "2"` spec is warned, not rejected: it means the credential is handled entirely proxy-side, with no in-container environment variable. |
+| `name` | string | Env-var name — MUST be a valid shell identifier when set, on both v1 and v2 specs. The engine sets it to the literal `proxy-managed` sentinel in-container only when `proxyManaged: true` is also set (see below); `name` alone declares the variable but populates nothing in-container. An empty name on a `schemaVersion "2"` spec is warned, not rejected: it means the credential is handled entirely proxy-side, with no in-container environment variable. |
 | `proxyManaged` | bool | When `true`, the sentinel is set in-container (re-expresses the removed v1 `environment.proxyManaged`). |
 | `inject[].domain` | string | REQUIRED. MUST appear in `permissions.network.allow`. |
 | `inject[].header` | string | The HTTP header to set. |
@@ -976,8 +976,9 @@ sandbox is wrong or meaningless in the next.
   Read it defensively, treating unset as `none`:
   `${SBX_CRED_MYSERVICE_MODE:-none}`.
 - The env var named by `credentials[].apiKey.name`: set to the sentinel value
-  when the credential is wired ([§5.4.1](#541-apikey)). A config file that
-  needs the value references the variable (for example
+  only when `apiKey.proxyManaged: true` is also set ([§5.4.1](#541-apikey)); `name`
+  on its own declares the variable but populates nothing in-container. A
+  config file that needs the value references the variable (for example
   `"${ANTHROPIC_API_KEY}"` in a format that expands env references) instead
   of embedding the sentinel literal.
 - `MCP_GATEWAY_URL` and `MCP_SENTINEL_TOKEN_NAME`: the MCP gateway endpoint

--- a/spec/types.go
+++ b/spec/types.go
@@ -380,9 +380,8 @@ func (c Credential) RoutingHosts() []string {
 
 // ApiKey describes an api-key-shaped credential. Inject is the fan-out
 // of which domains/headers the proxy injects the resolved value into;
-// Name is the env-var name the proxy populates inside the container
-// (set to the literal "proxy-managed" by the engine when this credential
-// is wired up).
+// Name is the env-var name, set to the literal "proxy-managed" sentinel
+// inside the container only when ProxyManaged is true.
 type ApiKey struct {
 	Name string `json:"name" yaml:"name"`
 	// ProxyManaged, when true, makes the engine set Name to the literal

--- a/spec/validate.go
+++ b/spec/validate.go
@@ -315,13 +315,16 @@ func ValidateArtifact(a *Artifact) error {
 		allowedDomains = a.Caps.Network.Allow
 	}
 
-	// This class of warning is validator-owned: drop every prior instance so
+	// These warning classes are validator-owned: drop every prior instance so
 	// revalidation reflects the artifact's current state, not its history.
 	retained := make([]string, 0, len(a.Warnings))
 	for _, w := range a.Warnings {
-		if !strings.HasPrefix(w, uncoveredDomainWarningPrefix) {
-			retained = append(retained, w)
+		if strings.HasPrefix(w, uncoveredDomainWarningPrefix) ||
+			strings.HasPrefix(w, inertInjectWarningPrefix) ||
+			strings.HasPrefix(w, apiKeyNameEmptyWarningPrefix) {
+			continue
 		}
+		retained = append(retained, w)
 	}
 	a.Warnings = retained
 
@@ -351,11 +354,23 @@ func ValidateArtifact(a *Artifact) error {
 			return fmt.Errorf("artifact: credentials[%d] (service %q): %w", i, c.Service, err)
 		}
 		if c.ApiKey != nil {
+			// A v2 apiKey with no name is proxy-side-only, a legitimate shape.
+			if c.ApiKey.Name == "" && a.Manifest.SchemaVersion == "2" {
+				a.Warnings = append(a.Warnings, fmt.Sprintf(
+					"%scredentials[%d] (service %q): no in-container environment variable will be set for this credential; set apiKey.name if the kit needs to read the value itself",
+					apiKeyNameEmptyWarningPrefix, i, c.Service))
+			}
 			for j, inj := range c.ApiKey.Inject {
 				if inj.Domain != "" && !allowListCovers(inj.Domain, allowedDomains) {
 					a.Warnings = append(a.Warnings, fmt.Sprintf(
 						"%scredentials[%d] (service %q) inject[%d].domain %q",
 						uncoveredDomainWarningPrefix, i, c.Service, j, inj.Domain))
+				}
+				// A domain-to-service association with nothing to inject is legitimate too.
+				if inj.Header == "" && inj.Username == "" {
+					a.Warnings = append(a.Warnings, fmt.Sprintf(
+						"%scredentials[%d] (service %q) inject[%d].domain %q: it injects nothing into requests; add header+format or username if you intend to authenticate requests to this domain",
+						inertInjectWarningPrefix, i, c.Service, j, inj.Domain))
 				}
 			}
 		}
@@ -546,14 +561,12 @@ func compileArgPattern(pat string) (*regexp.Regexp, error) {
 	return regexp.Compile(`\A(?:` + pat + `)\z`)
 }
 
-// ValidateApiKey requires inject[].domain and header or username on every
-// entry (SPEC-v2 §5.4.1); name itself is required only for schemaVersion "2".
+// ValidateApiKey requires inject[].domain, a well-formed header/format pair,
+// and a colon-free username (SPEC-v2 §5.4.1). An empty name and a
+// header/username-less inject are legitimate shapes, warned by ValidateArtifact instead.
 func ValidateApiKey(a *ApiKey, schemaVersion string) error {
 	if a == nil {
 		return nil
-	}
-	if a.Name == "" && schemaVersion == "2" {
-		return fmt.Errorf("apiKey: name is required")
 	}
 	if a.Name != "" && !shellIdentifierPattern.MatchString(a.Name) {
 		return fmt.Errorf("apiKey: name %q is not a valid shell identifier (letters, digits, underscores; can't start with a digit)", a.Name)
@@ -564,9 +577,6 @@ func ValidateApiKey(a *ApiKey, schemaVersion string) error {
 		}
 		if inj.Format != "" && strings.Count(inj.Format, "%s") != 1 {
 			return fmt.Errorf("apiKey: inject[%d].format must contain exactly one %%s placeholder (got %q)", j, inj.Format)
-		}
-		if inj.Header == "" && inj.Username == "" {
-			return fmt.Errorf("apiKey: inject[%d] sets neither header nor username, so it injects nothing", j)
 		}
 		if inj.Header != "" && inj.Username == "" && inj.Format == "" {
 			return fmt.Errorf("apiKey: inject[%d] sets header but no format, so it injects nothing", j)
@@ -581,6 +591,14 @@ func ValidateApiKey(a *ApiKey, schemaVersion string) error {
 // uncoveredDomainWarningPrefix tags a validator-owned warning class so
 // ValidateArtifact can find and drop its own prior instances on revalidation.
 const uncoveredDomainWarningPrefix = "apiKey inject domain not covered by permissions.network.allow: "
+
+// inertInjectWarningPrefix tags the validator-owned warning class for a
+// legitimate but header/username-less inject entry.
+const inertInjectWarningPrefix = "apiKey inject sets neither header nor username: "
+
+// apiKeyNameEmptyWarningPrefix tags the validator-owned warning class for a
+// legitimate but empty v2 apiKey.name.
+const apiKeyNameEmptyWarningPrefix = "apiKey.name is empty: "
 
 // allowListCovers mirrors sbx's runtime enforcement: a port range or other
 // non-numeric, non-"*" port never matches, so it doesn't count as coverage.

--- a/spec/validate.go
+++ b/spec/validate.go
@@ -357,7 +357,7 @@ func ValidateArtifact(a *Artifact) error {
 			// A v2 apiKey with no name is proxy-side-only, a legitimate shape.
 			if c.ApiKey.Name == "" && a.Manifest.SchemaVersion == "2" {
 				a.Warnings = append(a.Warnings, fmt.Sprintf(
-					"%scredentials[%d] (service %q): no in-container environment variable will be set for this credential; set apiKey.name if the kit needs to read the value itself",
+					"%scredentials[%d] (service %q): no in-container environment variable will be set for this credential; set apiKey.name (with proxyManaged: true) if the kit needs the value in-container",
 					apiKeyNameEmptyWarningPrefix, i, c.Service))
 			}
 			for j, inj := range c.ApiKey.Inject {

--- a/spec/validate_test.go
+++ b/spec/validate_test.go
@@ -1054,6 +1054,9 @@ credentials:
 		require.NoError(t, ValidateArtifact(a), "an empty apiKey.name must warn, not fail validation")
 		require.True(t, hasWarningContaining(a.Warnings, `credentials[0] (service "svc")`),
 			"expected an empty-name warning, got %v", a.Warnings)
+		// Name alone derives nothing in-container; the remediation must say so.
+		require.True(t, hasWarningContaining(a.Warnings, "proxyManaged: true"),
+			"remediation must tell the author proxyManaged: true is also required, got %v", a.Warnings)
 	})
 
 	// Coverage warnings are validator-owned: revalidating the same artifact

--- a/spec/validate_test.go
+++ b/spec/validate_test.go
@@ -540,9 +540,12 @@ func TestValidateApiKey(t *testing.T) {
 		require.NoError(t, ValidateApiKey(nil, "2"))
 	})
 
-	t.Run("v2_missing_name_rejected", func(t *testing.T) {
+	// An empty name is a legitimate shape (proxy-side-only credential); it is
+	// no longer rejected here — ValidateArtifact warns instead, see
+	// TestValidateArtifact/apikey_empty_name_warns_not_errors.
+	t.Run("v2_missing_name_allowed", func(t *testing.T) {
 		a := &ApiKey{Inject: []ApiKeyInject{{Domain: "api.example.com", Header: "x-api-key", Format: "%s"}}}
-		require.ErrorContains(t, ValidateApiKey(a, "2"), "name is required")
+		require.NoError(t, ValidateApiKey(a, "2"))
 	})
 
 	// v1's serviceDomains+serviceAuth fold can yield a header-only inject
@@ -593,9 +596,13 @@ func TestValidateApiKey(t *testing.T) {
 		require.ErrorContains(t, ValidateApiKey(a, "2"), "exactly one %s placeholder")
 	})
 
-	t.Run("inert_inject_rejected", func(t *testing.T) {
+	// Neither header nor username is a legitimate shape too — it maps the
+	// domain to the credential's service without injecting anything; it is
+	// no longer rejected here — ValidateArtifact warns instead, see
+	// TestValidateArtifact/apikey_inert_inject_warns_not_errors.
+	t.Run("inert_inject_allowed", func(t *testing.T) {
 		a := &ApiKey{Name: "TOKEN", Inject: []ApiKeyInject{{Domain: "d.example.com", Format: "%s"}}}
-		require.ErrorContains(t, ValidateApiKey(a, "2"), "sets neither header nor username")
+		require.NoError(t, ValidateApiKey(a, "2"))
 	})
 
 	t.Run("header_only_valid", func(t *testing.T) {
@@ -1031,6 +1038,156 @@ credentials:
 		require.Empty(t, a.Warnings)
 	})
 
+	// An empty apiKey.name on a v2 spec is a legitimate shape — the
+	// credential is handled entirely proxy-side — so it must warn, not fail.
+	t.Run("apikey_empty_name_warns_not_errors", func(t *testing.T) {
+		a := &Artifact{
+			Manifest: Manifest{SchemaVersion: "2", Kind: KindMixin, Name: "ok"},
+			Caps:     &Caps{Network: &CapsNetwork{Allow: []string{"api.example.com"}}},
+			Credentials: []Credential{{
+				Service: "svc",
+				ApiKey: &ApiKey{
+					Inject: []ApiKeyInject{{Domain: "api.example.com", Header: "x-api-key", Format: "%s"}},
+				},
+			}},
+		}
+		require.NoError(t, ValidateArtifact(a), "an empty apiKey.name must warn, not fail validation")
+		require.True(t, hasWarningContaining(a.Warnings, `credentials[0] (service "svc")`),
+			"expected an empty-name warning, got %v", a.Warnings)
+	})
+
+	// Coverage warnings are validator-owned: revalidating the same artifact
+	// must not accumulate a duplicate per call.
+	t.Run("apikey_empty_name_warning_is_idempotent_across_revalidation", func(t *testing.T) {
+		a := &Artifact{
+			Manifest: Manifest{SchemaVersion: "2", Kind: KindMixin, Name: "ok"},
+			Caps:     &Caps{Network: &CapsNetwork{Allow: []string{"api.example.com"}}},
+			Credentials: []Credential{{
+				Service: "svc",
+				ApiKey: &ApiKey{
+					Inject: []ApiKeyInject{{Domain: "api.example.com", Header: "x-api-key", Format: "%s"}},
+				},
+			}},
+		}
+		require.NoError(t, ValidateArtifact(a))
+		require.NoError(t, ValidateArtifact(a))
+		count := 0
+		for _, w := range a.Warnings {
+			if strings.HasPrefix(w, apiKeyNameEmptyWarningPrefix) {
+				count++
+			}
+		}
+		require.Equal(t, 1, count, "revalidation must not duplicate the warning, got %v", a.Warnings)
+	})
+
+	// Self-healing: once the author sets a name, revalidating the same
+	// artifact must drop the now-stale warning.
+	t.Run("apikey_empty_name_warning_clears_once_name_set", func(t *testing.T) {
+		a := &Artifact{
+			Manifest: Manifest{SchemaVersion: "2", Kind: KindMixin, Name: "ok"},
+			Caps:     &Caps{Network: &CapsNetwork{Allow: []string{"api.example.com"}}},
+			Credentials: []Credential{{
+				Service: "svc",
+				ApiKey: &ApiKey{
+					Inject: []ApiKeyInject{{Domain: "api.example.com", Header: "x-api-key", Format: "%s"}},
+				},
+			}},
+		}
+		require.NoError(t, ValidateArtifact(a))
+		require.NotEmpty(t, a.Warnings, "precondition: the name must start out empty")
+
+		a.Credentials[0].ApiKey.Name = "SVC_TOKEN"
+		require.NoError(t, ValidateArtifact(a))
+		require.Empty(t, a.Warnings, "the warning must clear once name is set, got %v", a.Warnings)
+	})
+
+	// The v1 serviceDomains+serviceAuth fold can legitimately produce a
+	// no-name apiKey; the empty-name warning is v2-only, so a v1 artifact
+	// must not receive it either.
+	t.Run("apikey_empty_name_not_warned_on_v1", func(t *testing.T) {
+		a := &Artifact{
+			Manifest: Manifest{SchemaVersion: "1", Kind: KindMixin, Name: "ok"},
+			Caps:     &Caps{Network: &CapsNetwork{Allow: []string{"api.example.com"}}},
+			Credentials: []Credential{{
+				Service: "svc",
+				ApiKey: &ApiKey{
+					Inject: []ApiKeyInject{{Domain: "api.example.com", Header: "x-api-key", Format: "%s"}},
+				},
+			}},
+		}
+		require.NoError(t, ValidateArtifact(a))
+		require.Empty(t, a.Warnings)
+	})
+
+	// An inject entry with neither header nor username is a legitimate
+	// shape — it associates the domain with the credential's service for
+	// routing/policy purposes without injecting anything — so it must warn,
+	// not fail.
+	t.Run("apikey_inert_inject_warns_not_errors", func(t *testing.T) {
+		a := &Artifact{
+			Manifest: Manifest{SchemaVersion: "2", Kind: KindMixin, Name: "ok"},
+			Caps:     &Caps{Network: &CapsNetwork{Allow: []string{"api.example.com"}}},
+			Credentials: []Credential{{
+				Service: "svc",
+				ApiKey: &ApiKey{
+					Name:   "SVC_TOKEN",
+					Inject: []ApiKeyInject{{Domain: "api.example.com"}},
+				},
+			}},
+		}
+		require.NoError(t, ValidateArtifact(a), "an inert inject must warn, not fail validation")
+		require.True(t, hasWarningContaining(a.Warnings, `credentials[0] (service "svc") inject[0].domain "api.example.com"`),
+			"expected an inert-inject warning, got %v", a.Warnings)
+	})
+
+	// Coverage warnings are validator-owned: revalidating the same artifact
+	// must not accumulate a duplicate per call.
+	t.Run("apikey_inert_inject_warning_is_idempotent_across_revalidation", func(t *testing.T) {
+		a := &Artifact{
+			Manifest: Manifest{SchemaVersion: "2", Kind: KindMixin, Name: "ok"},
+			Caps:     &Caps{Network: &CapsNetwork{Allow: []string{"api.example.com"}}},
+			Credentials: []Credential{{
+				Service: "svc",
+				ApiKey: &ApiKey{
+					Name:   "SVC_TOKEN",
+					Inject: []ApiKeyInject{{Domain: "api.example.com"}},
+				},
+			}},
+		}
+		require.NoError(t, ValidateArtifact(a))
+		require.NoError(t, ValidateArtifact(a))
+		count := 0
+		for _, w := range a.Warnings {
+			if strings.HasPrefix(w, inertInjectWarningPrefix) {
+				count++
+			}
+		}
+		require.Equal(t, 1, count, "revalidation must not duplicate the warning, got %v", a.Warnings)
+	})
+
+	// Self-healing: once the author adds a header/format, revalidating the
+	// same artifact must drop the now-stale warning.
+	t.Run("apikey_inert_inject_warning_clears_once_header_set", func(t *testing.T) {
+		a := &Artifact{
+			Manifest: Manifest{SchemaVersion: "2", Kind: KindMixin, Name: "ok"},
+			Caps:     &Caps{Network: &CapsNetwork{Allow: []string{"api.example.com"}}},
+			Credentials: []Credential{{
+				Service: "svc",
+				ApiKey: &ApiKey{
+					Name:   "SVC_TOKEN",
+					Inject: []ApiKeyInject{{Domain: "api.example.com"}},
+				},
+			}},
+		}
+		require.NoError(t, ValidateArtifact(a))
+		require.NotEmpty(t, a.Warnings, "precondition: the inject must start out inert")
+
+		a.Credentials[0].ApiKey.Inject[0].Header = "x-api-key"
+		a.Credentials[0].ApiKey.Inject[0].Format = "%s"
+		require.NoError(t, ValidateArtifact(a))
+		require.Empty(t, a.Warnings, "the warning must clear once header+format is set, got %v", a.Warnings)
+	})
+
 	// scheme: basic expands to Username set, Header empty (SPEC-v2 §5.4.1);
 	// this shape must validate clean despite the empty header.
 	t.Run("scheme_basic_post_fold_shape_is_clean", func(t *testing.T) {
@@ -1082,6 +1239,8 @@ network:
 		require.NoError(t, ValidateArtifact(art))
 		require.Empty(t, art.Credentials[0].ApiKey.Name, "no credentials.sources entry means no envName")
 		require.Equal(t, "x-api-key", art.Credentials[0].ApiKey.Inject[0].Header)
+		require.False(t, hasWarningContaining(art.Warnings, apiKeyNameEmptyWarningPrefix),
+			"the empty-name warning is v2-only, so the v1 fold must not receive it, got %v", art.Warnings)
 	})
 
 	t.Run("oauth_credential_file_structure_only_accepted", func(t *testing.T) {

--- a/spec/validate_test.go
+++ b/spec/validate_test.go
@@ -1059,8 +1059,6 @@ credentials:
 			"remediation must tell the author proxyManaged: true is also required, got %v", a.Warnings)
 	})
 
-	// Coverage warnings are validator-owned: revalidating the same artifact
-	// must not accumulate a duplicate per call.
 	t.Run("apikey_empty_name_warning_is_idempotent_across_revalidation", func(t *testing.T) {
 		a := &Artifact{
 			Manifest: Manifest{SchemaVersion: "2", Kind: KindMixin, Name: "ok"},
@@ -1143,8 +1141,6 @@ credentials:
 			"expected an inert-inject warning, got %v", a.Warnings)
 	})
 
-	// Coverage warnings are validator-owned: revalidating the same artifact
-	// must not accumulate a duplicate per call.
 	t.Run("apikey_inert_inject_warning_is_idempotent_across_revalidation", func(t *testing.T) {
 		a := &Artifact{
 			Manifest: Manifest{SchemaVersion: "2", Kind: KindMixin, Name: "ok"},

--- a/spec/validate_test.go
+++ b/spec/validate_test.go
@@ -562,8 +562,6 @@ func TestValidateApiKey(t *testing.T) {
 		require.ErrorContains(t, ValidateApiKey(a, "2"), "not a valid shell identifier")
 	})
 
-	// The shell-identifier shape check is not v2-gated: only the
-	// non-empty requirement is, so a malformed v1 name is rejected too.
 	t.Run("malformed_name_rejected_v1", func(t *testing.T) {
 		a := &ApiKey{Name: "bad-name", Inject: []ApiKeyInject{{Domain: "api.example.com", Header: "x-api-key", Format: "%s"}}}
 		require.ErrorContains(t, ValidateApiKey(a, "1"), "not a valid shell identifier")
@@ -574,8 +572,6 @@ func TestValidateApiKey(t *testing.T) {
 		require.NoError(t, ValidateApiKey(a, "2"))
 	})
 
-	// The shell-identifier check only applies to a non-empty name; an empty
-	// one stays governed solely by the v1/v2 name-required gate above.
 	t.Run("v1_empty_name_not_subject_to_shell_identifier_check", func(t *testing.T) {
 		a := &ApiKey{Inject: []ApiKeyInject{{Domain: "api.example.com", Header: "x-api-key", Format: "%s"}}}
 		require.NoError(t, ValidateApiKey(a, "1"))


### PR DESCRIPTION
## Summary

Two of the `apiKey` hard errors introduced in #283 over-reject working shapes: an empty `apiKey.name` on a v2 spec (a proxy-side-only credential with nothing for the container to read) and an inject entry with neither `header` nor `username` (a domain-to-service routing/policy association that intentionally injects nothing). Both are now validator-owned warnings — the same clear-then-recompute mechanism as the uncovered-domain warning, so revalidation stays idempotent and self-healing. Every other rule from #283 stays a hard error (non-empty names must be shell identifiers, `inject[].domain` required, `format` placeholder, header-without-format, colon usernames).

SPEC-v2 §5.4.1/§6 and the kit-author spec-anatomy topic are updated in the same diff. Kit sweep: 47 kits, zero errors, zero warnings, identical before and after. Rejection tests converted plus seven new warning-class subtests, all mutation-checked.

This is the patch intended for the v0.19.1 tag.

Authored by Claude (Sonnet 5) on behalf of @mdelapenya.
