### PR TITLE
fix(claude-mem): keep the worker on loopback and publish the viewer through a relay

### DIFF
--- a/claude-mem/README.md
+++ b/claude-mem/README.md
@@ -25,10 +25,11 @@ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=claude-mem
 
 Search past sessions with the bundled `mem-search` skill or the
 `mcp-search` MCP tools. The worker (viewer UI + live activity stream)
-listens on port 37700:
+listens on `127.0.0.1:37700` and is bridged to port 37800, which is the
+one to publish for host access (see [Design notes](#design-notes)):
 
 ```console
-sbx ports <sandbox> --publish 37700/tcp
+sbx ports <sandbox> --publish 37800/tcp
 ```
 
 ## Design notes
@@ -64,6 +65,30 @@ sbx ports <sandbox> --publish 37700/tcp
   OpenRouter) need a browser OAuth pairing or a preconfigured personal
   API key. Upstream's README still describes the pre-13.20.0 behavior —
   see [thedotmack/claude-mem#3893](https://github.com/thedotmack/claude-mem/issues/3893).
+- **Worker on loopback, viewer bridged to 37800**: claude-mem reads
+  `CLAUDE_MEM_WORKER_HOST` as *both* the address the worker binds and the
+  address every client dials — the hooks, the `mcp-search` MCP server and
+  the CLI all build `http://<host>:<port><path>` from it. A published port
+  has to be served from eth0, but binding the worker to `0.0.0.0` to get
+  that makes every client dial `0.0.0.0` too, and the sandbox's `NO_PROXY`
+  only exempts loopback (`localhost,127.0.0.1,::1,gateway.docker.internal`)
+  while `NODE_USE_ENV_PROXY=1` is injected. The requests go to the egress
+  proxy, which answers `Blocked by network policy: domain 0.0.0.0:37700` —
+  and Node's `fetch` *hangs* on that denial rather than failing. Measured on
+  a sandbox built from this kit: the `SessionStart` hook gives up with
+  `{"status":"error","message":"Failed to start worker"}`, no worker is left
+  running, and memory never works at all. The worker therefore stays on
+  `127.0.0.1:37700`, where every
+  client bypasses the proxy, and a ~30-line TCP relay
+  (`files/home/.local/bin/claude-mem-viewer-relay.js`, started from
+  `setup.startup`) serves 37800 on eth0 and forwards to it. Inbound
+  connections through a published port never touch the proxy, so the viewer
+  stays reachable from the host. Appending `0.0.0.0` to `NO_PROXY` instead
+  was rejected: `/etc/sandbox-persistent.sh` is only sourced by `bash`
+  (via `BASH_ENV`), so a client spawned through `sh`/`dash` or exec'd
+  directly still hangs — a hang is a worse failure than a clean error, and
+  the kit would be overwriting a runtime-owned variable
+  ([SPEC §9.5](../spec/SPEC-v2.md#95-environment-injected-by-the-runtime)).
 - **Settings reconciler**: claude-mem's installer merges
   `enabledPlugins` into `~/.claude/settings.json`, while the platform
   seeds the same file at startup *only when missing* — and the two race
@@ -90,6 +115,15 @@ sbx ports <sandbox> --publish 37700/tcp
 
 ```console
 sbx exec <sandbox> -- cat /tmp/claude-mem-reconcile.log
+sbx exec <sandbox> -- cat /tmp/claude-mem-viewer-relay.log
 sbx exec <sandbox> -- cat /home/agent/.claude/settings.json
 sbx exec <sandbox> -- ls /home/agent/.claude-mem/
+```
+
+The worker is reachable in-sandbox on loopback only; check it there, and
+check the relay on the port that gets published:
+
+```console
+sbx exec <sandbox> -- curl -s http://127.0.0.1:37700/api/health
+sbx exec <sandbox> -- curl -s http://127.0.0.1:37800/api/health
 ```

--- a/claude-mem/README.md
+++ b/claude-mem/README.md
@@ -79,11 +79,17 @@ sbx ports <sandbox> --publish 37800/tcp
   `{"status":"error","message":"Failed to start worker"}`, no worker is left
   running, and memory never works at all. The worker therefore stays on
   `127.0.0.1:37700`, where every
-  client bypasses the proxy, and a ~30-line TCP relay
+  client bypasses the proxy, and a small TCP relay
   (`files/home/.local/bin/claude-mem-viewer-relay.js`, started from
   `setup.startup`) serves 37800 on eth0 and forwards to it. Inbound
   connections through a published port never touch the proxy, so the viewer
-  stays reachable from the host. Appending `0.0.0.0` to `NO_PROXY` instead
+  stays reachable from the host. The relay binds `::` (falling back to
+  `0.0.0.0` where IPv6 is unavailable) so that both publish protocols work:
+  `sbx ports --publish 37800:37800/tcp` binds the host dual-stack and hands
+  an IPv6 connection to the sandbox's IPv6 address, and an IPv4-only relay
+  resets exactly the request a browser makes — `localhost` resolves to `::1`
+  first and the host side is listening, so nothing falls back to IPv4.
+  Appending `0.0.0.0` to `NO_PROXY` instead
   was rejected: `/etc/sandbox-persistent.sh` is only sourced by `bash`
   (via `BASH_ENV`), so a client spawned through `sh`/`dash` or exec'd
   directly still hangs — a hang is a worse failure than a clean error, and

--- a/claude-mem/files/home/.local/bin/claude-mem-viewer-relay.js
+++ b/claude-mem/files/home/.local/bin/claude-mem-viewer-relay.js
@@ -25,6 +25,16 @@ const WORKER_PORT = Number(process.env.CLAUDE_MEM_WORKER_PORT) || 37700;
 // claude-mem's own default range (37700 + uid % 100 spans 37700-37799) so it
 // cannot collide with a worker that lands on a port other than the pinned one.
 const RELAY_PORT = 37800;
+// `::` accepts both families (Node leaves ipv6Only off), which a published port
+// needs: `sbx ports --publish <host>:37800/tcp` binds the host dual-stack and
+// forwards an IPv6 connection to the sandbox's IPv6 address, so an IPv4-only
+// relay resets every request a browser makes to `http://localhost:37800` --
+// `localhost` resolves to `::1` first, and the host side is listening, so
+// nothing falls back to IPv4. 0.0.0.0 is the fallback for an image or host
+// without IPv6, where binding `::` fails outright.
+const BIND_HOSTS = ["::", "0.0.0.0"];
+
+let bindIndex = 0;
 
 const server = net.createServer((client) => {
   const worker = net.connect(WORKER_PORT, "127.0.0.1");
@@ -44,12 +54,29 @@ const server = net.createServer((client) => {
 server.on("error", (err) => {
   // startup runs on every container start; a relay from an earlier start in the
   // same container already owns the port. Exit quietly instead of crash-looping.
+  if (err.code === "EADDRINUSE") {
+    console.error("[claude-mem-viewer-relay] " + err.message);
+    process.exit(0);
+  }
+  if (bindIndex < BIND_HOSTS.length - 1) {
+    bindIndex += 1;
+    console.error(
+      "[claude-mem-viewer-relay] " + err.message + "; retrying on " + BIND_HOSTS[bindIndex]
+    );
+    server.listen(RELAY_PORT, BIND_HOSTS[bindIndex]);
+    return;
+  }
   console.error("[claude-mem-viewer-relay] " + err.message);
-  process.exit(err.code === "EADDRINUSE" ? 0 : 1);
+  process.exit(1);
 });
 
-server.listen(RELAY_PORT, "0.0.0.0", () => {
+server.listen(RELAY_PORT, BIND_HOSTS[bindIndex], () => {
   console.log(
-    "[claude-mem-viewer-relay] 0.0.0.0:" + RELAY_PORT + " -> 127.0.0.1:" + WORKER_PORT
+    "[claude-mem-viewer-relay] " +
+      BIND_HOSTS[bindIndex] +
+      ":" +
+      RELAY_PORT +
+      " -> 127.0.0.1:" +
+      WORKER_PORT
   );
 });

--- a/claude-mem/files/home/.local/bin/claude-mem-viewer-relay.js
+++ b/claude-mem/files/home/.local/bin/claude-mem-viewer-relay.js
@@ -1,0 +1,55 @@
+"use strict";
+
+// Bridges the sandbox's published port to the loopback-bound claude-mem worker.
+//
+// The worker has to stay on 127.0.0.1: claude-mem reads CLAUDE_MEM_WORKER_HOST
+// as *both* the address the worker binds and the address every client (the
+// hooks, the mcp-search MCP server, the CLI) connects to. The runtime's
+// NO_PROXY exempts loopback only (`localhost,127.0.0.1,::1,gateway.docker.internal`)
+// and NODE_USE_ENV_PROXY=1 is injected, so a worker on 0.0.0.0 sends every
+// client request to the egress proxy, which denies `0.0.0.0:<port>` -- and
+// Node's fetch hangs on that denial rather than failing. The measured result
+// is that the worker never comes up at all: claude-mem's SessionStart hook
+// reports {"status":"error","message":"Failed to start worker"}.
+//
+// Inbound connections arriving through a published port never go near that
+// proxy, so bridging them here keeps the viewer reachable from the host
+// without moving the worker off loopback.
+
+const net = require("net");
+
+// Startup commands run with a minimal environment, so fall back to the port
+// the kit pins in spec.yaml rather than trusting the variable to be present.
+const WORKER_PORT = Number(process.env.CLAUDE_MEM_WORKER_PORT) || 37700;
+// Kept in sync by hand with `ports:` in spec.yaml. Deliberately outside
+// claude-mem's own default range (37700 + uid % 100 spans 37700-37799) so it
+// cannot collide with a worker that lands on a port other than the pinned one.
+const RELAY_PORT = 37800;
+
+const server = net.createServer((client) => {
+  const worker = net.connect(WORKER_PORT, "127.0.0.1");
+  const drop = () => {
+    client.destroy();
+    worker.destroy();
+  };
+  // claude-mem spawns the worker lazily from its hooks, so a connection that
+  // arrives before the worker is up simply fails: drop both ends and keep
+  // serving instead of taking the relay down with it.
+  client.on("error", drop);
+  worker.on("error", drop);
+  client.pipe(worker);
+  worker.pipe(client);
+});
+
+server.on("error", (err) => {
+  // startup runs on every container start; a relay from an earlier start in the
+  // same container already owns the port. Exit quietly instead of crash-looping.
+  console.error("[claude-mem-viewer-relay] " + err.message);
+  process.exit(err.code === "EADDRINUSE" ? 0 : 1);
+});
+
+server.listen(RELAY_PORT, "0.0.0.0", () => {
+  console.log(
+    "[claude-mem-viewer-relay] 0.0.0.0:" + RELAY_PORT + " -> 127.0.0.1:" + WORKER_PORT
+  );
+});

--- a/claude-mem/spec.yaml
+++ b/claude-mem/spec.yaml
@@ -12,10 +12,10 @@ agentInstructions:
     Persistent memory is active: session activity is captured into a local
     SQLite database under `~/.claude-mem/` and relevant context is injected
     at session start. Search past sessions with the mem-search skill or the
-    mcp-search MCP tools. The worker (viewer UI + live activity stream) runs
-    on port 37700 (publish with `sbx ports <sandbox> --publish 37700/tcp`
-    to browse from the host). claude-mem's telemetry is disabled
-    (CLAUDE_MEM_TELEMETRY=0).
+    mcp-search MCP tools. The worker (viewer UI + live activity stream) is
+    bound to 127.0.0.1:37700 and bridged to 37800, which is the port to
+    publish for host access (`sbx ports <sandbox> --publish 37800/tcp`).
+    claude-mem's telemetry is disabled (CLAUDE_MEM_TELEMETRY=0).
 permissions:
   network:
     allow:
@@ -41,7 +41,10 @@ permissions:
       - ports.ubuntu.com
       - download.docker.com
 ports:
-  - container: 37700
+  # The relay below, not the worker itself: a published port has to be served
+  # from eth0, and the worker cannot leave loopback without breaking every
+  # claude-mem client (see CLAUDE_MEM_WORKER_HOST).
+  - container: 37800
     name: memory-viewer
 environment:
   variables:
@@ -56,9 +59,19 @@ environment:
     # Worker port otherwise defaults to 37700 + (uid % 100); pinned so it
     # doesn't shift if the base image's agent uid ever changes.
     CLAUDE_MEM_WORKER_PORT: "37700"
-    # Upstream default host is 127.0.0.1, unreachable via `sbx ports
-    # --publish` (must bind eth0/0.0.0.0 to be forwarded).
-    CLAUDE_MEM_WORKER_HOST: "0.0.0.0"
+    # Loopback, matching upstream's default, and NOT 0.0.0.0: claude-mem uses
+    # this one variable as both the worker's bind address and the address every
+    # client dials (`fetch("http://" + host + ":" + port + path)` in the hooks,
+    # the mcp-search MCP server and the CLI alike). The runtime's NO_PROXY
+    # exempts loopback only and injects NODE_USE_ENV_PROXY=1, so a worker on
+    # 0.0.0.0 sends every one of those requests to the egress proxy, which
+    # answers `Blocked by network policy: domain 0.0.0.0:37700` -- and Node's
+    # fetch hangs on that denial rather than failing. Measured on a sandbox
+    # built from this kit: the SessionStart hook gives up with
+    # {"status":"error","message":"Failed to start worker"}, no worker is left
+    # running and memory never works at all. The published port is served by
+    # the relay in setup.startup instead.
+    CLAUDE_MEM_WORKER_HOST: "127.0.0.1"
 setup:
   install:
     - command: npm config set proxy $HTTP_PROXY && npm config set https-proxy $HTTPS_PROXY || true
@@ -88,6 +101,17 @@ setup:
       user: "1000"
       description: Install latest claude-mem (plugin, marketplace registration, bun deps)
   startup:
+    # First, so it isn't held up by the reconciler's wait loop below. Absolute
+    # path because startup commands run with a minimal environment; detached
+    # with setsid and its stdio redirected so it outlives this shell (SPEC
+    # §9.6). Re-running it is safe: the script exits 0 on EADDRINUSE when a
+    # relay from an earlier start of the same container still owns the port.
+    - command:
+        - sh
+        - -c
+        - setsid node /home/agent/.local/bin/claude-mem-viewer-relay.js </dev/null >> /tmp/claude-mem-viewer-relay.log 2>&1 &
+      user: "1000"
+      description: Bridge published port 37800 to the loopback-bound worker on 37700
     - command:
         - sh
         - -c


### PR DESCRIPTION
## Summary

The claude-mem mixin set `CLAUDE_MEM_WORKER_HOST=0.0.0.0` so that the worker's
viewer port could be reached through `sbx ports --publish`. claude-mem uses that
one value as **both** the worker's bind address and the address every client
dials — the hooks, the `mcp-search` MCP server and the CLI all build
`fetch("http://" + host + ":" + port + path)` from it (`scripts/worker-service.cjs`,
`scripts/mcp-server.cjs`, `scripts/transcript-watcher.cjs` in 13.24.5).

The runtime's `NO_PROXY` exempts loopback only
(`localhost,127.0.0.1,::1,gateway.docker.internal`) and it injects
`NODE_USE_ENV_PROXY=1`, so with `0.0.0.0` every one of those requests went to the
egress proxy, which answers `Blocked by network policy: domain 0.0.0.0:37700` —
and Node's `fetch` *hangs* on that denial rather than failing. Measured on a
sandbox built from this kit before the change:

```
SessionStart hook → {"continue":true,"status":"error","message":"Failed to start worker"}
no worker process
curl http://0.0.0.0:37700/api/health → Blocked by network policy: domain 0.0.0.0:37700
node  fetch http://0.0.0.0:37700/    → hangs (killed at timeout)
node  fetch http://127.0.0.1:37700/  → OK
```

So memory never worked at all in a sandbox using this kit.

This PR binds the worker to `127.0.0.1` (upstream's default), where every client
bypasses the proxy, and serves the published port from a small TCP relay
(`files/home/.local/bin/claude-mem-viewer-relay.js`, started from
`setup.startup`) that forwards 37800 → `127.0.0.1:37700`. Inbound connections
arriving through a published port never touch the proxy. `ports:` now declares
37800, and the agent instructions and README name that port.

After the change, on a sandbox built from this kit:

```
SessionStart hook → {"continue":true,"status":"ready"}
worker log        → HTTP server started {host=127.0.0.1, port=37700, pid=334}
in-sandbox  /api/health on 127.0.0.1:37700 and 127.0.0.1:37800 → ok
from the host: 127.0.0.1:37800, [::1]:37800, localhost:37800 and the
  auto-published tcp4 port all answer 200; viewer page 200 / 60,857 bytes,
  viewer-bundle.js 200 / 332 KB, /api/projects /api/settings /api/logs
  /api/summaries all 200
```

## Spec choices worth flagging for review

- **Why not `NO_PROXY` += `0.0.0.0`.** Keeping the worker on `0.0.0.0` and
  exempting it from the proxy would be a smaller diff, but measured in a
  sandbox, `/etc/sandbox-persistent.sh` is sourced by `bash` (via `BASH_ENV`)
  and **not** by `sh`/dash or a direct exec, so a claude-mem client spawned
  either way still hangs — and a hang is a worse failure mode than a clean
  error. It would also mean a kit overwriting a runtime-owned proxy variable,
  which SPEC §9.5 forbids.
- **A relay rather than dropping the published port.** The alternative was to
  bind loopback and delete the `ports:` entry, losing host access to the viewer
  UI / live activity stream entirely. The relay keeps it.
- **The relay binds `::`, not `0.0.0.0`** (falling back to `0.0.0.0` where
  binding `::` fails). `sbx ports --publish 37800:37800/tcp` binds the host
  dual-stack and forwards an IPv6 connection to the sandbox's IPv6 address, and
  a browser asking for `http://localhost:37800` resolves `::1` first — with the
  host side listening there nothing falls back to IPv4, so an IPv4-only relay
  reset exactly the request a browser makes (`curl` exit 56) while
  `http://127.0.0.1:37800` returned 200. Second commit in this PR.
- **Relay port 37800**, deliberately outside claude-mem's own default range
  (`37700 + uid % 100` spans 37700–37799), so it cannot collide with a worker
  that lands on a port other than the pinned 37700.
- **Idempotency.** The relay exits 0 on `EADDRINUSE`, so the `setup.startup`
  entry is safe on every container start; verified across restarts (one listen
  line per start, no duplicate process). It is ordered before the existing
  settings reconciler so it isn't held up by that step's wait loop.
- **No new dependency**: the relay runs under `node`, which this kit's existing
  startup reconciler already relies on.

## Origin

Fix to this repo's existing `claude-mem/` mixin, found while using it: the
sandbox's egress proxy made claude-mem unusable because the worker address it
advertised to its own clients was `0.0.0.0`.

## Test plan

- [x] `sbx kit validate ./claude-mem/` passes
- [x] `./scripts/test-kit.sh` passes (the TCK, including the container leg that
      runs `setup.install` and the new `files/` entry)
- [x] `./scripts/test-kit-e2e.sh` passes under the script's `deny-all` baseline,
      scoped to its own `--app-name sbx-kits-contrib-tck` daemon: `TestE2EKit`
      green in 163s (`env`, `files` incl. the new
      `/home/agent/.local/bin/claude-mem-viewer-relay.js`, `tmpfs`,
      `agentContext`), with the kit's port declaration published as
      `memory-viewer: localhost:49152 -> 37800/tcp4`. No entry was added to
      `permissions.network.allow` for this change, and the install commands all
      ran under deny-all unchanged.
- [x] Manual smoke: sandbox created with `sbx create claude --kit ./claude-mem/`,
      and the before/after behaviour above captured from inside and from the host
      (worker health, relay forwarding, viewer UI and API over the published
      port, relay recovery across container restarts).

Nothing in `permissions.network.allow` changed.

