### PR TITLE
Harden tck.yml's kit-detection step

### DIFF
--- a/.github/workflows/tck.yml
+++ b/.github/workflows/tck.yml
@@ -28,20 +28,22 @@ jobs:
         id: filter-setup
         run: |
           filters=""
-          # Add a filter for each kit directory (spec.yaml or spec.yml)
-          for f in */spec.yaml */spec.yml; do
-            [ -f "$f" ] || continue
-            kit=$(dirname "$f")
+          # Add a filter for each kit directory. discover-kits.sh is the
+          # single source of truth for "what is a kit" — delegate to it here
+          # too instead of re-globbing spec.yaml/spec.yml.
+          while IFS= read -r kit; do
             filters=$(printf '%s\n%s: "%s/**"' "$filters" "$kit" "$kit")
-          done
+          done < <(./scripts/discover-kits.sh)
           # Add filters for shared packages that should trigger all kits
           filters=$(printf '%s\ntck: "tck/**"\nspec: "spec/**"\nscripts: "scripts/**"' "$filters")
 
           filters=$(printf '%s\nworkflows: [".github/workflows/e2e.yml", ".github/workflows/tck.yml"]' "$filters")
 
-          echo "filters<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$filters" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+          {
+            echo "filters<<EOF"
+            echo "$filters"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Filter changes
         id: filter
@@ -62,11 +64,14 @@ jobs:
           workflows_changed="${{ steps.filter.outputs.workflows }}"
 
           if [ "$tck_changed" = "true" ] || [ "$spec_changed" = "true" ] || [ "$workflows_changed" = "true" ]; then
-            kits=$(for f in */spec.yaml */spec.yml; do [ -f "$f" ] && dirname "$f"; done | sort -u | jq -R . | jq -sc .)
+            kits=$(./scripts/discover-kits.sh | jq -R . | jq -sc .)
           else
-            # Only kits that changed
+            # Only kits that changed. `grep -vE` exits 1 (no output, no
+            # match) when $changes is `[]` — e.g. a doc-only PR — which
+            # would abort this step under bash's default -e/pipefail in
+            # GitHub Actions. `|| true` keeps an empty result a success.
             changes='${{ steps.filter.outputs.changes }}'
-            kits=$(echo "$changes" | jq -r '.[]' | grep -vE '^(tck|spec|scripts|workflows)$' | jq -R . | jq -sc .)
+            kits=$(echo "$changes" | jq -r '.[]' | { grep -vE '^(tck|spec|scripts|workflows)$' || true; } | jq -R . | jq -sc .)
           fi
 
           echo "kits=${kits:-[]}" >> "$GITHUB_OUTPUT"
@@ -95,7 +100,15 @@ jobs:
         # local workflow stay 1:1. Pass the matrix kit name as a positional
         # arg (the script resolves it against the repo root) and forward
         # `-timeout 30m` to `go test`.
-        run: ./scripts/test-kit.sh "${{ matrix.kit }}" -timeout 30m
+        #
+        # matrix.kit comes from directory names in the PR's own checkout
+        # (discover-kits.sh); passed via env rather than interpolated into
+        # the script text so a directory name containing shell metacharacters
+        # can't inject commands. Unlike the e2e jobs, this one has no
+        # fork-PR restriction.
+        env:
+          KIT: ${{ matrix.kit }}
+        run: ./scripts/test-kit.sh "$KIT" -timeout 30m
 
   test-tck:
     needs: detect-changes

--- a/scripts/discover-kits.sh
+++ b/scripts/discover-kits.sh
@@ -8,9 +8,15 @@
 # legs racing to push the same tags.
 #
 # Used by every workflow that needs the full kit list — build-and-publish-kits.yml's
-# own discovery and hub-overview.yml's docs-triggered sync — so what counts as
-# a kit is defined in exactly one place.
+# own discovery, hub-overview.yml's docs-triggered sync, and tck.yml's kit
+# detection — so what counts as a kit is defined in exactly one place.
 set -euo pipefail
+
+# Anchor to the repo root so this works regardless of the caller's cwd —
+# run from a kit subdirectory otherwise, the glob below matches nothing and
+# the script silently prints an empty list instead of erroring.
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+cd "$SCRIPT_DIR/.."
 
 for f in */spec.yaml */spec.yml; do
   [ -f "$f" ] || continue


### PR DESCRIPTION
## Summary
While porting this repo's validator into `sbx-kits-internal` (importing `spec`/`tck` and copying `tck.yml`'s structure), a code review pass on that copy caught three real bugs — all present here too, since they were copied verbatim:

- **`grep -vE` exits 1 on an empty `$changes` list** (e.g. a PR that only touches `README.md`). GitHub Actions runs `run:` blocks under `-e`/`pipefail`, so the failing pipeline aborts the "Collect kits to test" step before the `kits=${kits:-[]}` fallback ever runs — turning a harmless doc-only PR into a red CI run. Fixed with `|| true`.
- **`matrix.kit` interpolated directly into a `run:` script** — a kit directory name containing shell metacharacters could inject commands. `test-kit` has no fork-PR restriction (unlike the e2e jobs), so this is reachable from any PR. Fixed by passing it via `env:` instead.
- **Both kit-discovery call sites in `tck.yml` re-glob `spec.yaml`/`spec.yml`** instead of calling `scripts/discover-kits.sh`, despite that script's own comment claiming to be the single source of truth. It does have real callers elsewhere (`build-and-publish-kits.yml`, `hub-overview.yml`) — just not here. Both call sites now delegate to it.

While touching `discover-kits.sh`, two adjacent fixes:
- Anchored it to the repo root like its sibling scripts (`test-kit.sh`, `test-kit-e2e.sh`) already do — running it from any other cwd previously returned an empty list silently instead of erroring.
- Fixed the same `>> "$GITHUB_OUTPUT"` individual-redirects shellcheck nit (SC2129) in the neighboring "Generate filters" step.

Not in scope here: `actionlint` also flagged pre-existing, unrelated shellcheck issues in `build-and-publish-kits.yml` and `publish-one-kit.yml` (SC2129, SC2016) — left untouched since they're a different file and different concern from this PR.

## Test plan
- [x] `actionlint` clean on `tck.yml` (was previously flagging the SC2129 nit)
- [x] `discover-kits.sh` tested from the repo root and from a kit subdirectory; its two existing callers (`build-and-publish-kits.yml`, `hub-overview.yml`) unmodified
- [x] Reproduced the empty-`$changes` pipefail failure directly, confirmed the fix
- [x] `go build ./...` / `go vet ./...` pass (untouched by this change, sanity-checked anyway)
- [x] Live TCK run (`./scripts/test-kit.sh aider`) passes end to end
- [ ] CI: confirm `detect-changes` still selects the right kits on a real PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)