### PR TITLE
Make e2e.yml a self-contained, secret-scoped reusable workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,6 +25,10 @@ on:
         description: sbx build channel to test against — "release", "nightly", or "rc".
         required: true
         type: string
+    secrets:
+      DOCKERPUBLICBOT_WRITE_PAT:
+        description: Docker Hub PAT for the "Sign in to Docker Hub via sbx" step.
+        required: true
 
 permissions:
   contents: read
@@ -157,7 +161,15 @@ jobs:
         # `ApplyKitNetworkPolicyScoped` in
         # docker/sandboxes:sandboxd/pkg/server/options_governance.go);
         # kit deny-rules win over allow-rules (deny-wins).
-        run: ./scripts/test-kit-e2e.sh "${{ matrix.kit }}"
+        #
+        # matrix.kit comes from directory names in the checked-out repo
+        # (discover-kits.sh); passed via env rather than interpolated into
+        # the script text so a directory name containing shell
+        # metacharacters can't inject commands into a job that holds a
+        # live Docker Hub credential.
+        env:
+          KIT: ${{ matrix.kit }}
+        run: ./scripts/test-kit-e2e.sh "$KIT"
 
       - name: Sign out of Docker Hub
         if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,7 +2,9 @@ name: Kit e2e
 
 # Reusable e2e runner. Installs a real `sbx` CLI for the requested
 # `channel`, authenticates against Docker Hub non-interactively, and runs
-# `./scripts/test-kit-e2e.sh <kit>` across the caller-supplied kit matrix.
+# the e2e TCK across the caller-supplied kit matrix, using this repo's own
+# harness (scripts/, tck/) checked out at the exact revision the caller
+# pinned in its `uses:` line. tck.yml calls this once per channel below.
 #
 # The whole point of parametrizing `channel` here — instead of hardcoding a
 # version — is that tck.yml calls this three times:
@@ -25,16 +27,32 @@ on:
         description: sbx build channel to test against — "release", "nightly", or "rc".
         required: true
         type: string
+      app-name:
+        description: >-
+          sbx --app-name scoping every sbx call. Callers should pass their own
+          so e2e state never collides with this repo's.
+        required: false
+        type: string
+        default: sbx-kits-contrib-tck
+      dockerhub-username:
+        description: >-
+          Docker Hub username for the non-interactive `sbx login`. Any account
+          that can pull the public sandbox template images is sufficient.
+        required: true
+        type: string
     secrets:
-      DOCKERPUBLICBOT_WRITE_PAT:
-        description: Docker Hub PAT for the "Sign in to Docker Hub via sbx" step.
+      DOCKERHUB_TOKEN:
+        description: >-
+          Docker Hub personal access token for `dockerhub-username`. Read
+          access to public images is enough.
         required: true
 
 permissions:
   contents: read
+  actions: read
 
 env:
-  APP_NAME: sbx-kits-contrib-tck
+  APP_NAME: ${{ inputs.app-name }}
 
 jobs:
   prepare-sbx:
@@ -99,12 +117,50 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+      actions: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Resolve the pinned sbx-kits-contrib revision
+        id: harness
+        # The expression context has no SHA for the *called* workflow (only
+        # the top-level caller's) — the run's `referenced_workflows` does,
+        # so this reads that instead. Requires `permissions: actions: read`
+        # on the caller.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          entry=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --jq '[.referenced_workflows[]? | select(.path | test("/\\.github/workflows/e2e\\.yml@"))] | first // empty | "\(.path) \(.sha)"')
+          if [ -z "$entry" ]; then
+            echo "::error::could not resolve this workflow's own revision from the run's referenced_workflows; the caller must grant 'actions: read'."
+            exit 1
+          fi
+          path=${entry% *}
+          sha=${entry##* }
+          repo=${path%%/.github/workflows/*}
+          echo "Using ${repo} e2e harness at ${sha}"
+          {
+            echo "repo=${repo}"
+            echo "sha=${sha}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Check out the sbx-kits-contrib e2e harness
+        # Hidden path so the caller's `*/spec.yaml` kit discovery never sees
+        # this repo's own kits.
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ steps.harness.outputs.repo }}
+          ref: ${{ steps.harness.outputs.sha }}
+          path: .sbx-kits-contrib
+          persist-credentials: false
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version-file: go.mod
+          go-version-file: .sbx-kits-contrib/go.mod
 
       - name: Enable KVM access
         run: |
@@ -132,11 +188,11 @@ jobs:
 
       - name: Sign in to Docker Hub via sbx
         env:
-          USERNAME: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
-          TOKEN: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
+          USERNAME: ${{ inputs.dockerhub-username }}
+          TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           if [ -z "${USERNAME}" ] || [ -z "${TOKEN}" ]; then
-            echo "DOCKERPUBLICBOT_USERNAME / DOCKERPUBLICBOT_WRITE_PAT not configured; cannot run e2e."
+            echo "dockerhub-username input / DOCKERHUB_TOKEN secret not configured; cannot run e2e."
             exit 1
           fi
           # Defensive trim: GH preserves any whitespace pasted into the
@@ -167,9 +223,12 @@ jobs:
         # the script text so a directory name containing shell
         # metacharacters can't inject commands into a job that holds a
         # live Docker Hub credential.
+        #
+        # Absolute kit path: the script resolves relative paths against its
+        # own repo root.
         env:
           KIT: ${{ matrix.kit }}
-        run: ./scripts/test-kit-e2e.sh "$KIT"
+        run: .sbx-kits-contrib/scripts/test-kit-e2e.sh "${GITHUB_WORKSPACE}/${KIT}"
 
       - name: Sign out of Docker Hub
         if: always()

--- a/.github/workflows/tck.yml
+++ b/.github/workflows/tck.yml
@@ -153,7 +153,8 @@ jobs:
     with:
       kits: ${{ needs.detect-changes.outputs.kits }}
       channel: release
-    secrets: inherit
+    secrets:
+      DOCKERPUBLICBOT_WRITE_PAT: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
 
   e2e-nightly:
     needs: detect-changes
@@ -167,7 +168,8 @@ jobs:
     with:
       kits: ${{ needs.detect-changes.outputs.kits }}
       channel: nightly
-    secrets: inherit
+    secrets:
+      DOCKERPUBLICBOT_WRITE_PAT: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
 
   e2e-rc:
     needs: detect-changes
@@ -181,7 +183,8 @@ jobs:
     with:
       kits: ${{ needs.detect-changes.outputs.kits }}
       channel: rc
-    secrets: inherit
+    secrets:
+      DOCKERPUBLICBOT_WRITE_PAT: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
 
   # Stable gate for branch protection. Configure the repo's required status
   # check to be `e2e` (not the dynamic `e2e-release (<kit>)` matrix legs,

--- a/.github/workflows/tck.yml
+++ b/.github/workflows/tck.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 env:
   APP_NAME: sbx-kits-contrib-tck
@@ -153,8 +154,9 @@ jobs:
     with:
       kits: ${{ needs.detect-changes.outputs.kits }}
       channel: release
+      dockerhub-username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
     secrets:
-      DOCKERPUBLICBOT_WRITE_PAT: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
 
   e2e-nightly:
     needs: detect-changes
@@ -168,8 +170,9 @@ jobs:
     with:
       kits: ${{ needs.detect-changes.outputs.kits }}
       channel: nightly
+      dockerhub-username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
     secrets:
-      DOCKERPUBLICBOT_WRITE_PAT: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
 
   e2e-rc:
     needs: detect-changes
@@ -183,8 +186,9 @@ jobs:
     with:
       kits: ${{ needs.detect-changes.outputs.kits }}
       channel: rc
+      dockerhub-username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
     secrets:
-      DOCKERPUBLICBOT_WRITE_PAT: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
 
   # Stable gate for branch protection. Configure the repo's required status
   # check to be `e2e` (not the dynamic `e2e-release (<kit>)` matrix legs,

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Each subtest (`env`, `files/<path>`, `tmpfs/<path>`, `memory`) reports independe
 
 ### Running in CI
 
-The e2e legs in [`.github/workflows/tck.yml`](.github/workflows/tck.yml) run alongside the default `test-kit` job, via the reusable [`.github/workflows/e2e.yml`](.github/workflows/e2e.yml). Each signs in to Docker Hub using `DOCKERPUBLICBOT_USERNAME` / `DOCKERPUBLICBOT_WRITE_PAT` repo secrets, then runs the e2e test once per detected kit — against three `sbx` channels:
+The e2e legs in [`.github/workflows/tck.yml`](.github/workflows/tck.yml) run alongside the default `test-kit` job, via the reusable [`.github/workflows/e2e.yml`](.github/workflows/e2e.yml). `tck.yml` passes this repo's `DOCKERPUBLICBOT_USERNAME` variable and `DOCKERPUBLICBOT_WRITE_PAT` secret into e2e.yml's generic `dockerhub-username` input and `DOCKERHUB_TOKEN` secret, which e2e.yml uses to sign in to Docker Hub, then runs the e2e test once per detected kit — against three `sbx` channels:
 
 - **`e2e-release`** downloads the latest tagged `sbx` release. This is the channel users have today, so it **gates the PR** through the stable `e2e` job (the required status check).
 - **`e2e-nightly`** downloads the rolling `nightly` build, so kits are also exercised against what `sbx` will ship next. It is **informational only** — a broken nightly shows a red check but never blocks merge. The `e2e-nightly-report` job echoes its outcome to the run log and the job summary.
@@ -282,6 +282,48 @@ The e2e legs in [`.github/workflows/tck.yml`](.github/workflows/tck.yml) run alo
 **All e2e legs are skipped on fork PRs** because GitHub does not expose secrets to fork-triggered workflows — so for the typical contributor, e2e never runs in CI on their PR, and the reviewer sees a green check that does **not** cover the e2e assertions.
 
 That makes a local e2e run **mandatory** before opening a PR from a fork. Run `./scripts/test-kit-e2e.sh <kit>` — the script applies the same `deny-all` baseline CI uses on a scoped daemon (`--app-name sbx-kits-contrib-tck`), so the network contract gets tested without touching your main sbx state. See [Declare every domain your kit needs](#declare-every-domain-your-kit-needs) for the recurring "read the proxy log, add a host, re-run" loop.
+
+#### Calling e2e.yml from another kit repository
+
+`.github/workflows/e2e.yml` is self-contained: it checks out this repository
+at the exact commit the caller pinned and runs its own `scripts/test-kit-e2e.sh`
+and `tck/` Go harness against the caller's kit directories. A minimal caller
+looks like:
+
+```yaml
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  e2e-release:
+    uses: docker/sbx-kits-contrib/.github/workflows/e2e.yml@<sha> # vX.Y.Z
+    with:
+      kits: ${{ needs.detect-changes.outputs.kits }}
+      channel: release
+      app-name: my-kits-tck
+      dockerhub-username: ${{ vars.DOCKERHUB_USERNAME }}
+    secrets:
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+```
+
+- Pin `uses:` to a full commit SHA, not a branch or tag alone.
+- The caller needs only its own kit directories — the harness, Go module,
+  and scripts all come from this repo at the pinned SHA.
+- Grant `actions: read` (shown above at the caller workflow's top level, or
+  on the calling job) — the reusable workflow resolves its own pinned
+  revision from the run's `referenced_workflows` via the Actions API, and a
+  reusable workflow's token permissions can never exceed what the caller
+  grants.
+- Pass exactly the one secret shown above, never `secrets: inherit`.
+- Any Docker Hub account works — a read-only PAT is enough to pull the
+  public sandbox template images. The variable and secret names on the
+  caller side (`DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` above) are the
+  caller's own choice; this repo's own `tck.yml` maps its
+  `DOCKERPUBLICBOT_USERNAME` / `DOCKERPUBLICBOT_WRITE_PAT` bot credentials
+  onto the same `dockerhub-username` input and `DOCKERHUB_TOKEN` secret.
+- Choose an `app-name` distinct from this repo's own, so e2e state (daemon,
+  credential store, policy) never collides.
 
 ## Extending a Parent Agent
 

--- a/scripts/test-kit-e2e.sh
+++ b/scripts/test-kit-e2e.sh
@@ -12,7 +12,8 @@
 #   - Scopes every sbx call to APP_NAME=sbx-kits-contrib-tck so the test
 #     daemon, sandboxes, policy, and cache are isolated from your main
 #     sbx state. Nothing the script does touches your day-to-day daemon.
-#     The Go harness uses the same app-name internally (tck/e2e_test.go).
+#     The Go harness reads the same APP_NAME this script exports
+#     (tck/e2e_test.go).
 #   - Sets the scoped daemon's default network policy to `deny-all` so
 #     the run is a real contract test of permissions.network.allow — the same
 #     baseline CI runs under.

--- a/skills/kit-author/topics/testing.md
+++ b/skills/kit-author/topics/testing.md
@@ -288,7 +288,7 @@ cd my-kit
 
 That's the whole recipe — no manual policy dance. The script:
 
-- Scopes every `sbx` call to `--app-name sbx-kits-contrib-tck`, the same app-name the e2e harness uses internally ([`tck/e2e_test.go:415`](../../../tck/e2e_test.go#L415)). The test daemon's sandboxes, policy, secrets, and cache are isolated from your day-to-day sbx state.
+- Scopes every `sbx` call to `--app-name sbx-kits-contrib-tck`, the same default the e2e harness falls back to when `$APP_NAME` is unset ([`tck/e2e_test.go:35`](../../../tck/e2e_test.go#L35)). The test daemon's sandboxes, policy, secrets, and cache are isolated from your day-to-day sbx state.
 - Sets the scoped daemon's default network policy to `deny-all` — the same baseline CI uses, so any host your install or startup hooks reach for must be in `permissions.network.allow` or the request is blocked.
 - Runs `go test -tags=e2e` with `KIT_UNDER_TEST` exported.
 - On non-zero exit, prints a hint pointing at `sbx --app-name sbx-kits-contrib-tck policy log <sandbox>`.

--- a/tck/e2e_test.go
+++ b/tck/e2e_test.go
@@ -4,11 +4,12 @@
 // responsible for installing sbx and running `sbx login` before this test
 // runs. Build-tagged `e2e` so it never runs in the default `go test ./...`
 // flow that kit authors invoke locally — only the matrix job in tck.yml
-// opts in via `-tags=e2e`.
+// (or, cross-repo, another kit repository's e2e leg via e2e.yml) opts in
+// via `-tags=e2e`.
 //
 // This is a thin wrapper around the exported tck.RunE2EKit — see tck/e2e.go
-// for the actual e2e logic, which any module importing this package (e.g.
-// sbx-kits-internal) can drive against its own app-name.
+// for the actual e2e logic, which any module importing this package can
+// drive against its own app-name.
 
 package tck_test
 
@@ -20,10 +21,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// appName scopes every `sbx` call this repo's own e2e run makes, keeping it
-// isolated from a developer's or another module's main sbx state. Must stay
-// in sync with scripts/test-kit-e2e.sh's default APP_NAME.
-const appName = "sbx-kits-contrib-tck"
+// Fallback when $APP_NAME is unset; keep in sync with scripts/test-kit-e2e.sh.
+const defaultAppName = "sbx-kits-contrib-tck"
 
 // TestE2EKit is the single e2e entry point for all kit types in this repo.
 // KIT_UNDER_TEST is read from the environment; the CI matrix and
@@ -32,6 +31,11 @@ const appName = "sbx-kits-contrib-tck"
 func TestE2EKit(t *testing.T) {
 	kitPath := os.Getenv("KIT_UNDER_TEST")
 	require.NotEmpty(t, kitPath, "KIT_UNDER_TEST must point at a kit directory")
+
+	appName := os.Getenv("APP_NAME")
+	if appName == "" {
+		appName = defaultAppName
+	}
 
 	tck.RunE2EKit(t, kitPath, tck.E2EOptions{AppName: appName})
 }


### PR DESCRIPTION
## Summary

`e2e.yml` is the reusable workflow `tck.yml` calls once per sbx channel. This makes it safe and usable from another kit repository.

- **Scope the secret.** `tck.yml` passed `secrets: inherit`, so every repository secret reached a job that needs one Docker Hub token. The workflow now declares the secret it needs and `tck.yml` passes only that. `matrix.kit` is passed via `env:` instead of being interpolated into the script text. Both were flagged by zizmor.
- **Run this repo's harness, not the caller's.** The workflow checked out the caller and ran the caller's `scripts/test-kit-e2e.sh` against the caller's Go module, so any caller had to carry copies of the scripts, a `go.mod`, and a `tck/` wrapper. It now checks out this repository at the revision the caller pinned in `uses:` and runs its own scripts and `tck/` against the caller's kit directory. The revision is read from the run's `referenced_workflows`, since the expression context only exposes the caller's SHA. That needs `actions: read` on the caller.
- **Fix the `APP_NAME` override and expose it as an input.** `APP_NAME` was hardcoded in the workflow and in `tck/e2e_test.go`. `scripts/test-kit-e2e.sh` documented `APP_NAME` as an override, but the Go harness ignored it, so an override logged in and set policy under one app-name while `sbx create` ran under another. The harness now reads `$APP_NAME`, and the workflow exposes it as `app-name` (default unchanged).
- **Generic Docker Hub credentials.** The `workflow_call` interface named this org's bot account. It now takes a `dockerhub-username` input and a `DOCKERHUB_TOKEN` secret, and `tck.yml` maps the bot credentials onto them. README documents the caller contract.

## Verification

- `go build ./...`, `go vet ./...`, `go vet -tags=e2e ./tck/...`, `gofmt -l .`: clean
- actionlint on `e2e.yml` and `tck.yml`: clean except the pre-existing SC2129 nit tracked in #291
- zizmor on `e2e.yml`: no findings
- The resolve step was run standalone against a real run object and returns this repository and the pinned SHA; it errors on an empty `referenced_workflows`

## Known gap

The e2e legs skip on fork PRs, so this PR's own CI does not exercise the new checkout path. It needs a run from a branch in this repository before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
