### PR TITLE
feat(graphify): add graphify mixin kit

### DIFF
--- a/graphify/README.md
+++ b/graphify/README.md
@@ -1,0 +1,79 @@
+# graphify
+
+A mixin installing a pinned [Graphify](https://github.com/Graphify-Labs/graphify)
+0.9.57 runtime — code-graph extraction and query over a codebase, via
+[tree-sitter](https://tree-sitter.github.io/tree-sitter/) parsing and
+[NetworkX](https://networkx.org/). The kit installs the runtime into a
+root-owned venv at `/opt/graphify`, with `graphify` on `PATH` and
+`graphify-mcp` left unsymlinked inside the venv. It composes with any base
+sandbox (no `requires.agent`, no image, credentials, ports, volumes, or
+startup hooks) — combine it with whichever agent kit you run.
+
+## Requirements
+
+- A base image with Python 3.10+ and a working `venv` module. Dependencies
+  install as prebuilt wheels only (no source builds), which PyPI covers for
+  `linux/amd64` and `linux/arm64`.
+- Network: the kit allows `pypi.org:443` and `files.pythonhosted.org:443`
+  under deny-all.
+
+## Usage
+
+```console
+sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=graphify" ~/my-project
+```
+
+Or from its published OCI artifact on Docker Hub:
+
+```console
+sbx run claude --kit "docker.io/sbx/graphify-kit:latest" ~/my-project
+```
+
+Graphs are never built automatically. Run `graphify extract <path>` to build
+one, then `graphify query` against it. Code-only extraction needs no API key
+and makes no network call.
+
+To install a different Graphify release than the kit's default, override the
+version and its matching wheel hash together at create time (the install
+fails closed if they don't match):
+
+```console
+sbx run claude --kit <ref> --kit-arg version=<v> --kit-arg sha256=<wheel sha256> ~/my-project
+```
+
+The hash is the wheel's sha256 from `https://pypi.org/pypi/graphifyy/<v>/json`.
+
+## Agent integration is up to you
+
+This kit deliberately ships no project integration — no installed skill, no
+CLAUDE.md wiring, no git hooks. Upstream's own installer
+(`graphify install --project --platform <id>`) works fine against this
+runtime, but you own what it does once you run it. Review it first:
+
+- The installed skill's bootstrap self-installs or upgrades Graphify,
+  unpinned, via `pip` or `uv`. This kit's PyPI network allowance makes that
+  path reachable and it will silently replace the pinned runtime.
+- Upstream's docs suggest `post-commit` / `post-checkout` git hooks. On a
+  directly mounted sandbox, those hooks land in the **host** repository, not
+  a sandbox-local copy.
+- Some of upstream's per-platform installers write to `$HOME` or to global
+  (not project-local) configuration.
+
+## Direct mount vs. `--clone`
+
+On a directly mounted project, `graphify extract <path>` writes
+`graphify-out/` into the directory it scans, and upstream's skill (if you
+installed it) writes `.graphify_python` there on every invocation — both land
+in your host checkout. On a `sbx run --clone` sandbox, the same writes stay
+inside the sandbox's private clone.
+
+## Updating the pinned version
+
+Only relevant when changing this kit in sbx-kits-contrib, not when using it
+(users can already override per sandbox with `--kit-arg`, above). Edit the
+`version` and `sha256` defaults in `spec.yaml`'s `args:` block.
+
+## Licensing
+
+Graphify is licensed Apache-2.0. This kit installs it from PyPI and ships no
+upstream text of its own.

--- a/graphify/spec.yaml
+++ b/graphify/spec.yaml
@@ -1,0 +1,141 @@
+schemaVersion: "2"
+kind: mixin
+name: graphify
+displayName: Graphify
+description: "Installs a pinned graphify CLI for code-graph extraction."
+licenses:
+  - Apache-2.0
+
+# Overridable at install time, as a coupled pair — a version without its matching
+# wheel hash fails the install's sha256 check:
+#   sbx run claude --kit <ref> --kit-arg version=<v> --kit-arg sha256=<wheel sha256>
+args:
+  version:
+    default: "0.9.57"
+    description: "graphifyy release to install from PyPI"
+    pattern: '^[0-9]+\.[0-9]+\.[0-9]+$'
+  sha256:
+    default: "f35c86410e7d92ace69a50ac8dbed568903c880482c656f43437ca657fee8c37"
+    description: "sha256 of the graphifyy wheel for the selected version"
+    pattern: '^[0-9a-f]{64}$'
+
+permissions:
+  network:
+    allow:
+      - pypi.org:443
+      - files.pythonhosted.org:443
+
+agentInstructions:
+  content: |
+    A pinned Graphify ${{ kit.args.version }} CLI is installed at `/usr/local/bin/graphify`.
+
+    Build a graph explicitly with `graphify extract <path>`, then query it
+    with `graphify query`.
+
+    Never run the upgrade or install commands that Graphify's own docs or
+    skill suggest — the runtime here is pinned, and a self-upgrade defeats
+    that pin. Do not install Graphify's git hooks.
+
+    No project integration (skill or agent-file wiring) is preinstalled. To
+    complete it when the user asks, run `graphify install --project
+    --platform <id>` from the project root, with `<id>` matching this
+    sandbox's agent (for example `claude`). For claude it writes project
+    files only; some other platforms also touch HOME or global config, so
+    review what it writes. On a directly mounted workspace the project files
+    land in the host checkout — say so.
+    Skip anything it suggests beyond that — hook installation and the
+    installed skill's self-upgrade bootstrap stay forbidden per the rules
+    above.
+
+setup:
+  install:
+    - command: |
+        set -eu
+
+        GRAPHIFY_VERSION="${{ kit.args.version }}"
+        VENV="/opt/graphify"
+        LINK="/usr/local/bin/graphify"
+
+        version_reports_pinned() {
+          [ "$("$1" --version 2>/dev/null)" = "graphify $GRAPHIFY_VERSION" ]
+        }
+
+        # Re-checks the install tail's invariants (readlink equivalence stands in for
+        # its shebang check): a poisoned or partial runtime must fall through to a
+        # real install rather than short-circuit.
+        installed() {
+          [ -x "$VENV/bin/python" ] || return 1
+          [ -x "$VENV/bin/graphify" ] || return 1
+          [ "$(readlink -f "$LINK" 2>/dev/null)" = "$VENV/bin/graphify" ] || return 1
+          version_reports_pinned "$VENV/bin/graphify" || return 1
+          "$VENV/bin/python" -c 'import graphify' >/dev/null 2>&1
+        }
+
+        if installed; then
+          exit 0
+        fi
+
+        if ! command -v python3 >/dev/null 2>&1; then
+          echo "graphify kit: python3 not found - install Python 3.10+ on the base image" >&2
+          exit 1
+        fi
+
+        if ! python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)'; then
+          echo "graphify kit: Python $(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])') is too old - graphify needs Python 3.10+" >&2
+          exit 1
+        fi
+
+        if ! python3 -c 'import venv' >/dev/null 2>&1; then
+          echo "graphify kit: python3's venv module is unavailable - install python3-venv on the base image" >&2
+          exit 1
+        fi
+
+        if ! command -v /usr/bin/pip >/dev/null 2>&1; then
+          echo "graphify kit: /usr/bin/pip not found - install pip on the base image" >&2
+          exit 1
+        fi
+
+        # The base template ships Python without ensurepip, so plain "python3 -m venv" fails here.
+        python3 -m venv --without-pip "$VENV"
+
+        WHEEL_SHA256="${{ kit.args.sha256 }}"
+        WHEEL_DIR=$(mktemp -d /tmp/graphify-wheel.XXXXXX)
+        trap 'rm -rf "$WHEEL_DIR"' EXIT
+
+        /usr/bin/pip download --no-deps --only-binary=:all: --no-cache-dir \
+          --dest "$WHEEL_DIR" "graphifyy==$GRAPHIFY_VERSION"
+        echo "$WHEEL_SHA256  $WHEEL_DIR/graphifyy-$GRAPHIFY_VERSION-py3-none-any.whl" | sha256sum -c -
+
+        # pip only accepts --python before the subcommand name; after it, the flag is rejected.
+        /usr/bin/pip --python "$VENV/bin/python" install --only-binary=:all: --no-cache-dir \
+          "$WHEEL_DIR/graphifyy-$GRAPHIFY_VERSION-py3-none-any.whl"
+
+        # "ln -sf" onto an existing directory creates the link inside it instead of
+        # replacing it, so a stray directory at $LINK must be rejected explicitly rather
+        # than silently misplacing the symlink.
+        if [ -e "$LINK" ] || [ -L "$LINK" ]; then
+          if [ -d "$LINK" ] && [ ! -L "$LINK" ]; then
+            echo "graphify kit: $LINK exists and is a directory - remove or rename it and re-run install" >&2
+            exit 1
+          fi
+          rm -f "$LINK"
+        fi
+        ln -sfn "$VENV/bin/graphify" "$LINK"
+
+        if ! version_reports_pinned "$VENV/bin/graphify"; then
+          echo "graphify kit: verification failed - graphify --version did not report $GRAPHIFY_VERSION" >&2
+          exit 1
+        fi
+
+        if ! "$VENV/bin/python" -c 'import graphify' >/dev/null 2>&1; then
+          echo "graphify kit: verification failed - import graphify failed under $VENV/bin/python" >&2
+          exit 1
+        fi
+
+        SHEBANG=$(head -n1 "$LINK" | sed 's/^#!//')
+        if [ "$SHEBANG" != "$VENV/bin/python" ]; then
+          echo "graphify kit: verification failed - $LINK shebang resolves to '$SHEBANG', expected $VENV/bin/python" >&2
+          exit 1
+        fi
+      user: "0"
+      description: Install the pinned graphify CLI into a root-owned venv at /opt/graphify; the graphifyy wheel is sha256-verified, its dependencies resolve from PyPI


### PR DESCRIPTION
## What

Adds a v2 `kind: mixin` kit named `graphify`: two files, `spec.yaml` (141 lines) and `README.md`. `setup.install` provisions a pinned graphify CLI in a venv at `/opt/graphify` — the `graphifyy` wheel (default 0.9.57) is downloaded from PyPI, sha256-verified, and installed with `--only-binary=:all:`; dependencies resolve from PyPI like the repo's other package-manager kits. Version and wheel hash are declared as `args` with defaults, overridable per sandbox as a coupled pair (`--kit-arg version=... --kit-arg sha256=...`) — a mismatched pair fails closed. Network allowance is exactly `pypi.org:443` + `files.pythonhosted.org:443`. Graph builds stay explicit (`graphify extract <path>`, offline, no API key); the kit ships no agent/project integration — the agent instructions tell the agent how to complete it on request via upstream's installer, and the README documents the caveats (self-upgrade path, git hooks, direct-mount writes) as user-owned choices.

## Tests

The install script was executed end-to-end locally on the template userland (Ubuntu 26.04 / CPython 3.14): sha256 verify, full install, `graphify --version` / `import graphify` / shebang checks, idempotent re-run, and a wrong-hash run failing closed with nothing installed. An earlier revision of the same gates/venv/verify skeleton passed the full TCK including a real container install; CI on this push runs the full TCK for the final script. Host sbx e2e (direct and `--clone`, stop/start, daemon restart, `sbx kit add`) has not run yet and will be exercised before merge.